### PR TITLE
docs: introduce KUMA bilingual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,34 @@
 # DefuzeX Python SDK
 
-DefuzeX Python SDK v4 是 Agent 行为测试的公开 Python 客户端。它负责解析测试要求、生成最小化仓库元数据、驱动同步 Run、采集 Evidence，并通过 Website Backend 的公开 HTTPS API 获取官方 Case 和 Judgment。
+[中文](#中文) | [English](#english)
 
-SDK 的联网边界固定为：
+## 中文
+
+DefuzeX Python SDK 是面向 Agent 行为测试的公开 Python 客户端。它解析测试要求、驱动同步 `Run` 协议、采集有界 Evidence，并通过 DefuzeX 公开 HTTPS API 获取官方 Case 和最终 Judgment。
+
+### 定位与边界
 
 ```text
-SDK -> Website Backend public API -> private Core MCP -> model/core database
+SDK -> DefuzeX public API -> DefuzeX managed services
 ```
 
-SDK 不直连 MCP、模型或数据库，也不包含 Private Rubric、hidden answer、模型配置或服务端凭据。详细依赖方向见 [架构文档](docs/architecture.md)，公开 HTTP 契约摘要见 [API Contract](docs/api-contract.md)。
+SDK 只实现客户端协议和 Evidence 边界。它不启动或托管 Agent，不选择 Agent 所用模型，不提供沙箱、服务端部署、数据库或后台任务，也不直连 DefuzeX 内部服务。服务端专属的评估材料、执行配置和凭据不会进入 SDK。
 
-它也不是 Agent runner、容器编排器或服务端 SDK。用户代码负责执行被测 Agent、管理其工具权限与进程，并把真实 output 或标准 OTel span 交给 Run；DefuzeX SDK 只负责测试协议和可验证 Evidence。Website Backend 负责公开鉴权、scope、配额、计费和安全错误映射，Core MCP 负责 Case、Private Rubric、Judge、模型调用与核心数据。
+详细设计见[架构文档](docs/architecture.md)，HTTP 边界见[公开 API Contract](docs/api-contract.md)。
 
-## 适用场景与核心概念
+### 核心概念
 
-DefuzeX 适合验证会读写仓库、调用工具或执行工作流的 Agent：官方 Provider 可使用服务端 Case/Judge，自定义 Provider 可用于本地测试、固定回归或私有评估逻辑。SDK 评估的是 Agent 在一个受控任务中的真实行为，不负责启动 Agent、选择模型或提供沙箱。
+- **Case**：一次完整测试的公开输入序列。
+- **Input**：当前交给用户 Agent 的一个任务。
+- **Run**：严格执行 `get_input()` -> Agent -> `submit()` 的单 Case 状态机。
+- **Submission / History**：Agent 对每个 Input 的结果和不可变历史。
+- **Evidence**：文件变化、显式日志和可选的同进程 OpenTelemetry spans。
+- **Judgment / TestReport**：Judge 对完整 Run 返回的公开结果。
+- **Provider**：Case 或 Judge 的边界实现；可以使用官方服务，也可以完全本地自定义。
 
-- **Case**：一次完整测试的公开输入序列；官方 Case 的私有 Rubric 始终留在服务端。
-- **Input**：Case 中当前交给 Agent 的一个任务。
-- **Run**：严格执行 `get_input()` → Agent → `submit()` 握手的单 Case 状态机。
-- **Submission/History**：Agent 的结果及其与 Input 对齐的不可变历史。
-- **Evidence**：文件变化、显式日志和可选同进程 OTel spans；采集和提交保持事务语义。
-- **Judgment/TestReport**：Judge 对完整 Run 的公开结果。
-- **Provider**：Case 或 Judge 的边界实现；可以是官方 HTTPS Provider，也可以是本地自定义实现。
+### 安装
 
-## 安装
-
-Python 3.10 或更高版本：
-
-从 GitHub 获取当前正式版本：
+需要 Python 3.10 或更高版本。
 
 ```bash
 git clone https://github.com/DefuzeX-company/defuzex-python-sdk.git
@@ -52,101 +52,64 @@ python -m pip install --upgrade pip
 python -m pip install -e .
 ```
 
-如果 `defuzex` 已发布到你使用的 Python 包源，也可以直接安装：
-
-```bash
-python -m pip install defuzex
-```
-
-从本仓库开发时使用 editable install：
-
-```bash
-python -m pip install -e ".[dev]"
-```
-
-`[dev]` 只包含 Ruff、build 和 twine 等开发工具。用户仅需 Trace Evidence 时安装 `[otel]`；核心安装不强制引入 OTel。
-
-OpenTelemetry 是可选能力，不属于核心依赖：
+如果 `defuzex` 已在你使用的包源发布，也可以运行 `python -m pip install defuzex`。可选能力按需安装；核心包不强制引入 OpenTelemetry：
 
 ```bash
 python -m pip install "defuzex[otel]"
-# 或从源码安装
-python -m pip install -e ".[otel]"
+python -m pip install -e ".[dev]"
 ```
 
-仓库中的版本号不代表某个公共包索引已经发布了同版本；请以你实际使用的包源或本仓库提交为准。
+仓库版本号不代表同版本已经发布到公共包索引，请以实际包源或所用 Git commit 为准。
 
-## 无账号的本地首次运行
-
-安装后直接运行：
+### 无账号首次运行
 
 ```bash
 defuzex quickstart
 ```
 
-该命令不需要账号、API Key、Docker 或 `allow_local=True`。它不会读取当前目录或用户仓库，也不会访问 Backend、Core、模型或网络；SDK 只在操作系统临时目录中创建一个隔离仓库。内置的确定性 fake Agent 对固定 Input 返回 `defuzex-ready`，公开 evaluator 只执行一条可解释规则：输出必须与该文本完全一致。
-
-预期摘要类似：
+该命令不需要账号、API Key、Docker 或网络，也不会读取当前目录或用户仓库。它在临时目录中使用固定 Input、确定性示例 Agent 和一条公开规则完成本地检查。
 
 ```text
 Local check: PASS
 Score: 100/100
 Reason: Output exactly matched the published rule.
-Artifact: <absolute temporary path>/result.json
+Artifact: <temporary directory>/result.json
 ```
 
-结果文件包含固定 Input、其 SHA-256、fake output、分数和原因，不包含凭证或用户文件。使用 `defuzex quickstart --fail-demo` 可查看确定性的失败评分和非零退出码。该 quickstart 不是 LLM Judge 或生产 Agent；接入真实框架使用 [Single Agent Template](examples/single_agent_template/README.md)，官方 Case/Judge 仍需显式使用正式 `create_run()` 配置。
-
-## 无需 API Key 的可运行示例
-
-安装本仓库后，在仓库根目录运行：
+`defuzex quickstart --fail-demo` 会演示确定性失败并返回非零退出码。另一个无需凭据的完整 Run 示例是：
 
 ```bash
 python examples/minimal_local.py
 ```
 
-[完整示例源码](examples/minimal_local.py)使用临时仓库、自定义 Case Provider、`judge=False` 和 `allow_local=True`。它不读取 API Key、不访问公网，也不会修改运行命令所在的真实仓库；临时目录会在结束时自动删除。
+它使用临时仓库、自定义 Case Provider、`judge=False` 和 `allow_local=True`，不会修改用户仓库。
 
-预期输出：
+### 官方服务 Quickstart
 
-```text
-input=Return a bounded maintenance result.
-state=completed
-submissions=1
-```
-
-该示例演示 SDK 的最短完整链路：创建 Run、取得 Input、提交 Agent output、检查 History。要使用官方 Case/Judge，再按下一节配置公开 API Key。
-
-## 官方服务 Quickstart
-
-### 1. 准备 API Key
-
-官方 Case 或官方 Judge 需要 `dfx_` 开头的 API Key。推荐只放在环境变量中：
+官方 Case 或官方 Judge 需要 `dfx_` 开头的 API Key。请通过进程环境或本机凭证存储提供，不要写入源码、Notebook 输出或 Git。
 
 ```powershell
-$env:DEFUZEX_API_KEY = "dfx_<public-id>.<secret>"
+$env:DEFUZEX_API_KEY = "dfx_your_key_here"
+defuzex whoami
 ```
 
-也可以写入当前用户的凭证文件；该操作只写本地文件，不发起网络请求：
+```bash
+export DEFUZEX_API_KEY="dfx_your_key_here"
+defuzex whoami
+```
+
+也可以让 SDK 原子写入当前用户的凭证目录；此操作不访问网络：
 
 ```python
 from defuzex import configure
 
-credential_path = configure(api_key="dfx_<public-id>.<secret>")
+credential_path = configure(api_key="dfx_your_key_here")
 print(credential_path)
 ```
 
-凭证解析优先级为：`create_run(api_key=...)` 或 `DefuzeClient(api_key=...)`、`DEFUZEX_API_KEY`、用户凭证文件。不要把 Key 写入源码、Notebook 输出或 Git。
+凭证解析优先级为：函数参数、`DEFUZEX_API_KEY`、用户凭证文件。
 
-可先验证公开身份、scope 和额度：
-
-```bash
-defuzex whoami
-```
-
-### 2. 写 requirement 文件
-
-官方 Case Provider 需要显式的 UTF-8 requirement 文件。例如 `requirement.md`：
+官方 Case Provider 需要显式的 UTF-8 requirement 文件，例如 `requirement.md`：
 
 ```markdown
 ---
@@ -160,16 +123,14 @@ Maintain a Python repository without changing its public interface.
 
 ## Behaviors to Test
 
-Diagnose the requested defect, apply a bounded fix, and run relevant tests.
+Diagnose the requested defect, apply a bounded fix, and run relevant checks.
 
 ## Known Limitations or Prohibited Behaviors
 
-Do not read credentials, modify tests, or access paths outside the repository.
+Do not read credentials or access paths outside the repository.
 ```
 
-三个二级标题也接受仓库测试中使用的中文别名。结构化输入还需要本地 JSON Schema，但当前官方 Case 服务只接受 `input_type: text`；结构化输入仅适用于自定义 Case Provider。
-
-### 3. 执行 Run
+当前官方服务接受文本 Input。结构化 Input 需要自定义 Case Provider 和本地 JSON Schema。用户负责调用真实 Agent；SDK 只负责 Run 协议：
 
 ```python
 from typing import Any
@@ -185,192 +146,76 @@ def execute_agent(test_input: Any) -> dict[str, Any]:
 run = create_run(
     repo_path=".",
     requirement_path="requirement.md",
-    allow_local=True,  # 仅本地开发；正式模式默认要求同容器运行
+    allow_local=True,  # Local development only; production defaults to Docker.
 )
 
 while (test_input := run.get_input()) is not None:
-    output = execute_agent(test_input)
-    report = run.submit(output)
+    report = run.submit(execute_agent(test_input))
 
 print(run.state)
 print(run.report)
 ```
 
-`get_input()` 默认返回 payload；使用 `get_input(full=True)` 可获得不可变的 `DefuzeXInput`，其中包含 `run_id`、`case_id`、`input_id`、索引、payload 类型和 public constraints。`submit(output)` 接受有限值 JSON 可序列化数据；若 Agent 的 OTel `invoke_agent`/`invoke_workflow` span 已提供标准 `gen_ai.output.messages`，也可直接调用 `submit()`。
+`get_input()` 默认返回 JSON 兼容 payload；`get_input(full=True)` 返回不可变的 `DefuzeXInput`。`submit(output)` 要求有限值、可序列化为 JSON 的真实 Agent 结果。
 
-## 公开 API 速查
+### 公开 API 与配置
 
-优先从稳定公开模块导入；以下划线开头的模块和名称属于内部实现：
-
-| 导入位置 | 公开用途 |
+| 导入位置 | 用途 |
 |---|---|
 | `defuzex.configure` | 验证并原子保存 API Key，不访问网络 |
-| `defuzex.create_run` | 创建一个同步 Python `Run` |
-| `defuzex.DefuzeClient` | 读取 entitlements、strategy catalog 和 Judge 动态配置 |
+| `defuzex.create_run` | 创建同步 Python `Run` |
+| `defuzex.DefuzeClient` | 读取公开 entitlements、strategy catalog 和 Judge 配置 |
 | `defuzex.Case`、`DefuzeXInput`、`Submission`、`HistoryItem`、`TestReport` | 不可变公开协议对象 |
 | `defuzex.errors` | `DefuzeError` 及稳定错误子类 |
-| `defuzex.providers` | 自定义 Provider Protocol/context、normalizer 和官方 Provider |
-| `defuzex.otel` | 可选 `[otel]` extra 的显式 Trace Evidence attach API |
+| `defuzex.providers` | 官方/自定义 Provider 协议、context 和 normalizer |
+| `defuzex.otel` | 可选的同进程 Trace Evidence attach API |
 
-`create_run()` 返回的 `Run` 提供 `get_input()`、`submit()`、`judge()`、`cancel()`，以及只读的 `state`、`history`、`report` 和 `runtime_warnings`。单 Case/单 Judge 的 v2 operation、轮询和恢复元数据是官方 Provider 的内部 transport 行为，不会把 Python API 改成后台 job API。
+`Run` 提供 `get_input()`、`submit()`、`judge()`、`cancel()`，以及 `state`、`history`、`report` 和 `runtime_warnings`。
 
-## 配置
-
-公开入口是 `defuzex.create_run()`。常用参数如下：
-
-| 参数 | 默认值 | 作用 |
+| `create_run()` 参数 | 默认值 | 作用 |
 |---|---:|---|
-| `repo_path` | `"."` | 被测仓库；必须是可读目录 |
-| `requirement_path` | `None` | requirement 文件；官方 Provider 和默认自定义 Provider 要求显式提供 |
-| `case_provider` | `None` | `None` 使用官方 Case；也可传实现 `CaseProvider` 的对象或 callable |
-| `judge_provider` | `None` | `None` 且 `judge=True` 时使用官方 Judge |
-| `strategy` | `"auto"` | SDK 发送纯 `agent_description` 与结构化 `behavior_spec`；显式模式只指定 strategy ID。实际策略和 version 均由 Backend/Core 权威解析 |
-| `max_inputs` | `None` | 自定义 Case 必填；限制归一化后的 Input 数量 |
-| `judge` | `True` | 最后一次提交后是否执行 Judge |
-| `on_failure` | `"continue"` | 非 completed 提交后继续下一 Input，或使用 `"stop"` 停止 |
+| `repo_path` | `"."` | 被测仓库目录 |
+| `requirement_path` | `None` | requirement 文件；官方 Provider 要求显式提供 |
+| `case_provider` / `judge_provider` | `None` | 省略时使用相应官方 Provider |
+| `strategy` | `"auto"` | 自动选择或显式 strategy ID；实际选择由服务端返回 |
+| `max_inputs` | `None` | 自定义 Case 必填的 Input 上限 |
+| `judge` / `on_failure` | `True` / `"continue"` | 是否 Judge，以及失败后继续或停止 |
 | `allow_local` | `False` | 显式允许非 Docker 的开发运行 |
-| `track_files` | `True` | 为每个 Input 采集前后文件快照和变化元数据 |
-| `upload_diff` | `False` | 在文件 Evidence 中加入文本 diff；开启前应评估敏感内容 |
-| `save_local` | `False` | 将每步结构化记录保存在 `.defuzex/runs/<run_id>/submissions/` |
-| `allow_sensitive` | `False` | 显式允许普通 Evidence 中命中的敏感内容；不会放宽 OTel allowlist |
-| `timeout` | `300.0` | 每次公开 Backend 请求的秒级超时 |
-| `operation_wait_timeout` | `600.0` | 官方单 Case/Judge 从 POST 到终态的独立总等待上限；超时保留恢复元数据 |
-| `max_retries` | `2` | 0–5；仅对 Backend 标记为瞬态且可重试的失败做指数退避重试 |
-| `api_key` | `None` | 本次调用的 API Key，优先于环境和用户凭证文件 |
-| `trace_evidence` | `None` | `configure_trace_evidence()` 返回的同进程 Trace capture |
+| `track_files` / `upload_diff` | `True` / `False` | 文件元数据采集与可选文本 diff |
+| `save_local` | `False` | 保存步骤记录到 `.defuzex/runs/<run_id>/submissions/` |
+| `allow_sensitive` | `False` | 普通 Evidence 的显式扫描覆盖；不影响 OTel allowlist |
+| `timeout` | `300.0` | 单次公开 HTTP 请求超时（秒） |
+| `operation_wait_timeout` | `600.0` | 官方单 Case/Judge operation 总等待上限（秒） |
+| `max_retries` | `2` | 0–5；仅重试服务端标记为瞬态的失败 |
+| `api_key` / `trace_evidence` | `None` | 本次凭证与可选 Trace capture |
 
-公开服务默认地址是 `https://defuzex.ai/api/agentdefuze`。`DEFUZEX_BASE_URL` 可覆盖 `create_run()` 的地址；明文 HTTP 只允许 loopback 地址。`DefuzeClient` 也支持显式 `base_url` 和 `timeout`：
+环境变量包括 `DEFUZEX_API_KEY`、`DEFUZEX_BASE_URL` 和 `DEFUZEX_CONFIG_HOME`。默认公开地址是 `https://defuzex.ai/api/agentdefuze`。非 loopback 地址必须使用 HTTPS，URL 不能包含 credentials。SDK 不接受内部服务地址或数据库连接配置。
 
-```python
-from defuzex import DefuzeClient
-
-client = DefuzeClient(timeout=10.0)
-entitlements = client.entitlements()
-strategies = client.strategies()
-judge_limits = client.judge_config()
-```
-
-这些读取返回 Backend 的公开动态配置。SDK 不缓存或推断服务端 scope、配额、计费或上传限制。
-
-### 环境变量
-
-| 变量 | 作用 |
-|---|---|
-| `DEFUZEX_API_KEY` | 官方 Provider 使用的 `dfx_` Bearer Key；优先级低于函数参数，高于凭证文件 |
-| `DEFUZEX_BASE_URL` | 覆盖 `create_run()` 使用的 Website Backend public API base URL |
-| `DEFUZEX_CONFIG_HOME` | 覆盖 `configure()`/凭证读取的用户级目录，适合隔离开发和测试环境 |
-
-不要设置 MCP URL、模型 Key 或数据库地址；它们不是 SDK 配置。非 loopback 的 `DEFUZEX_BASE_URL` 必须使用 HTTPS，URL 中也不能包含 credentials。
-
-## Provider 组合
-
-是否传入 Provider 决定联网范围：
+### Provider 与 Run 生命周期
 
 | Case | Judge | 行为 |
 |---|---|---|
-| 省略 | 省略 | 官方 Case + 官方 Judge；需要 API Key |
-| 省略 | 自定义 | 官方 Case + 本地自定义 Judge；需要 API Key |
-| 自定义 | 省略 | 本地自定义 Case + 官方 Judge；需要 API Key |
-| 自定义 | 自定义 | 完全本地；自定义 Case 必须提供固定公开 rubric |
-| 任意 | `judge=False` | 不创建 Judge Provider，Run 在最后一次提交后结束 |
+| 省略 | 省略 | 官方 Case + 官方 Judge，需要 API Key |
+| 省略 | 自定义 | 官方 Case + 本地 Judge，需要 API Key |
+| 自定义 | 省略 | 本地 Case + 官方 Judge，需要 API Key |
+| 自定义 | 自定义 | 完全本地；Case 必须包含固定公开 rubric |
+| 任意 | `judge=False` | 最后一次提交后结束，不创建 Judge Provider |
 
-自定义 Provider 可以是实现 Protocol 的对象，也可以是 callable：
+自定义 Provider 可以实现公开 Protocol，也可以传 callable。最小实现见 [`examples/minimal_local.py`](examples/minimal_local.py)。所有外部 Case 和 Judgment 都会在进入 Run 前归一化并严格验证。
 
-```python
-from defuzex import create_run
-from defuzex.providers import CaseGenerationContext, JudgeContext
+Run 依次执行：`create_run()` 验证并返回 `ready`；`get_input()` 交付当前 Input；用户 Agent 执行；`submit()` 原子记录 Evidence 和 History；仍有 Input 时回到 `ready`，最后一步进入 `completed`；启用 Judge 时，成功后进入 `report_ready`。
 
+官方 Provider 内部使用 v2 operation 有界轮询，但 Python API 表面保持同步。SDK 不创建后台 worker，`wait=False` 不受支持。operation 超时会保留有限恢复元数据并抛出可重试的 `DefuzeTimeoutError(code="operation_wait_timeout")`。当前高层 API 不能在进程丢失整个 `Run` 对象后仅凭 `run_id` 重建；Judge 重试需要原 Run 和 History。
 
-def make_case(context: CaseGenerationContext) -> dict[str, object]:
-    return {
-        "inputs": ["Inspect the repository safely."],
-        "rubric": {"criteria": ["The result stays within the repository."]},
-    }
+非法顺序会抛出 `InputProtocolError`。提前放弃时调用 `run.cancel()`，以释放运行锁并隔离迟到 span。每个容器只能有一个 active Run，同一个 Run 只能有一个当前 Input。
 
+### Evidence 与 OpenTelemetry
 
-def judge_locally(context: JudgeContext) -> dict[str, object]:
-    return {"status": "pass", "confidence": 1.0}
+每次 `get_input()` 到 `submit()` 是一个 Evidence 事务：Repo metadata 只包含相对路径、类型、大小和 fingerprint；文件追踪默认只记录 hash/size/mode 和变化类型；`logs=[...]` 只读取显式文件增量；提交成功后才推进日志 offset 与 Trace 预算。`CaptureStatus`、`missing`、`dropped_count` 和 `runtime_warnings` 表示不完整或降级。`save_local=True` 原子保存结构化步骤记录，但不替代服务端提交。
 
-
-run = create_run(
-    repo_path=".",
-    requirement_path="requirement.md",
-    case_provider=make_case,
-    judge_provider=judge_locally,
-    max_inputs=1,
-    allow_local=True,
-)
-```
-
-所有 Case 和 Judgment 结果都会先归一化并验证，再进入 Run。官方 Provider 还会拒绝包含 Private Rubric、hidden answer、provider key、MCP 地址或模型配置的畸形响应。
-
-## Run 生命周期
-
-一个 `Run` 只对应一个完整 `Case`，并执行严格握手：
-
-1. `create_run()` 完成离线预检、Provider 选择、Case 生成和归一化，返回 `state == "ready"` 的 Run。
-2. `get_input()` 交付当前 Input 并开始本步 Evidence；重复调用会返回同一个 Input，不会前进。
-3. 用户 Agent 执行任务。
-4. `submit()` 验证 output/status，准备 Evidence，创建 `Submission`，原子记录 History 后才提交日志 offset 和 Trace 预算。
-5. 还有 Input 时回到 `ready`；最后一步进入 `completed`。
-6. `judge=True` 时最后一次 `submit()` 保持同步用户体验：Official Provider 在内部提交 v2 operation 并有界轮询，终态 Judgment 归一化为 `TestReport`，状态变为 `report_ready`。
-
-在没有已交付 Input 时调用 `submit()`，或在错误状态调用 `get_input()`/`judge()`，会抛出 `InputProtocolError`。`wait=False` 不受支持，SDK 不启动后台队列。Judge 失败时已提交的 History 不会伪装回滚，Run 回到 `completed`，可以调用 `run.judge()` 重试。官方 Case/Judge 会复用已保存的幂等键；已取得 `operation_id` 时只继续 GET。`operation_wait_timeout` 会抛出可重试的 `DefuzeTimeoutError(code="operation_wait_timeout")`，不会删除恢复元数据。当前高层 API 不能在整个 Python 进程丢失 `Run` 对象后仅凭 `run_id` 重建该 Run；Judge 的恢复要求原 `Run` 对象及其 History 仍可用。
-
-`run.cancel()` 会释放运行锁、取消当前 Evidence 事务并阻止迟到 Trace 进入其他 Run。建议在用户代码提前退出且尚未完成时显式调用它。
-
-可观察属性：
-
-- `run.run_id`、`run.case_id`、`run.strategy`、`run.max_inputs`
-- `run.state`
-- `run.history`：不可变的 `HistoryItem` tuple
-- `run.report`：Judge 完成前为 `None`
-- `run.runtime_warnings`：Evidence/Trace 降级，不包含伪造成功
-
-## 用户 Agent、Docker 与 SDK 的责任边界
-
-SDK 不启动 Agent，也不替用户选择模型、执行工具或赋予文件/网络权限。用户集成需要：
-
-1. 将 SDK 和被测 Agent 安装在同一个 Docker 容器中；正式模式由 SDK 检查这一点。
-2. 以 `get_input()` 取得测试输入，调用真实 Agent，再用 `submit()` 提交结果；不要让多个线程同时推进同一个 Run 的协议状态。
-3. 为 Agent 设置符合自身风险模型的文件、命令、网络和 secret 权限。SDK 的 Evidence 扫描不能替代容器隔离或最小权限。
-4. 在提前停止、异常退出或放弃当前 Run 时调用 `cancel()`，让运行锁和 Evidence 关联及时释放。
-
-`allow_local=True` 只用于明确的本地开发/测试。它放宽“必须在 Docker 中”的检查，但不会提供沙箱，也不会改变公开网络、敏感扫描、协议顺序或单 active Run 限制。SDK 仓库不启动 Backend、Core 或模型服务；服务端部署与本地服务编排不是普通 SDK 调用的前置条件。
-
-## Case、Submission 与 Judgment
-
-公开契约位于 `defuzex.contracts`，并从顶层包导出常用类型：
-
-- `DefuzeXInput`：一个已验证的 text 或 structured 输入。
-- `Case`：至少包含一个 Input；官方 Case 不向 SDK 暴露私有 rubric。
-- `Submission`：状态为 `completed`、`failed`、`timeout` 或 `aborted`，包含 output/error 和 Evidence 摘要。
-- `HistoryItem`：强制 Input 与 Submission 的 run/case/input 标识一致。
-- `TestReport`：状态为 `pass`、`issue` 或 `insufficient_evidence`；confidence 接受 Core 的 `low`/`medium`/`high`，自定义 Judge 也可返回 0–1 数值。
-- `JudgeBatchResult`：官方同步批量 Judge 的单项 report 或稳定 error。
-
-这些 dataclass 是不可变、深层 JSON 兼容的边界对象；未知主 schema 版本会被拒绝。高层 `Run` 使用单 Run Judge；高级调用者可通过 `OfficialJudgeProvider.judge_batch()` 同步提交最多由 Backend 动态配置允许的多个 `JudgeContext`。批量结果保持输入顺序，并隔离每项错误。
-
-## Evidence
-
-每次 `get_input()` 到 `submit()` 构成一个 Evidence 事务：
-
-- Repo Meta 只收集相对路径、entry 类型、文件大小和基于这些字段的 SHA-256 fingerprint；不读取源码、README、Git 内容、绝对主机路径或 symlink 目标。
-- 文件追踪记录前后 hash/size/mode 和 created/modified/deleted/renamed；默认不上传文本 diff。
-- `logs=[...]` 只采集显式传入文件的增量；只有提交成功后才推进 offset。
-- `CaptureStatus` 分别报告 snapshot、diff、logs、sensitive scan 和 traces 的 `complete/partial/failed/skipped`。
-- `missing`、`dropped_count` 和 `runtime_warnings` 明确记录不完整证据。
-- `save_local=True` 使用 pending file + rename 保存结构化步骤记录；它不替代服务端提交，也不会让失败请求看起来成功。
-
-启动 Run 会创建被排除的 `.defuzex/` 目录，并在需要时向仓库 `.gitignore` 幂等加入 `/.defuzex/`。正式模式要求 SDK 与 Agent 在同一个 Docker 容器内，并通过 OS lock 限制每个容器一个 active Run；`allow_local=True` 仅显式放宽开发环境检查。
-
-## OpenTelemetry Trace Evidence
-
-DefuzeX 使用官方 OpenTelemetry `SpanProcessor`/`SpanExporter` 扩展点，不替换或重置用户已有的 `TracerProvider`：
+OpenTelemetry 是可选能力。DefuzeX 使用标准 `SpanProcessor`/`SpanExporter` 扩展点，不替换已有 `TracerProvider`：
 
 ```python
-import json
-
 from opentelemetry.sdk.trace import TracerProvider
 
 from defuzex import create_run
@@ -381,48 +226,34 @@ trace_evidence = configure_trace_evidence(
     provider,
     limits=TraceEvidenceLimits(max_spans=100, max_total_bytes=256_000),
 )
-tracer = provider.get_tracer("my-agent")
-
 run = create_run(
     repo_path=".",
     requirement_path="requirement.md",
     allow_local=True,
     trace_evidence=trace_evidence,
 )
-
-while (test_input := run.get_input()) is not None:
-    with tracer.start_as_current_span("invoke_agent my-agent") as span:
-        span.set_attribute("gen_ai.operation.name", "invoke_agent")
-        span.set_attribute("gen_ai.request.model", "instrumented-model-name")
-        output_messages = [
-            {
-                "role": "assistant",
-                "parts": [{"type": "text", "content": str(test_input)}],
-            }
-        ]
-        span.set_attribute("gen_ai.output.messages", json.dumps(output_messages))
-    report = run.submit()
 ```
 
-成熟 Agent 的 instrumentation 通常负责写入这些 span 属性。SDK 只会自动采用 Agent/Workflow span attribute 或 event 中的标准输出，不会把普通 `chat` 模型调用误判为最终 Agent 结果。同一 span 的最后一个有效 event 优先于 attribute；多个候选按结束时间选择，时间相同时 Workflow 优先于 Agent，再以 span ID 稳定打破平局，重复值只保留一个候选。instrumentation 已明确记录最终输出时，即使 span 因通用控制流异常被 OTel 标为 `error`，该输出仍可提交，而 Trace 继续如实保留 `error` 状态。未提供标准字段、字段无效或超出 Trace 字节上限时，`submit()` 安全失败并要求兼容路径 `run.submit(output)`；显式 output 始终优先。
+Capture 只接受同一进程、当前 Input 生命周期内的已结束 spans，并保留父子关系、时间、状态和受控 metadata。属性、事件、span 数量和每 Run 总字节均有硬上限。截断、丢弃和 exporter/flush 失败会进入 capture 状态与 warning，不会伪造成功或破坏 Run。
 
-capture 只接收同一进程中，在当前 Input 已关联后开始并结束的 span；线程池 worker span 会在 start 时关联，cancel/finish 后结束的迟到 span 会被丢弃。它不提供 OTLP receiver、跨进程采集、Trace UI 或存储平台。
+只有约定的 Agent/Workflow span 最终输出可作为省略 `submit(output)` 时的来源；显式 output 始终优先。没有有效输出时 SDK 会安全失败并要求显式提交。`allow_sensitive=True` 不能放宽 OTel 的拒绝式 allowlist。OTel 不提供跨进程 OTLP receiver、UI 或存储平台。
 
-Trace Evidence 保留 trace/span/parent ID、name、kind、status、开始/结束/时长、受控 events、resource 和 instrumentation scope。普通 span attribute 默认拒绝，只允许必要的 `gen_ai` 模型、usage 和 latency 字段；resource 仅允许 service、deployment environment 和 OTel SDK 元数据。自动提交只在内存中读取最终 Agent 输出，原文不会复制进 Trace Evidence。prompt、completion、源码、文件内容、原始日志、token/API key 和 Private Rubric 永远不会因 `allow_sensitive=True` 被放行。
+### Agent、Docker 与安全边界
 
-`TraceEvidenceLimits` 对 span 数、attribute 数、每 span event 数、文本长度和整个 Run 的紧凑 JSON 字节数设置硬上限。截断和丢弃通过 `truncated`、`dropped_count`、`reasons`、`capture_status.traces`、`missing` 与 `runtime_warnings` 暴露。Exporter、序列化或 flush 失败只降低 Trace Evidence，不破坏 `get_input()`、`submit()` 或 Judge。
+- 用户代码负责启动 Agent、调用工具、限制权限并返回真实 JSON 结果。
+- 正式模式默认要求 SDK 与 Agent 在同一个 Docker 容器；`allow_local=True` 只用于显式本地开发，不是沙箱。
+- SDK 的 Evidence 扫描不能替代容器隔离、最小权限或用户对 Agent 网络/文件访问的限制。
+- SDK 只调用公开 HTTPS API；上传前扫描 output、error、显式日志、diff、自定义 Case 和 repo path。
+- API Key 只进入 `Authorization` header，不进入 body、Repo metadata 或 Evidence。
+- SDK 不拥有服务端鉴权策略、scope、配额、计费、服务端评估逻辑、模型执行或数据库。
 
-成功捕获时，canonical 公共扩展为：
+公开用户镜像只做构建验证：
 
-```text
-Submission.extensions["trace_evidence"]
--> history[].submission.trace_evidence
--> schema_version == "defuzex.trace_evidence.v1"
+```bash
+docker build -f examples/full_stack/Dockerfile.user-flow -t defuzex-user-flow .
 ```
 
-## 错误处理
-
-新代码应捕获 `defuzex.errors.DefuzeError` 或其稳定子类：
+### 错误处理与故障排查
 
 ```python
 from defuzex.errors import DefuzeError
@@ -433,123 +264,358 @@ except DefuzeError as exc:
     print(exc.code, exc.retryable, exc.request_id)
 ```
 
-常用类型包括 `ConfigurationError`、`AuthenticationError`、`PermissionDeniedError`、`ValidationError`、`SensitiveDataError`、`LimitExceededError`、`InputProtocolError`、`ProviderError`、`DefuzeTimeoutError`、`ServiceBusyError` 和 `ServiceError`。`code` 与 `retryable` 用于程序判断；`details` 不会进入异常显示文本。Backend 内部错误详情不会透传，避免泄漏服务端上下文。`defuzex.exceptions` 只保留旧客户端异常名的兼容性。
+常用类型包括 `ConfigurationError`、`AuthenticationError`、`PermissionDeniedError`、`ValidationError`、`SensitiveDataError`、`LimitExceededError`、`InputProtocolError`、`ProviderError`、`DefuzeTimeoutError`、`ServiceBusyError` 和 `ServiceError`。服务端内部详情不会进入公开异常文本。
 
-POST 请求自动带 Bearer `dfx_` 凭证和幂等键。仅 Backend 明确标记为可重试的瞬态失败会在 `max_retries` 范围内做有上限的指数退避重试，且每次 POST 重试复用同一 body 和幂等键；operation GET 的网络瞬断可在总等待预算内继续。所有 `ServiceBusyError` 都不会自动重试。公网响应超过 8 MiB 会在解析前被拒绝。
+| 现象 | 处理 |
+|---|---|
+| 没有 API Key | 使用自定义 Case 与自定义 Judge，或 `judge=False` |
+| `DockerRequiredError` | 生产环境使用同容器；仅本地开发使用 `allow_local=True` |
+| `submit()` 返回 `None` | 检查是否仍有 Input、是否关闭 Judge，以及 `state`/`history` |
+| operation 超时 | 检查 `retryable`，保留原 Run 后重试，不要切换协议 |
+| OTel 未安装或无最终输出 | 安装 `[otel]` 并显式 attach，或调用 `run.submit(output)` |
 
-## 隐私与边界
+POST 使用稳定幂等键。只有明确的瞬态失败会在 `max_retries` 范围内退避重试；`ServiceBusyError` 不自动重试。公开响应超过 8 MiB 会在解析前被拒绝。
 
-- SDK 只访问 Website Backend 的 `/sdk/` 公开路径，绝不接受 URL credentials，也不直接探测 Core MCP。
-- 官方上传前扫描 output、error、log、diff、custom Case 和 repo path；默认发现高置信敏感内容即阻止提交。
-- `allow_sensitive=True` 是普通 Evidence 的显式覆盖，不影响 OTel 的拒绝式 allowlist，也不允许协议出现私有字段。
-- API Key 只用于 `Authorization` header，不进入 body、`repr()`、Repo Meta 或 Evidence。
-- SDK 不拥有 API Key 策略、scope、配额、计费、Private Rubric、模型执行、Prompt、模型配置或数据库；这些是服务端职责。
+### 文档、开发与限制
 
-## 深入文档与示例
-
-- [SDK v4 架构](docs/architecture.md)：模块职责、依赖方向、Run 状态机、Evidence 事务和 OTel 适配。
-- [公开 API Contract](docs/api-contract.md)：Website Backend base URL、鉴权、错误与公开服务摘要。
-- [离线最小示例](examples/minimal_local.py)：无需凭证、网络或外部服务的单 Input 完整 Run。
-- [Single Agent Template](examples/single_agent_template/README.md)：框架无关的单 Agent 接入骨架、官方模式占位与确定性成功/失败 smoke。
-- [用户接入指南](examples/full_stack/USER_GUIDE.md)：从 GitHub 安装、API Key、requirement、用户 Agent 适配、Evidence 与结果检查。
-- [真实用户流程 Notebook](examples/full_stack/defuzex_v4_real_user_flow.ipynb)：通过环境变量读取凭据，在用户选择的安全工作目录中运行官方 Case → Agent → Evidence → Judge 流程。
-- 本 README 的自定义 Provider 示例不需要官方服务，但仍会创建 Run 工作目录；开发机需使用 `allow_local=True`。
-
-## 目录结构
+- [SDK 架构](docs/architecture.md)
+- [公开 API Contract](docs/api-contract.md)
+- [离线最小示例](examples/minimal_local.py)
+- [Single Agent Template](examples/single_agent_template/README.md)
+- [用户接入指南](examples/full_stack/USER_GUIDE.md)
+- [真实用户流程 Notebook](examples/full_stack/defuzex_v4_real_user_flow.ipynb)
+- [贡献说明](CONTRIBUTING.md)、[安全报告](SECURITY.md)、[Apache License 2.0](LICENSE)
 
 ```text
-src/defuzex/              Python 包与公开入口
-  providers/              official/custom Case 与 Judge Provider 边界
-  tracking/               snapshot、diff、log 与 Evidence 事务
-docs/                     架构和公开 API contract
-examples/full_stack/      用户侧 Docker、Notebook 与接入指南
-examples/minimal_local.py 无凭证、无网络的最小公开示例
-examples/single_agent_template/ 框架无关的单 Agent 接入模板
-pyproject.toml            包元数据、可选依赖及 Ruff 配置
+src/defuzex/                       Python 包与公开入口
+src/defuzex/providers/             official/custom Provider 边界
+src/defuzex/tracking/              snapshot、diff、log 与 Evidence 事务
+docs/                              架构与公开 HTTP contract
+examples/minimal_local.py          无凭据离线示例
+examples/single_agent_template/    框架无关 Agent 接入模板
+examples/full_stack/               用户侧 Docker、Notebook 与接入指南
 ```
-
-关键入口是 `src/defuzex/api.py` 的 `create_run()`、`src/defuzex/run.py` 的同步状态机，以及 `src/defuzex/backend.py` 的唯一公网 transport。业务代码应优先从 `defuzex` 和 `defuzex.providers` 的公开导出导入，而不是依赖以下划线开头的内部模块。
-
-## 开发与验证
-
-开发安装：
 
 ```bash
 python -m pip install -e ".[dev]"
-```
-
-公开仓库质量门禁：
-
-```bash
 python -m ruff check --exclude "*.ipynb" .
 python -m ruff format --check --exclude "*.ipynb" .
 python -m compileall -q src examples
 defuzex quickstart
 python examples/minimal_local.py
-```
-
-公开 CI 验证静态质量、跨 Python 安装与导入、CLI、离线示例和发行物。维护者在接收发布前另行运行私有安全、协议和跨仓回归；公开镜像不包含内部验收资产或完整私有测试套件。
-
-构建与包元数据验证使用 `[dev]` 已安装的 `build` 和 `twine`；它们不是 SDK runtime dependency：
-
-```bash
 python -m build
 python -m twine check dist/*
 ```
 
-CI 在 Ubuntu 上覆盖 Python 3.10–3.14 的安装、导入、CLI 与离线示例，并在 Windows/macOS 3.13 上复核相同用户路径。Docker 门只验证公开用户镜像可构建，不启动 Agent、不读取凭据：
+公开 CI 验证 lint、跨 Python 安装/导入、CLI、离线示例和打包。维护者在发布前另行执行私有安全与跨服务契约回归；公开分发仓不包含内部验收资产。
+
+当前限制：Python Run API 为同步表面；官方单 Case/Judge 内部使用有界 operation 轮询；官方 Case 当前只返回文本 Input；正式 Run 默认要求同容器；每个容器一个 active Run；OTel 仅同进程；SDK 不提供 Agent runner、托管服务部署、UI、模型调用或数据库。
+
+## English
+
+The DefuzeX Python SDK is the public Python client for Agent behavior testing. It parses test requirements, drives a synchronous `Run` protocol, captures bounded Evidence, and obtains official Cases and final Judgments through the DefuzeX public HTTPS API.
+
+### Scope and boundaries
+
+```text
+SDK -> DefuzeX public API -> DefuzeX managed services
+```
+
+The SDK implements client protocols and Evidence boundaries only. It does not start or host an Agent, select the Agent's model, provide a sandbox, deploy services, own a database, run background jobs, or connect directly to DefuzeX internal services. Server-only evaluation material, execution configuration, and credentials do not enter the SDK.
+
+See the [architecture document](docs/architecture.md) and [public API Contract](docs/api-contract.md).
+
+### Core concepts
+
+- **Case**: the public sequence of inputs for one complete test.
+- **Input**: one task currently delivered to the user's Agent.
+- **Run**: a single-Case state machine with a strict `get_input()` -> Agent -> `submit()` handshake.
+- **Submission / History**: the Agent result for each Input and its immutable history.
+- **Evidence**: file changes, explicit logs, and optional in-process OpenTelemetry spans.
+- **Judgment / TestReport**: the public result for the complete Run.
+- **Provider**: an official or fully local Case/Judge boundary implementation.
+
+### Installation
+
+Python 3.10 or newer is required.
+
+```bash
+git clone https://github.com/DefuzeX-company/defuzex-python-sdk.git
+cd defuzex-python-sdk
+python -m venv .venv
+```
+
+Windows PowerShell:
+
+```powershell
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -e .
+```
+
+Linux/macOS:
+
+```bash
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -e .
+```
+
+If `defuzex` is available from your package index, use `python -m pip install defuzex`. Install optional capabilities only when needed; the core package does not require OpenTelemetry:
+
+```bash
+python -m pip install "defuzex[otel]"
+python -m pip install -e ".[dev]"
+```
+
+A repository version does not prove that the same version is published to a public package index. Use the package index or Git commit you installed as the source of truth.
+
+### Account-free first run
+
+```bash
+defuzex quickstart
+```
+
+This command needs no account, API Key, Docker, or network and does not read the current directory or a user repository. It uses an isolated temporary directory, fixed Input, deterministic example Agent, and one published rule.
+
+```text
+Local check: PASS
+Score: 100/100
+Reason: Output exactly matched the published rule.
+Artifact: <temporary directory>/result.json
+```
+
+`defuzex quickstart --fail-demo` demonstrates a deterministic failure and exits non-zero. A complete credential-free Run is also available:
+
+```bash
+python examples/minimal_local.py
+```
+
+It uses a temporary repository, custom Case Provider, `judge=False`, and `allow_local=True`, and does not modify the user's repository.
+
+### Hosted-service quickstart
+
+An official Case or Judge requires an API Key beginning with `dfx_`. Supply it through the process environment or local user credential store. Never place it in source code, Notebook output, or Git.
+
+```powershell
+$env:DEFUZEX_API_KEY = "dfx_your_key_here"
+defuzex whoami
+```
+
+```bash
+export DEFUZEX_API_KEY="dfx_your_key_here"
+defuzex whoami
+```
+
+The SDK can write the key atomically to the user credential directory without making a network request:
+
+```python
+from defuzex import configure
+
+credential_path = configure(api_key="dfx_your_key_here")
+print(credential_path)
+```
+
+Credential precedence is: function argument, `DEFUZEX_API_KEY`, then the user credential file.
+
+The official Case Provider requires an explicit UTF-8 requirement file, for example `requirement.md`:
+
+```markdown
+---
+agent_description: A repository maintenance agent
+input_type: text
+---
+
+## Production Use Scenario
+
+Maintain a Python repository without changing its public interface.
+
+## Behaviors to Test
+
+Diagnose the requested defect, apply a bounded fix, and run relevant checks.
+
+## Known Limitations or Prohibited Behaviors
+
+Do not read credentials or access paths outside the repository.
+```
+
+The hosted service currently accepts text Inputs. Structured Inputs require a custom Case Provider and local JSON Schema. The user owns the real Agent invocation; the SDK owns only the Run protocol:
+
+```python
+from typing import Any
+
+from defuzex import create_run
+
+
+def execute_agent(test_input: Any) -> dict[str, Any]:
+    """Replace this body with the Agent invocation being evaluated."""
+    return {"result": str(test_input)}
+
+
+run = create_run(
+    repo_path=".",
+    requirement_path="requirement.md",
+    allow_local=True,  # Local development only; production defaults to Docker.
+)
+
+while (test_input := run.get_input()) is not None:
+    report = run.submit(execute_agent(test_input))
+
+print(run.state)
+print(run.report)
+```
+
+`get_input()` returns the JSON-compatible payload by default. `get_input(full=True)` returns an immutable `DefuzeXInput`. `submit(output)` requires the real Agent result as finite JSON-serializable data.
+
+### Public API and configuration
+
+| Import | Purpose |
+|---|---|
+| `defuzex.configure` | Validate and atomically save an API Key without network access |
+| `defuzex.create_run` | Create a synchronous Python `Run` |
+| `defuzex.DefuzeClient` | Read public entitlements, strategy catalog, and Judge configuration |
+| `defuzex.Case`, `DefuzeXInput`, `Submission`, `HistoryItem`, `TestReport` | Immutable public contract objects |
+| `defuzex.errors` | `DefuzeError` and stable subclasses |
+| `defuzex.providers` | Official/custom Provider protocols, contexts, and normalizers |
+| `defuzex.otel` | Optional in-process Trace Evidence attach API |
+
+`Run` exposes `get_input()`, `submit()`, `judge()`, `cancel()`, and the `state`, `history`, `report`, and `runtime_warnings` properties.
+
+| `create_run()` argument | Default | Purpose |
+|---|---:|---|
+| `repo_path` | `"."` | Repository under test |
+| `requirement_path` | `None` | Requirement file; official Providers require it explicitly |
+| `case_provider` / `judge_provider` | `None` | Omit to use the corresponding official Provider |
+| `strategy` | `"auto"` | Automatic selection or explicit strategy ID; the service returns the actual selection |
+| `max_inputs` | `None` | Required Input bound for a custom Case |
+| `judge` / `on_failure` | `True` / `"continue"` | Whether to Judge and whether to continue or stop after failure |
+| `allow_local` | `False` | Explicitly permit a non-Docker development run |
+| `track_files` / `upload_diff` | `True` / `False` | File metadata capture and optional text diff |
+| `save_local` | `False` | Save step records under `.defuzex/runs/<run_id>/submissions/` |
+| `allow_sensitive` | `False` | Explicit ordinary-Evidence scan override; does not affect the OTel allowlist |
+| `timeout` | `300.0` | Per-request public HTTP timeout in seconds |
+| `operation_wait_timeout` | `600.0` | Total wait bound for one official Case/Judge operation |
+| `max_retries` | `2` | 0–5; retry only service-marked transient failures |
+| `api_key` / `trace_evidence` | `None` | Per-call credential and optional Trace capture |
+
+Environment variables are `DEFUZEX_API_KEY`, `DEFUZEX_BASE_URL`, and `DEFUZEX_CONFIG_HOME`. The default public URL is `https://defuzex.ai/api/agentdefuze`. Non-loopback URLs must use HTTPS and URLs cannot contain credentials. The SDK does not accept internal service addresses or database connection configuration.
+
+### Providers and Run lifecycle
+
+| Case | Judge | Behavior |
+|---|---|---|
+| Omitted | Omitted | Official Case + official Judge; API Key required |
+| Omitted | Custom | Official Case + local Judge; API Key required |
+| Custom | Omitted | Local Case + official Judge; API Key required |
+| Custom | Custom | Fully local; Case must contain a fixed public rubric |
+| Any | `judge=False` | Finish after the final submission without a Judge Provider |
+
+A custom Provider may implement the public Protocol or be a callable. See [`examples/minimal_local.py`](examples/minimal_local.py). Every external Case and Judgment is normalized and strictly validated before entering a Run.
+
+The lifecycle is: `create_run()` validates and returns `ready`; `get_input()` delivers the current Input; the user Agent runs; `submit()` atomically commits Evidence and History; the Run returns to `ready` when more Inputs remain and enters `completed` after the last; an enabled successful Judge moves it to `report_ready`.
+
+Official Providers use bounded v2 operation polling internally while the Python API stays synchronous. The SDK creates no background worker and `wait=False` is unsupported. A deadline preserves bounded resume metadata and raises retryable `DefuzeTimeoutError(code="operation_wait_timeout")`. The high-level API cannot reconstruct a lost `Run` from only `run_id` after the process exits; Judge retry needs the original Run and History.
+
+Invalid ordering raises `InputProtocolError`. Call `run.cancel()` when abandoning a Run to release its lock and isolate late spans. One container may have only one active Run, and one Run may have only one current Input.
+
+### Evidence and OpenTelemetry
+
+Each `get_input()` to `submit()` interval is an Evidence transaction. Repository metadata contains only relative paths, types, sizes, and a fingerprint. File tracking records hashes/sizes/modes and change types by default. `logs=[...]` reads only increments from explicit files. Log offsets and Trace budgets advance only after commit. `CaptureStatus`, `missing`, `dropped_count`, and `runtime_warnings` expose incomplete capture. `save_local=True` atomically stores structured step records but does not replace hosted submission.
+
+OpenTelemetry is optional. DefuzeX uses standard `SpanProcessor`/`SpanExporter` extension points and does not replace an existing `TracerProvider`:
+
+```python
+from opentelemetry.sdk.trace import TracerProvider
+
+from defuzex import create_run
+from defuzex.otel import TraceEvidenceLimits, configure_trace_evidence
+
+provider = TracerProvider()
+trace_evidence = configure_trace_evidence(
+    provider,
+    limits=TraceEvidenceLimits(max_spans=100, max_total_bytes=256_000),
+)
+run = create_run(
+    repo_path=".",
+    requirement_path="requirement.md",
+    allow_local=True,
+    trace_evidence=trace_evidence,
+)
+```
+
+Capture accepts only ended spans from the same process and current Input lifecycle. It preserves parentage, timing, status, and controlled metadata. Attributes, events, span counts, and total bytes per Run have hard limits. Truncation, drops, and exporter/flush failures appear in status and warnings without fabricating success or breaking the Run.
+
+Only a convention-compliant Agent/Workflow span final output may supply an omitted `submit(output)` value; explicit output always wins. Without a valid output, the SDK fails safely and requests an explicit submission. `allow_sensitive=True` cannot relax the OTel deny-by-default allowlist. OTel support is not a cross-process OTLP receiver, UI, or storage platform.
+
+### Agent, Docker, and security boundaries
+
+- User code starts the Agent, invokes tools, constrains permissions, and returns the real JSON result.
+- Production mode requires the SDK and Agent in one Docker container by default. `allow_local=True` is an explicit development escape hatch, not a sandbox.
+- Evidence scanning does not replace container isolation, least privilege, or user control of Agent network/filesystem access.
+- The SDK calls only the public HTTPS API and scans output, errors, explicit logs, diffs, custom Cases, and repository paths before upload.
+- The API Key enters only the `Authorization` header, never the body, repository metadata, or Evidence.
+- The SDK does not own hosted authentication policy, scopes, quotas, billing, server evaluation logic, model execution, or databases.
+
+The public user image is build-validated only:
 
 ```bash
 docker build -f examples/full_stack/Dockerfile.user-flow -t defuzex-user-flow .
 ```
 
-### 分支、验收与发布规范
+### Errors and troubleshooting
 
-- `main` 只保存经本仓明确负责人验收的正式代码；禁止直接在 `main` 开发或提交。
-- 每位会修改仓库的人使用独立的 `dev/<owner>` 分支。不得多人共用一个开发分支，也不得把未经负责人验收的代码合入 `main`。
-- 本仓负责人审查需求到代码/测试的映射和实际门禁证据，解决合并冲突，并且是把各 `dev/<owner>` 合入 `main` 的唯一明确责任人。作者不能自我批准。
-- 正常 SDK 发布顺序是：`dev/<owner>` → 负责人验收并合入 `main` → 从 `main` 的确定 commit 构建并验证发行物 → 发布该发行物。仓库版本号本身不证明发行物已经发布。
-- 热修复仍从独立 `dev/<owner>` 完成修复和回归测试，经负责人验收后合入 `main`；回滚应恢复到已验证 commit/发行物，不得直接修改已安装包后把结果反推为源码事实。
-- `deploy` 只适用于实际部署到服务器的仓库，用来精确指向当前 EC2 运行代码。本仓是 Python 客户端库，不代表 EC2 运行服务，因此不需要 `deploy` 分支。对于需要服务器部署的兄弟仓库，顺序必须是：负责人验收合入 `main` → 从 `main` 的确定 commit 部署 EC2 → 线上验收通过后让 `deploy` 指向同一 commit；回滚后 `deploy` 也必须指向 EC2 实际运行的回滚 commit。
-- 禁止在服务器直接改代码后只更新 `deploy`，也禁止把运行时配置、secret、凭证或数据库内容放入任何分支。
+```python
+from defuzex.errors import DefuzeError
 
-## FAQ
+try:
+    report = run.judge()
+except DefuzeError as exc:
+    print(exc.code, exc.retryable, exc.request_id)
+```
 
-### 没有 API Key 可以使用 SDK 吗？
+Common types include `ConfigurationError`, `AuthenticationError`, `PermissionDeniedError`, `ValidationError`, `SensitiveDataError`, `LimitExceededError`, `InputProtocolError`, `ProviderError`, `DefuzeTimeoutError`, `ServiceBusyError`, and `ServiceError`. Internal service details do not enter public exception text.
 
-可以。使用自定义 Case Provider，并传入自定义 Judge 或 `judge=False`，即可完全本地运行；官方 Case 或官方 Judge 才需要 API Key。参见[离线最小示例](examples/minimal_local.py)。
+| Symptom | Action |
+|---|---|
+| No API Key | Use a custom Case with a custom Judge, or `judge=False` |
+| `DockerRequiredError` | Use one container in production; use `allow_local=True` only for explicit local development |
+| `submit()` returns `None` | Check for remaining Inputs, disabled Judge, and `state`/`history` |
+| Operation timeout | Inspect `retryable`, retain the original Run, and retry without switching protocols |
+| OTel missing or no final output | Install `[otel]` and attach explicitly, or call `run.submit(output)` |
 
-### 为什么本地运行报 `DockerRequiredError`？
+POST requests use stable idempotency keys. Only explicitly transient failures are retried with bounded backoff under `max_retries`; `ServiceBusyError` is not retried automatically. Public responses larger than 8 MiB are rejected before parsing.
 
-正式模式默认要求 SDK 与 Agent 同处一个 Docker 容器。仅在明确的本地开发或测试中设置 `allow_local=True`；它不会创建沙箱或降低其他安全校验。
+### Documentation, development, and limitations
 
-### 为什么 `submit()` 返回 `None`？
+- [SDK architecture](docs/architecture.md)
+- [Public API Contract](docs/api-contract.md)
+- [Offline minimal example](examples/minimal_local.py)
+- [Single Agent Template](examples/single_agent_template/README.md)
+- [User integration guide](examples/full_stack/USER_GUIDE.md)
+- [Real user-flow Notebook](examples/full_stack/defuzex_v4_real_user_flow.ipynb)
+- [Contributing](CONTRIBUTING.md), [security reporting](SECURITY.md), and [Apache License 2.0](LICENSE)
 
-非最后一个 Input、`judge=False`，或一次非 completed 提交尚未触发最终 Judge 时，`submit()` 可以返回 `None`。检查 `run.state` 和 `run.history`；Judge 成功后也可读取 `run.report`。
+```text
+src/defuzex/                       Python package and public entry points
+src/defuzex/providers/             Official/custom Provider boundaries
+src/defuzex/tracking/              Snapshot, diff, log, and Evidence transactions
+docs/                              Architecture and public HTTP contract
+examples/minimal_local.py          Credential-free offline example
+examples/single_agent_template/    Framework-neutral Agent integration template
+examples/full_stack/               User-side Docker, Notebook, and integration guide
+```
 
-### OTel 是必需的吗？
+```bash
+python -m pip install -e ".[dev]"
+python -m ruff check --exclude "*.ipynb" .
+python -m ruff format --check --exclude "*.ipynb" .
+python -m compileall -q src examples
+defuzex quickstart
+python examples/minimal_local.py
+python -m build
+python -m twine check dist/*
+```
 
-不是。没有标准 Agent/Workflow span 输出时，直接调用 `run.submit(output)`。只有需要同进程 Trace Evidence 或自动提取最终输出时才安装 `[otel]` extra。
+Public CI checks lint, cross-Python installation/import, the CLI, offline examples, and packaging. Maintainers run separate private security and cross-service contract regressions before release; the public distribution does not contain internal acceptance assets.
 
-### operation 超时后会怎样？
-
-SDK 抛出可重试的 `DefuzeTimeoutError(code="operation_wait_timeout")` 并保留有限恢复元数据。同一 Case 请求可复用请求身份；Judge 需要原 `Run` 对象和 History 才能从高层 API 重试。进程丢失整个 `Run` 后，当前不能只凭 `run_id` 重建。
-
-### SDK 能直接连接 Core MCP、模型或数据库吗？
-
-不能。SDK 唯一网络边界是 Website Backend 的公开 API；不要向 SDK 配置 MCP 地址、模型 Key、Prompt、Private Rubric 或数据库连接。
-
-## 贡献、安全与许可证
-
-- 贡献流程和本地门禁见 [CONTRIBUTING.md](CONTRIBUTING.md)。
-- 漏洞请按 [SECURITY.md](SECURITY.md) 私下报告，不要创建公开 issue。
-- 本项目使用 [Apache License 2.0](LICENSE)。
-
-## 当前限制
-
-- Python Run API 仍是同步的；官方单 Case/Judge 内部使用 Backend v2 operation 有界轮询。批量 Judge 保持既有同步接口；SDK 不运行 Celery 或后台结果队列。
-- 官方 Case 当前只生成文本 Input；结构化 Input 只能来自自定义 Provider。
-- 正式 Run 默认必须与 Agent 同处一个 Docker 容器；本地运行必须显式 `allow_local=True`。
-- 每个容器只有一个 active Run；一个 `Run` 也只允许一个当前 Input。
-- OTel 仅采集同进程 span，不接收远程 OTLP，也不跨进程关联。
-- SDK 不提供 Agent runner、服务端部署、UI、模型调用或数据库。
+Current limitations: the Python Run API is synchronous; official single-Case/Judge calls use bounded operation polling internally; official Cases currently contain text Inputs only; production Runs require one shared container by default; each container has one active Run; OTel capture is in-process only; and the SDK does not provide an Agent runner, managed-service deployment, UI, model execution, or database.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 <p align="center">
-  <img src="docs/assets/defuzex-banner.svg" width="760" alt="DefuzeX Python SDK geometric wordmark banner">
+  <img src="docs/assets/defuzex-banner.svg" width="760" alt="KUMA geometric wordmark banner">
 </p>
 
-<h1 align="center">DefuzeX Python SDK</h1>
+<h1 align="center">KUMA</h1>
 
 <p align="center">
-  <strong>Evidence-first behavior testing for AI agents</strong><br>
-  面向 AI Agent 的证据优先行为测试 SDK
+  <strong>DefuzeX Python SDK</strong><br>
+  Knowledge-grounded Universal Measurement for Agents<br>
+  面向 Agent 的知识与证据驱动通用评测
 </p>
 
 <p align="center">
@@ -18,7 +19,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/DefuzeX-company/defuzex-python-sdk/actions/workflows/ci.yml"><img src="https://github.com/DefuzeX-company/defuzex-python-sdk/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
+  <a href="https://github.com/DefuzeX-AI/KUMA-DefuzeX/actions/workflows/ci.yml"><img src="https://github.com/DefuzeX-AI/KUMA-DefuzeX/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
   <img src="https://img.shields.io/badge/Python-3.10--3.14-3776AB?logo=python&amp;logoColor=white" alt="Python 3.10 to 3.14">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-4C8CBF" alt="Apache 2.0 license"></a>
   <img src="https://img.shields.io/badge/package-v4.0.0-6C63FF" alt="Package v4.0.0">
@@ -55,8 +56,8 @@ SDK 只实现客户端协议和 Evidence 边界。它不启动或托管 Agent，
 需要 Python 3.10 或更高版本。
 
 ```bash
-git clone https://github.com/DefuzeX-company/defuzex-python-sdk.git
-cd defuzex-python-sdk
+git clone https://github.com/DefuzeX-AI/KUMA-DefuzeX.git
+cd KUMA-DefuzeX
 python -m venv .venv
 ```
 
@@ -364,8 +365,8 @@ See the [architecture document](docs/architecture.md) and [public API Contract](
 Python 3.10 or newer is required.
 
 ```bash
-git clone https://github.com/DefuzeX-company/defuzex-python-sdk.git
-cd defuzex-python-sdk
+git clone https://github.com/DefuzeX-AI/KUMA-DefuzeX.git
+cd KUMA-DefuzeX
 python -m venv .venv
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
-# DefuzeX Python SDK
+<p align="center">
+  <img src="docs/assets/defuzex-banner.svg" width="760" alt="DefuzeX Python SDK geometric wordmark banner">
+</p>
 
-[中文](#中文) | [English](#english)
+<h1 align="center">DefuzeX Python SDK</h1>
+
+<p align="center">
+  <strong>Evidence-first behavior testing for AI agents</strong><br>
+  面向 AI Agent 的证据优先行为测试 SDK
+</p>
+
+<p align="center">
+  <a href="docs/architecture.md"><strong>阅读文档 / Read the Docs →</strong></a>
+</p>
+
+<p align="center">
+  <a href="#中文">简体中文</a> &nbsp;|&nbsp; <a href="#english">English</a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/DefuzeX-company/defuzex-python-sdk/actions/workflows/ci.yml"><img src="https://github.com/DefuzeX-company/defuzex-python-sdk/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI status"></a>
+  <img src="https://img.shields.io/badge/Python-3.10--3.14-3776AB?logo=python&amp;logoColor=white" alt="Python 3.10 to 3.14">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-4C8CBF" alt="Apache 2.0 license"></a>
+  <img src="https://img.shields.io/badge/package-v4.0.0-6C63FF" alt="Package v4.0.0">
+</p>
+
+---
 
 ## 中文
 

--- a/docs/assets/defuzex-banner.svg
+++ b/docs/assets/defuzex-banner.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 280" role="img" aria-labelledby="title description">
+  <title id="title">DefuzeX geometric wordmark</title>
+  <desc id="description">A dark blue banner with a connected D and X symbol beside the geometric word DefuzeX.</desc>
+  <defs>
+    <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#071426"/>
+      <stop offset="0.55" stop-color="#102A43"/>
+      <stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#38BDF8"/>
+      <stop offset="1" stop-color="#A78BFA"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1200" height="280" rx="28" fill="url(#background)"/>
+  <path d="M0 224 C180 154 302 275 478 210 S822 130 1200 208" fill="none" stroke="#38BDF8" stroke-opacity="0.12" stroke-width="2"/>
+  <path d="M0 56 C228 128 374 8 604 70 S990 154 1200 72" fill="none" stroke="#A78BFA" stroke-opacity="0.12" stroke-width="2"/>
+
+  <g transform="translate(70 48)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M34 18 H98 C146 18 174 48 174 92 S146 166 98 166 H34 Z" stroke="#F8FAFC" stroke-width="15"/>
+    <path d="M84 58 L142 126 M142 58 L84 126" stroke="url(#accent)" stroke-width="15"/>
+    <circle cx="84" cy="58" r="8" fill="#38BDF8" stroke="none"/>
+    <circle cx="142" cy="58" r="8" fill="#A78BFA" stroke="none"/>
+    <circle cx="84" cy="126" r="8" fill="#A78BFA" stroke="none"/>
+    <circle cx="142" cy="126" r="8" fill="#38BDF8" stroke="none"/>
+  </g>
+
+  <g transform="translate(310 71)" fill="none" stroke="#F8FAFC" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M0 0 V138 H42 C82 138 102 112 102 69 S82 0 42 0 Z"/>
+    <path d="M142 0 V138 M142 0 H220 M142 69 H207 M142 138 H220"/>
+    <path d="M260 138 V0 H338 M260 68 H325"/>
+    <path d="M378 0 V96 C378 126 397 142 426 142 S474 126 474 96 V0"/>
+    <path d="M514 0 H598 L514 138 H598"/>
+    <path d="M638 0 V138 M638 0 H716 M638 69 H703 M638 138 H716"/>
+    <path d="M756 0 L848 138 M848 0 L756 138" stroke="url(#accent)"/>
+  </g>
+
+  <g fill="#38BDF8">
+    <circle cx="1075" cy="36" r="4" opacity="0.8"/>
+    <circle cx="1110" cy="54" r="3" opacity="0.5"/>
+    <circle cx="1142" cy="33" r="5" opacity="0.65"/>
+  </g>
+</svg>

--- a/docs/assets/defuzex-banner.svg
+++ b/docs/assets/defuzex-banner.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 280" role="img" aria-labelledby="title description">
-  <title id="title">DefuzeX geometric wordmark</title>
-  <desc id="description">A dark blue banner with a connected D and X symbol beside the geometric word DefuzeX.</desc>
+  <title id="title">KUMA geometric wordmark</title>
+  <desc id="description">A dark blue banner with a connected K symbol beside the geometric word KUMA.</desc>
   <defs>
     <linearGradient id="background" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#071426"/>
@@ -18,22 +18,19 @@
   <path d="M0 56 C228 128 374 8 604 70 S990 154 1200 72" fill="none" stroke="#A78BFA" stroke-opacity="0.12" stroke-width="2"/>
 
   <g transform="translate(70 48)" fill="none" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M34 18 H98 C146 18 174 48 174 92 S146 166 98 166 H34 Z" stroke="#F8FAFC" stroke-width="15"/>
-    <path d="M84 58 L142 126 M142 58 L84 126" stroke="url(#accent)" stroke-width="15"/>
-    <circle cx="84" cy="58" r="8" fill="#38BDF8" stroke="none"/>
-    <circle cx="142" cy="58" r="8" fill="#A78BFA" stroke="none"/>
-    <circle cx="84" cy="126" r="8" fill="#A78BFA" stroke="none"/>
-    <circle cx="142" cy="126" r="8" fill="#38BDF8" stroke="none"/>
+    <rect x="28" y="18" width="154" height="148" rx="34" stroke="#F8FAFC" stroke-width="12"/>
+    <path d="M78 54 V130 M78 92 L140 54 M78 92 L140 130" stroke="url(#accent)" stroke-width="15"/>
+    <circle cx="78" cy="54" r="8" fill="#38BDF8" stroke="none"/>
+    <circle cx="140" cy="54" r="8" fill="#A78BFA" stroke="none"/>
+    <circle cx="78" cy="130" r="8" fill="#A78BFA" stroke="none"/>
+    <circle cx="140" cy="130" r="8" fill="#38BDF8" stroke="none"/>
   </g>
 
-  <g transform="translate(310 71)" fill="none" stroke="#F8FAFC" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M0 0 V138 H42 C82 138 102 112 102 69 S82 0 42 0 Z"/>
-    <path d="M142 0 V138 M142 0 H220 M142 69 H207 M142 138 H220"/>
-    <path d="M260 138 V0 H338 M260 68 H325"/>
-    <path d="M378 0 V96 C378 126 397 142 426 142 S474 126 474 96 V0"/>
-    <path d="M514 0 H598 L514 138 H598"/>
-    <path d="M638 0 V138 M638 0 H716 M638 69 H703 M638 138 H716"/>
-    <path d="M756 0 L848 138 M848 0 L756 138" stroke="url(#accent)"/>
+  <g transform="translate(340 71)" fill="none" stroke="#F8FAFC" stroke-width="13" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M0 0 V138 M0 70 L88 0 M0 70 L92 138" stroke="url(#accent)"/>
+    <path d="M142 0 V94 C142 126 162 142 192 142 S242 126 242 94 V0"/>
+    <path d="M300 138 V0 L360 82 L420 0 V138"/>
+    <path d="M478 138 L536 0 L594 138 M501 86 H571"/>
   </g>
 
   <g fill="#38BDF8">


### PR DESCRIPTION
## Summary

- introduce the KUMA product identity while preserving the DefuzeX Python SDK and `defuzex` package contract
- provide a complete Chinese/English README with documentation and language navigation
- add a self-contained, script-free SVG banner and truthful CI, Python, license, and package badges
- update repository links and clone instructions to `DefuzeX-AI/KUMA-DefuzeX`

## Validation

- GitHub Actions passed on Python 3.10–3.14, Windows, macOS, package, and Docker jobs
- Ruff, compile, CLI, local example, build, Twine, link, archive, SVG safety, and secret scans passed
- no tests, internal acceptance assets, credentials, private endpoints, or private DefuzeX assets are included

## Review gate

Draft only. Merge requires repository-owner approval.
