### PR TITLE
feat(sdk): add canonical runtime evidence contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ python examples/minimal_local.py
 
 - Synchronous, single-Case [`Run` lifecycle](docs/sdk-guide.md#run-lifecycle-and-providers) with immutable inputs, submissions, history, and reports.
 - Official or custom [Case and Judge providers](docs/sdk-guide.md#run-lifecycle-and-providers), including fully local operation.
-- Bounded [Evidence capture](docs/sdk-guide.md#evidence-and-opentelemetry) for file changes, explicit logs, and capture gaps.
+- Bounded [Evidence capture](docs/sdk-guide.md#evidence-and-opentelemetry) with a canonical, hash-only [Runtime Evidence contract](docs/runtime-evidence.md).
 - Optional [OpenTelemetry trace evidence](docs/sdk-guide.md#evidence-and-opentelemetry) without replacing the application's tracer provider.
 - Public HTTPS-only service boundary; the SDK does not host Agents, models, databases, or private evaluation assets. See [architecture](docs/architecture.md) and the [public API contract](docs/api-contract.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -65,7 +65,7 @@ python examples/minimal_local.py
 
 - 同步、单 Case 的 [`Run` 生命周期](docs/architecture.md#run-状态机)，包含不可变的 Input、Submission、History 和 Report。
 - 支持官方或自定义 [Case 与 Judge Provider](docs/architecture.md#provider)，也可完全本地运行。
-- 有界 [Evidence 采集](docs/architecture.md#trackingevidence-与隐私)，覆盖文件变化、指定日志和采集缺口。
+- 有界 [Evidence 采集](docs/architecture.md#trackingevidence-与隐私)，并提供规范、仅含哈希的 [Runtime Evidence 合同](docs/runtime-evidence.md)。
 - 可选的 [OpenTelemetry Trace Evidence](docs/architecture.md#opentelemetry-适配)，不替换应用已有的 Tracer Provider。
 - 仅访问公开 HTTPS 服务；SDK 不托管 Agent、模型、数据库或私有评估资产。参见[架构](docs/architecture.md)和[公开 API Contract](docs/api-contract.md)。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -234,6 +234,14 @@ flowchart LR
 
 Evidence 的完整性不由单个布尔值掩盖。`CaptureStatus` 分组件记录 complete/partial/failed/skipped，`missing` 给出缺失原因，`dropped_count` 给出丢弃数量，非致命运行问题进入 `runtime_warnings`。`save_local=True` 将同一结构写入 `.defuzex/runs/<run_id>/submissions/`，先写 pending file，提交后 rename；本地保存失败只产生 warning，不伪造提交状态。
 
+每个已关联 Run/Case/Input 的 Submission 还会生成
+[`defuzex.runtime_evidence.v1`](runtime-evidence.md) 公开 envelope。它使用闭合
+typed component union，只传关联 ID、顺序、路径/大小、结果枚举和 SHA-256，
+不传日志、输出或工具参数正文。Official Judge 通过公开 Judge config 的
+`evidence_types` 协商传输：新服务收到每步 typed EvidenceItem，未广告该 schema
+的旧服务仍收到 `defuzex.run_evidence.v1`。SDK 不从文本、OTel span name 或框架
+事件推断 tool/command/test/state 事实。
+
 ## OpenTelemetry 适配
 
 `otel.py` 通过用户提供的 SDK `TracerProvider.add_span_processor()` 增加一个处理器。它不调用全局 `set_tracer_provider()`，因此可与已有 processor/exporter 和 instrumentation 共存。未安装 `[otel]` 时，核心包不导入 OpenTelemetry，也不改变原有行为。

--- a/docs/runtime-evidence.md
+++ b/docs/runtime-evidence.md
@@ -1,0 +1,117 @@
+# Runtime Evidence v1
+
+`Submission.extensions["runtime_evidence"]` is the canonical, bounded record of
+runtime facts the SDK observed between one `get_input()` and its matching
+`submit()`. Its closed schema is `defuzex.runtime_evidence.v1`; it does not
+change the public Run method signatures.
+
+## Envelope and association
+
+```json
+{
+  "schema_version": "defuzex.runtime_evidence.v1",
+  "run_id": "run-...",
+  "input_id": "step-1",
+  "step_id": "step-1",
+  "submission_id": "submission-...",
+  "components": [
+    {
+      "component_id": "component-0000",
+      "sequence": 0,
+      "kind": "file_change",
+      "path": "src/example.py",
+      "change_type": "modified",
+      "before_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+      "after_sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+      "size_bytes": 120
+    },
+    {
+      "component_id": "component-0001",
+      "sequence": 1,
+      "kind": "agent_response_claim",
+      "claim_id": "submission-response",
+      "claim": "completed",
+      "text_sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+    }
+  ]
+}
+```
+
+The envelope contains exactly those six top-level fields. `run_id`, `input_id`,
+`step_id`, and the stable `submission_id` bind it to one history item. It does
+not contain `case_id`, `step_index`, an association map, or Case-generation
+metadata. The outer Judge request owns `case_id` correlation.
+
+`components` contains 1–100 items. `component_id` and non-negative `sequence`
+are each unique, and sequence is strictly ascending. Serialization uses stable,
+compact JSON. One encoded EvidenceItem is at most 120,000 characters.
+
+## Closed component union
+
+All components contain `component_id`, `sequence`, and `kind`. The remaining
+fields are limited to:
+
+| `kind` | Fields |
+| --- | --- |
+| `file_change` | `path`, `change_type` (`created`, `modified`, `deleted`, `unchanged`), optional `before_sha256`, `after_sha256`, `size_bytes` |
+| `tool_call` | `tool_name`, `outcome` (`succeeded`, `failed`, `unknown`), required `arguments_sha256`, optional `result_sha256` |
+| `command_result` | `command_id`, `exit_code`, optional `stdout_sha256`, `stderr_sha256` |
+| `test_result` | `suite_id`, `outcome` (`passed`, `failed`, `partial`), `passed`, `failed`, `skipped` |
+| `state_transition` | `state_id`, `outcome` (`succeeded`, `failed`, `unknown`), optional `before_sha256`, `after_sha256` |
+| `artifact_snapshot` | `artifact_id`, optional `path`, `sha256`, `size_bytes`, `media_type` |
+| `agent_response_claim` | `claim_id`, `claim` (`completed`, `refused`, `blocked`), `text_sha256` |
+
+The current framework-neutral SDK implementation always emits an
+`agent_response_claim`. File tracking can emit `file_change`. Explicit log files
+and configured in-process OTel capture can emit hash-only `artifact_snapshot`
+items. Renames are represented as one delete and one create because `renamed`
+is not part of the wire union.
+
+The SDK currently has no public instrumentation that proves tool calls,
+commands, tests, or state transitions, so it does not emit or declare those
+kinds. An OTel span is an artifact observation, not proof of a `tool_call`.
+Missing observations remain absent; the Judge decides whether that produces
+`insufficient_evidence` for the Case's private capture requirements.
+
+## Official transport and compatibility
+
+Official Judge revalidates every envelope against its actual Run/Input/step and
+stable Submission identity before upload. It sends one public `EvidenceItem`
+per history item with:
+
+- `source`: `defuzex.runtime_evidence.v1`
+- `media_type`: `application/vnd.defuzex.runtime-evidence+json`
+- `content`: the canonical UTF-8 JSON above
+- `name`: display-only filename
+
+Transport is negotiated through the Backend's public Judge config. The SDK only
+sends typed items when `evidence_types` explicitly contains
+`defuzex.runtime_evidence.v1`. Otherwise it sends the existing
+`defuzex.run_evidence.v1` item, so an older Backend never receives an unknown
+schema.
+
+For Official Case generation, `create_run()` derives `evidence_capabilities`
+from the same configured capture boundaries. It only adds that optional public
+wire field when `GET /sdk/entitlements/` contains
+`protocol.casegen_frameworks = ["defuzex.casegen.ita.v1", ...]`; a missing,
+malformed, or non-matching capability keeps the legacy request shape. Stable
+ordering is `file_change`, `artifact_snapshot`, `agent_response_claim` for kinds
+the Run can actually produce. The SDK never declares framework-only kinds.
+
+## Privacy and resource behavior
+
+The envelope contains hashes instead of Agent output, log bodies, trace bodies,
+stdout/stderr, tool arguments, prompts, or model responses. Paths must be safe,
+root-relative, and pass the existing sensitive-path scanner. Invalid, external,
+or sensitive observations are dropped before serialization and reflected in the
+Submission's existing `missing` and `dropped_count` fields. Component and total
+character limits are enforced while retaining the response claim.
+
+Preparation, `save_local=True` persistence, log offsets, and trace exporter
+state retain the existing transaction boundary: only an accepted Submission
+commits them. Upload validation fails closed on extra fields, bad hashes,
+duplicate IDs/sequences, malformed content, or association mismatch.
+
+Generation packs, IT/Action selection, difficulty, injection data, behavior
+oracles, private evaluation bundles, private rubrics, prompts, model settings,
+and service credentials are outside this SDK contract and must never enter it.

--- a/src/defuzex/_runtime_evidence.py
+++ b/src/defuzex/_runtime_evidence.py
@@ -1,0 +1,303 @@
+"""Build and validate canonical, hash-only Runtime Evidence items."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ._runtime_evidence_contract import (
+    RUNTIME_EVIDENCE_MAX_CHARS,
+    RUNTIME_EVIDENCE_SCHEMA,
+    normalize_sha256,
+    runtime_evidence_json,
+    validate_runtime_evidence,
+)
+from .contracts import FileChange, FileEvidence
+from .privacy import scan_sensitive_path
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeEvidenceLimits:
+    """Internal resource limits bounded by the frozen Core contract."""
+
+    max_components: int = 100
+    max_text_length: int = 1024
+    max_content_chars: int = RUNTIME_EVIDENCE_MAX_CHARS
+
+    def __post_init__(self) -> None:
+        values = (self.max_components, self.max_text_length, self.max_content_chars)
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) for value in values
+        ):
+            raise ValueError("runtime evidence limits must be integers")
+        if not 1 <= self.max_components <= 100 or self.max_text_length <= 0:
+            raise ValueError("runtime evidence item limits are invalid")
+        if not 1024 <= self.max_content_chars <= RUNTIME_EVIDENCE_MAX_CHARS:
+            raise ValueError("runtime evidence character limit is invalid")
+
+
+@dataclass(frozen=True, slots=True)
+class BuiltRuntimeEvidence:
+    evidence: Mapping[str, Any]
+    missing: tuple[str, ...] = ()
+    dropped_count: int = 0
+
+
+def runtime_submission_id(run_id: str, input_id: str) -> str:
+    """Return the stable public Submission identity used for retries/replays."""
+
+    digest = hashlib.sha256(
+        f"defuzex-runtime-submission-v1\0{run_id}\0{input_id}".encode()
+    ).hexdigest()
+    return f"submission-{digest[:32]}"
+
+
+def _sha256(value: Any) -> str:
+    if isinstance(value, str):
+        payload = value.encode("utf-8", "surrogatepass")
+    else:
+        payload = json.dumps(
+            value,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _relative_path(value: Any, root: Path, limit: int) -> str | None:
+    try:
+        relative = Path(value).resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, TypeError, ValueError):
+        return None
+    if (
+        not relative
+        or len(relative) > limit
+        or scan_sensitive_path(relative, location="runtime_evidence_path")
+    ):
+        return None
+    return relative
+
+
+def _file_component(change: FileChange, *, path: str, operation: str) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "kind": "file_change",
+        "path": path,
+        "change_type": operation,
+    }
+    size = change.before_size if operation == "deleted" else change.after_size
+    if size is not None:
+        result["size_bytes"] = size
+    before = normalize_sha256(change.before_hash)
+    after = normalize_sha256(change.after_hash)
+    if before is not None:
+        result["before_sha256"] = before
+    if after is not None:
+        result["after_sha256"] = after
+    return result
+
+
+def _file_components(
+    evidence: FileEvidence | None,
+    root: Path,
+    limits: RuntimeEvidenceLimits,
+) -> tuple[list[dict[str, Any]], int]:
+    if evidence is None:
+        return [], 0
+    result: list[dict[str, Any]] = []
+    dropped = 0
+    ordered = sorted(
+        evidence.changes,
+        key=lambda item: (item.path.casefold(), item.change_type, item.old_path or ""),
+    )
+    for change in ordered:
+        path = _relative_path(change.path, root, limits.max_text_length)
+        if path is None:
+            dropped += 1
+            continue
+        if change.change_type == "renamed":
+            old_path = _relative_path(change.old_path, root, limits.max_text_length)
+            if old_path is None:
+                dropped += 1
+                continue
+            result.append(_file_component(change, path=old_path, operation="deleted"))
+            result.append(_file_component(change, path=path, operation="created"))
+        else:
+            result.append(
+                _file_component(change, path=path, operation=change.change_type)
+            )
+    return result, dropped
+
+
+def _log_components(
+    logs: Sequence[Mapping[str, Any]],
+    root: Path,
+    limits: RuntimeEvidenceLimits,
+) -> tuple[list[dict[str, Any]], int]:
+    result: list[dict[str, Any]] = []
+    dropped = 0
+    for index, segment in enumerate(logs):
+        digest = normalize_sha256(segment.get("sha256"))
+        start, end = segment.get("start_offset"), segment.get("end_offset")
+        if (
+            digest is None
+            or isinstance(start, bool)
+            or not isinstance(start, int)
+            or isinstance(end, bool)
+            or not isinstance(end, int)
+            or not 0 <= start <= end
+        ):
+            dropped += 1
+            continue
+        component: dict[str, Any] = {
+            "kind": "artifact_snapshot",
+            "artifact_id": f"log-segment-{index}",
+            "sha256": digest,
+            "size_bytes": end - start,
+            "media_type": "text/plain",
+        }
+        path = _relative_path(segment.get("path"), root, limits.max_text_length)
+        if path is not None:
+            component["path"] = path
+        result.append(component)
+    return result, dropped
+
+
+def _trace_component(trace_evidence: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    if trace_evidence is None:
+        return None
+    text = runtime_evidence_json(trace_evidence)
+    return {
+        "kind": "artifact_snapshot",
+        "artifact_id": "opentelemetry-trace-evidence",
+        "sha256": hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        "size_bytes": len(text.encode("utf-8")),
+        "media_type": "application/vnd.defuzex.trace-evidence+json",
+    }
+
+
+def _claim_component(status: str, output: Any, error: str | None) -> dict[str, Any]:
+    claim_text = output if output is not None else error or ""
+    return {
+        "kind": "agent_response_claim",
+        "claim_id": "submission-response",
+        "claim": "completed" if status == "completed" else "blocked",
+        "text_sha256": _sha256(claim_text),
+    }
+
+
+def _with_component_ids(
+    components: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "component_id": f"component-{sequence:04d}",
+            "sequence": sequence,
+            **component,
+        }
+        for sequence, component in enumerate(components)
+    ]
+
+
+def _envelope(
+    *,
+    run_id: str,
+    input_id: str,
+    step_id: str,
+    submission_id: str,
+    components: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": RUNTIME_EVIDENCE_SCHEMA,
+        "run_id": run_id,
+        "input_id": input_id,
+        "step_id": step_id,
+        "submission_id": submission_id,
+        "components": _with_component_ids(components),
+    }
+
+
+def _fit_components(
+    components: list[dict[str, Any]],
+    *,
+    identifiers: Mapping[str, str],
+    limits: RuntimeEvidenceLimits,
+) -> tuple[dict[str, Any], int, bool]:
+    dropped = max(0, len(components) - limits.max_components)
+    retained = components[: limits.max_components]
+    if dropped and limits.max_components > 1:
+        retained[-1] = components[-1]
+    elif dropped:
+        retained = [components[-1]]
+    envelope = _envelope(**identifiers, components=retained)
+    char_limited = False
+    while len(runtime_evidence_json(envelope)) > limits.max_content_chars:
+        if len(retained) <= 1:
+            raise ValueError("runtime evidence metadata exceeds the character limit")
+        retained.pop(-2)
+        dropped += 1
+        char_limited = True
+        envelope = _envelope(**identifiers, components=retained)
+    return envelope, dropped, char_limited
+
+
+def build_runtime_evidence(
+    *,
+    run_id: str,
+    input_id: str,
+    step_id: str,
+    submission_id: str,
+    root: Path,
+    status: str,
+    output: Any,
+    error: str | None,
+    file_evidence: FileEvidence | None,
+    logs: Sequence[Mapping[str, Any]],
+    trace_evidence: Mapping[str, Any] | None,
+    limits: RuntimeEvidenceLimits | None = None,
+) -> BuiltRuntimeEvidence:
+    """Build one closed canonical envelope without raw Agent or tool content."""
+
+    active_limits = limits or RuntimeEvidenceLimits()
+    files, file_dropped = _file_components(file_evidence, root, active_limits)
+    artifacts, log_dropped = _log_components(logs, root, active_limits)
+    trace = _trace_component(trace_evidence)
+    components = [*files, *artifacts]
+    if trace is not None:
+        components.append(trace)
+    components.append(_claim_component(status, output, error))
+    identifiers = {
+        "run_id": run_id,
+        "input_id": input_id,
+        "step_id": step_id,
+        "submission_id": submission_id,
+    }
+    envelope, limit_dropped, char_limited = _fit_components(
+        components, identifiers=identifiers, limits=active_limits
+    )
+    validate_runtime_evidence(envelope, **identifiers)
+    missing = []
+    if file_dropped or log_dropped:
+        missing.append("runtime_evidence_observation_filtered")
+    if limit_dropped:
+        missing.append("runtime_evidence_component_limit")
+    if char_limited:
+        missing.append("runtime_evidence_character_limit")
+    return BuiltRuntimeEvidence(
+        evidence=envelope,
+        missing=tuple(missing),
+        dropped_count=file_dropped + log_dropped + limit_dropped,
+    )
+
+
+__all__ = [
+    "BuiltRuntimeEvidence",
+    "RuntimeEvidenceLimits",
+    "build_runtime_evidence",
+    "runtime_submission_id",
+]

--- a/src/defuzex/_runtime_evidence_contract.py
+++ b/src/defuzex/_runtime_evidence_contract.py
@@ -1,0 +1,313 @@
+"""Canonical Runtime Evidence wire constants, serialization, and validation."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+RUNTIME_EVIDENCE_SCHEMA = "defuzex.runtime_evidence.v1"
+RUNTIME_EVIDENCE_MEDIA_TYPE = "application/vnd.defuzex.runtime-evidence+json"
+RUNTIME_EVIDENCE_MAX_CHARS = 120_000
+CASEGEN_FRAMEWORK_SCHEMA = "defuzex.casegen.ita.v1"
+CASEGEN_EVIDENCE_CAPABILITY_ORDER = (
+    "file_change",
+    "tool_call",
+    "command_result",
+    "test_result",
+    "state_transition",
+    "artifact_snapshot",
+    "agent_response_claim",
+)
+_HASH = re.compile(r"[0-9a-f]{64}")
+_KINDS = frozenset(
+    {
+        "file_change",
+        "tool_call",
+        "command_result",
+        "test_result",
+        "state_transition",
+        "artifact_snapshot",
+        "agent_response_claim",
+    }
+)
+_COMMON_FIELDS = frozenset({"component_id", "sequence", "kind"})
+_KIND_FIELDS = {
+    "file_change": frozenset(
+        {"path", "change_type", "before_sha256", "after_sha256", "size_bytes"}
+    ),
+    "tool_call": frozenset(
+        {"tool_name", "outcome", "arguments_sha256", "result_sha256"}
+    ),
+    "command_result": frozenset(
+        {"command_id", "exit_code", "stdout_sha256", "stderr_sha256"}
+    ),
+    "test_result": frozenset({"suite_id", "outcome", "passed", "failed", "skipped"}),
+    "state_transition": frozenset(
+        {"state_id", "outcome", "before_sha256", "after_sha256"}
+    ),
+    "artifact_snapshot": frozenset(
+        {"artifact_id", "path", "sha256", "size_bytes", "media_type"}
+    ),
+    "agent_response_claim": frozenset({"claim_id", "claim", "text_sha256"}),
+}
+_KIND_OPTIONAL_FIELDS = {
+    "file_change": frozenset({"before_sha256", "after_sha256", "size_bytes"}),
+    "tool_call": frozenset({"result_sha256"}),
+    "command_result": frozenset({"stdout_sha256", "stderr_sha256"}),
+    "test_result": frozenset(),
+    "state_transition": frozenset({"before_sha256", "after_sha256"}),
+    "artifact_snapshot": frozenset({"path"}),
+    "agent_response_claim": frozenset(),
+}
+
+
+def runtime_evidence_json(value: Mapping[str, Any]) -> str:
+    """Serialize one canonical envelope as bounded UTF-8 JSON text."""
+
+    return json.dumps(
+        _json_value(value),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _json_value(child) for key, child in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_json_value(child) for child in value]
+    return value
+
+
+def normalize_sha256(value: Any) -> str | None:
+    """Return one lowercase 64-hex digest, accepting the SDK's local prefix."""
+
+    if not isinstance(value, str):
+        return None
+    candidate = value.removeprefix("sha256:").casefold()
+    return candidate if _HASH.fullmatch(candidate) else None
+
+
+def derive_casegen_evidence_capabilities(
+    *, track_files: bool, trace_evidence_configured: bool
+) -> tuple[str, ...]:
+    """Declare only canonical component kinds this Run configuration can emit."""
+
+    declared = set()
+    if track_files:
+        declared.add("file_change")
+    if trace_evidence_configured:
+        declared.add("artifact_snapshot")
+    if declared:
+        declared.add("agent_response_claim")
+    return tuple(item for item in CASEGEN_EVIDENCE_CAPABILITY_ORDER if item in declared)
+
+
+def casegen_framework_is_advertised(entitlements: Mapping[str, Any]) -> bool:
+    """Return whether entitlements explicitly advertise the IT+A public bridge."""
+
+    protocol = entitlements.get("protocol")
+    if not isinstance(protocol, Mapping):
+        return False
+    frameworks = protocol.get("casegen_frameworks")
+    return (
+        isinstance(frameworks, list)
+        and all(isinstance(item, str) for item in frameworks)
+        and CASEGEN_FRAMEWORK_SCHEMA in frameworks
+    )
+
+
+def _text(value: Any, maximum: int) -> bool:
+    return isinstance(value, str) and 1 <= len(value) <= maximum
+
+
+def _optional_hash(component: Mapping[str, Any], name: str) -> bool:
+    return name not in component or normalize_sha256(component[name]) == component[name]
+
+
+def _required_hash(component: Mapping[str, Any], name: str) -> bool:
+    value = component.get(name)
+    return isinstance(value, str) and normalize_sha256(value) == value
+
+
+def _relative_wire_path(value: Any) -> bool:
+    if not _text(value, 1024):
+        return False
+    normalized = value.replace("\\", "/")
+    return not (
+        normalized.startswith("/")
+        or re.match(r"^[a-zA-Z]:/", normalized)
+        or ".." in normalized.split("/")
+    )
+
+
+def _non_negative(value: Any) -> bool:
+    return not isinstance(value, bool) and isinstance(value, int) and value >= 0
+
+
+def _valid_component_fields(component: Mapping[str, Any]) -> bool:
+    kind = component.get("kind")
+    if kind not in _KINDS:
+        return False
+    allowed = _COMMON_FIELDS | _KIND_FIELDS[kind]
+    required = allowed - _KIND_OPTIONAL_FIELDS[kind]
+    return required <= set(component) <= allowed
+
+
+def _valid_component_value(component: Mapping[str, Any]) -> bool:
+    kind = component["kind"]
+    if kind == "file_change":
+        return (
+            _relative_wire_path(component["path"])
+            and component["change_type"]
+            in {"created", "modified", "deleted", "unchanged"}
+            and _optional_hash(component, "before_sha256")
+            and _optional_hash(component, "after_sha256")
+            and (
+                "size_bytes" not in component or _non_negative(component["size_bytes"])
+            )
+        )
+    if kind == "tool_call":
+        return (
+            _text(component["tool_name"], 128)
+            and component["outcome"] in {"succeeded", "failed", "unknown"}
+            and _required_hash(component, "arguments_sha256")
+            and _optional_hash(component, "result_sha256")
+        )
+    if kind == "command_result":
+        return (
+            _text(component["command_id"], 128)
+            and isinstance(component["exit_code"], int)
+            and not isinstance(component["exit_code"], bool)
+            and _optional_hash(component, "stdout_sha256")
+            and _optional_hash(component, "stderr_sha256")
+        )
+    if kind == "test_result":
+        return (
+            _text(component["suite_id"], 128)
+            and component["outcome"] in {"passed", "failed", "partial"}
+            and all(
+                _non_negative(component[name])
+                for name in ("passed", "failed", "skipped")
+            )
+        )
+    if kind == "state_transition":
+        return (
+            _text(component["state_id"], 128)
+            and component["outcome"] in {"succeeded", "failed", "unknown"}
+            and _optional_hash(component, "before_sha256")
+            and _optional_hash(component, "after_sha256")
+        )
+    if kind == "artifact_snapshot":
+        return (
+            _text(component["artifact_id"], 128)
+            and ("path" not in component or _relative_wire_path(component["path"]))
+            and normalize_sha256(component["sha256"]) == component["sha256"]
+            and _non_negative(component["size_bytes"])
+            and _text(component["media_type"], 128)
+        )
+    return (
+        _text(component["claim_id"], 128)
+        and component["claim"] in {"completed", "refused", "blocked"}
+        and normalize_sha256(component["text_sha256"]) == component["text_sha256"]
+    )
+
+
+def _validate_association(
+    value: Mapping[str, Any],
+    *,
+    run_id: str,
+    input_id: str,
+    step_id: str,
+    submission_id: str,
+) -> None:
+    actual = (
+        value["run_id"],
+        value["input_id"],
+        value["step_id"],
+        value["submission_id"],
+    )
+    if (
+        value["schema_version"] != RUNTIME_EVIDENCE_SCHEMA
+        or actual != (run_id, input_id, step_id, submission_id)
+        or not _text(value["run_id"], 128)
+        or not _text(value["input_id"], 128)
+        or not _text(value["step_id"], 80)
+        or not _text(value["submission_id"], 128)
+    ):
+        raise ValueError("runtime evidence association is invalid")
+
+
+def _validate_components(components: Any) -> None:
+    if (
+        not isinstance(components, Sequence)
+        or isinstance(components, str | bytes | bytearray)
+        or not 1 <= len(components) <= 100
+    ):
+        raise ValueError("runtime evidence components are invalid")
+    component_ids: set[str] = set()
+    previous_sequence = -1
+    for component in components:
+        if not isinstance(component, Mapping) or not _valid_component_fields(component):
+            raise ValueError("runtime evidence component is invalid")
+        component_id, sequence = component["component_id"], component["sequence"]
+        if (
+            not _text(component_id, 128)
+            or component_id in component_ids
+            or not _non_negative(sequence)
+            or sequence <= previous_sequence
+            or not _valid_component_value(component)
+        ):
+            raise ValueError("runtime evidence component is invalid")
+        component_ids.add(component_id)
+        previous_sequence = sequence
+
+
+def validate_runtime_evidence(
+    value: Any,
+    *,
+    run_id: str,
+    input_id: str,
+    step_id: str,
+    submission_id: str,
+) -> None:
+    """Fail closed on malformed, duplicate, or mis-associated public evidence."""
+
+    fields = {
+        "schema_version",
+        "run_id",
+        "input_id",
+        "step_id",
+        "submission_id",
+        "components",
+    }
+    if not isinstance(value, Mapping) or set(value) != fields:
+        raise ValueError("runtime evidence envelope is invalid")
+    _validate_association(
+        value,
+        run_id=run_id,
+        input_id=input_id,
+        step_id=step_id,
+        submission_id=submission_id,
+    )
+    _validate_components(value["components"])
+    if len(runtime_evidence_json(value)) > RUNTIME_EVIDENCE_MAX_CHARS:
+        raise ValueError("runtime evidence exceeds the character limit")
+
+
+__all__ = [
+    "CASEGEN_EVIDENCE_CAPABILITY_ORDER",
+    "CASEGEN_FRAMEWORK_SCHEMA",
+    "RUNTIME_EVIDENCE_MAX_CHARS",
+    "RUNTIME_EVIDENCE_MEDIA_TYPE",
+    "RUNTIME_EVIDENCE_SCHEMA",
+    "casegen_framework_is_advertised",
+    "derive_casegen_evidence_capabilities",
+    "normalize_sha256",
+    "runtime_evidence_json",
+    "validate_runtime_evidence",
+]

--- a/src/defuzex/api.py
+++ b/src/defuzex/api.py
@@ -7,6 +7,10 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from ._runtime_evidence_contract import (
+    casegen_framework_is_advertised,
+    derive_casegen_evidence_capabilities,
+)
 from .backend import DEFAULT_BASE_URL, BackendClient
 from .config import CreateRunConfig, resolve_create_run_config, write_api_key
 from .contracts import Case
@@ -46,6 +50,7 @@ def _adapted_providers(
     judge_provider: Any,
     api_key: str | None,
     repo_path: Path,
+    trace_evidence: TraceEvidenceCapture | None,
 ) -> tuple[CaseProvider, JudgeProvider | None, bool, bool]:
     official_case = case_provider is None
     official_judge = config.judge and judge_provider is None
@@ -60,15 +65,27 @@ def _adapted_providers(
             timeout=config.timeout,
             max_retries=config.max_retries,
         )
-    adapted_case = (
-        OfficialCaseProvider(
+    evidence_capabilities = derive_casegen_evidence_capabilities(
+        track_files=config.track_files,
+        trace_evidence_configured=trace_evidence is not None,
+    )
+    can_negotiate = bool(official_case and official_judge and evidence_capabilities)
+    if can_negotiate and backend is not None:
+        can_negotiate = casegen_framework_is_advertised(
+            backend.json("GET", "/sdk/entitlements/")
+        )
+    if not can_negotiate:
+        evidence_capabilities = ()
+    if official_case and backend is not None:
+        official_case_provider = OfficialCaseProvider(
             backend,
             allow_sensitive=config.allow_sensitive,
             operation_wait_timeout=config.operation_wait_timeout,
         )
-        if official_case and backend is not None
-        else adapt_case_provider(case_provider)
-    )
+        official_case_provider._configure_evidence_capabilities(evidence_capabilities)
+        adapted_case: CaseProvider = official_case_provider
+    else:
+        adapted_case = adapt_case_provider(case_provider)
     if not config.judge:
         adapted_judge = None
     elif official_judge and backend is not None:
@@ -382,6 +399,7 @@ def create_run(
         judge_provider=judge_provider,
         api_key=api_key,
         repo_path=resolved_repo,
+        trace_evidence=trace_evidence,
     )
     requirement_required = bool(
         getattr(adapted_case_provider, "requirement_required", True)

--- a/src/defuzex/providers/_official_evidence_upload.py
+++ b/src/defuzex/providers/_official_evidence_upload.py
@@ -1,0 +1,219 @@
+"""Validate and serialize legacy or canonical Official Judge Evidence uploads."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .._runtime_evidence import runtime_submission_id
+from .._runtime_evidence_contract import (
+    RUNTIME_EVIDENCE_MEDIA_TYPE,
+    RUNTIME_EVIDENCE_SCHEMA,
+    runtime_evidence_json,
+    validate_runtime_evidence,
+)
+from ..backend import UploadPart
+from ..errors import LimitExceededError, ProviderError
+from ..privacy import scan_sensitive_json
+from ._evidence_projection import project_run_evidence
+from ._official_wire import history_evidence, plain_json
+from .base import JudgeContext
+
+_MAX_BATCH_ITEMS = 20
+
+
+@dataclass(frozen=True, slots=True)
+class JudgeUploadConfig:
+    max_files: int
+    max_file_bytes: int
+    max_total_bytes: int
+    manifest_schema_version: str
+    max_batch_items: int
+    evidence_types: frozenset[str]
+
+
+def judge_upload_config(response: Mapping[str, Any]) -> JudgeUploadConfig:
+    """Validate the public Backend's dynamic Judge upload contract."""
+
+    max_files = response.get("max_files")
+    max_file_bytes = response.get("max_file_bytes")
+    max_total_bytes = response.get("max_total_bytes")
+    allowed = response.get("allowed_extensions")
+    manifest_schema_version = response.get("manifest_schema_version")
+    evidence_types = response.get("evidence_types")
+    max_batch_items = response.get("max_batch_items", _MAX_BATCH_ITEMS)
+    if (
+        isinstance(max_files, bool)
+        or not isinstance(max_files, int)
+        or max_files < 1
+        or isinstance(max_file_bytes, bool)
+        or not isinstance(max_file_bytes, int)
+        or max_file_bytes <= 0
+        or isinstance(max_total_bytes, bool)
+        or not isinstance(max_total_bytes, int)
+        or max_total_bytes <= 0
+        or not isinstance(allowed, list)
+        or ".json" not in allowed
+        or not isinstance(manifest_schema_version, str)
+        or not manifest_schema_version
+        or not isinstance(evidence_types, list)
+        or "raw_log" not in evidence_types
+        or isinstance(max_batch_items, bool)
+        or not isinstance(max_batch_items, int)
+        or max_batch_items < 1
+    ):
+        raise ProviderError(
+            "The Backend returned invalid Judge upload configuration",
+            code="invalid_response",
+        )
+    return JudgeUploadConfig(
+        max_files=max_files,
+        max_file_bytes=max_file_bytes,
+        max_total_bytes=max_total_bytes,
+        manifest_schema_version=manifest_schema_version,
+        max_batch_items=max_batch_items,
+        evidence_types=frozenset(evidence_types),
+    )
+
+
+def _runtime_evidence_part(
+    item: Any, *, index: int, max_file_bytes: int, part_prefix: str
+) -> tuple[UploadPart, dict[str, Any], list[Any]] | None:
+    value = item.submission.extensions.get("runtime_evidence")
+    if value is None:
+        return None
+    submission_id = runtime_submission_id(
+        item.submission.run_id, item.submission.input_id
+    )
+    try:
+        validate_runtime_evidence(
+            value,
+            run_id=item.submission.run_id,
+            input_id=item.submission.input_id,
+            step_id=item.test_input.input_id,
+            submission_id=submission_id,
+        )
+    except ValueError as exc:
+        raise ProviderError(
+            "Runtime Evidence is invalid", code="runtime_evidence_invalid"
+        ) from exc
+    encoded = runtime_evidence_json(value).encode()
+    if len(encoded) > max_file_bytes:
+        raise LimitExceededError(
+            "Runtime Evidence exceeds the Judge upload limit",
+            code="log_size_exceeded",
+        )
+    filename = f"defuzex-runtime-evidence-{index:04d}.json"
+    return (
+        UploadPart(
+            name=f"{part_prefix}runtime-{index}" if part_prefix else "logs",
+            filename=filename,
+            content_type=RUNTIME_EVIDENCE_MEDIA_TYPE,
+            data=encoded,
+        ),
+        {
+            "name": filename,
+            "sha256": hashlib.sha256(encoded).hexdigest(),
+            "evidence_type": RUNTIME_EVIDENCE_SCHEMA,
+        },
+        scan_sensitive_json(value, location="runtime_evidence"),
+    )
+
+
+def _runtime_evidence_parts(
+    context: JudgeContext, config: JudgeUploadConfig, part_prefix: str
+) -> tuple[list[UploadPart], list[dict[str, Any]], list[Any]]:
+    if RUNTIME_EVIDENCE_SCHEMA not in config.evidence_types:
+        return [], [], []
+    parts: list[UploadPart] = []
+    manifest: list[dict[str, Any]] = []
+    findings: list[Any] = []
+    for index, item in enumerate(context.history):
+        built = _runtime_evidence_part(
+            item,
+            index=index,
+            max_file_bytes=config.max_file_bytes,
+            part_prefix=part_prefix,
+        )
+        if built is None:
+            continue
+        part, entry, item_findings = built
+        parts.append(part)
+        manifest.append(entry)
+        findings.extend(item_findings)
+    return parts, manifest, findings
+
+
+def _typed_upload(
+    parts: list[UploadPart],
+    manifest: list[dict[str, Any]],
+    findings: list[Any],
+    config: JudgeUploadConfig,
+) -> tuple[tuple[UploadPart, ...], dict[str, Any], list[Any]]:
+    if len(parts) > config.max_files:
+        raise LimitExceededError(
+            "Runtime Evidence exceeds the Judge file-count limit",
+            code="log_size_exceeded",
+        )
+    if sum(len(part.data) for part in parts) > config.max_total_bytes:
+        raise LimitExceededError(
+            "Runtime Evidence exceeds the Judge upload limit",
+            code="log_size_exceeded",
+        )
+    return (
+        tuple(parts),
+        {"schema_version": config.manifest_schema_version, "files": manifest},
+        findings,
+    )
+
+
+def _legacy_upload(
+    context: JudgeContext, config: JudgeUploadConfig, part_prefix: str
+) -> tuple[tuple[UploadPart, ...], dict[str, Any], list[Any]]:
+    evidence = {
+        "schema_version": "defuzex.run_evidence.v1",
+        "run_status": context.run_status,
+        "history": history_evidence(context),
+        "summary": plain_json(context.evidence_summary),
+    }
+    findings = list(scan_sensitive_json(evidence, location="judge_evidence"))
+    evidence, evidence_bytes = project_run_evidence(
+        evidence,
+        max_utf8_bytes=min(config.max_file_bytes, config.max_total_bytes),
+    )
+    filename = "defuzex-run-evidence.json"
+    part = UploadPart(
+        name=f"{part_prefix}log" if part_prefix else "logs",
+        filename=filename,
+        content_type="application/json",
+        data=evidence_bytes,
+    )
+    manifest = {
+        "schema_version": config.manifest_schema_version,
+        "files": [
+            {
+                "name": filename,
+                "sha256": hashlib.sha256(evidence_bytes).hexdigest(),
+                "evidence_type": "raw_log",
+            }
+        ],
+    }
+    return ((part,), manifest, findings)
+
+
+def evidence_upload(
+    context: JudgeContext, config: JudgeUploadConfig, part_prefix: str
+) -> tuple[tuple[UploadPart, ...], dict[str, Any], list[Any]]:
+    """Build typed evidence when negotiated, otherwise the legacy run item."""
+
+    runtime_parts, runtime_manifest, findings = _runtime_evidence_parts(
+        context, config, part_prefix
+    )
+    if runtime_parts:
+        return _typed_upload(runtime_parts, runtime_manifest, findings, config)
+    return _legacy_upload(context, config, part_prefix)
+
+
+__all__ = ["JudgeUploadConfig", "evidence_upload", "judge_upload_config"]

--- a/src/defuzex/providers/official_case.py
+++ b/src/defuzex/providers/official_case.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Mapping
 from typing import Any
 
+from .._runtime_evidence_contract import CASEGEN_EVIDENCE_CAPABILITY_ORDER
 from ..backend import BackendClient, new_idempotency_key
 from ..errors import (
     ConfigurationError,
@@ -236,7 +237,10 @@ def _behavior_spec(context: CaseGenerationContext) -> dict[str, str]:
 
 
 def _safe_case_payload(
-    context: CaseGenerationContext, *, allow_sensitive: bool
+    context: CaseGenerationContext,
+    *,
+    allow_sensitive: bool,
+    evidence_capabilities: tuple[str, ...],
 ) -> tuple[dict[str, Any], str]:
     if context.input_type != "text":
         raise ConfigurationError(
@@ -255,6 +259,8 @@ def _safe_case_payload(
         "count": 1,
         **safe_fields,
     }
+    if evidence_capabilities:
+        payload["evidence_capabilities"] = list(evidence_capabilities)
     return payload, repo_meta["repo_fingerprint"]
 
 
@@ -320,6 +326,22 @@ class OfficialCaseProvider:
         self.client = client
         self.allow_sensitive = allow_sensitive
         self.operation_wait_timeout = operation_wait_timeout
+        self._evidence_capabilities: tuple[str, ...] = ()
+
+    def _configure_evidence_capabilities(self, values: tuple[str, ...]) -> None:
+        declared = set(values)
+        ordered = tuple(
+            item for item in CASEGEN_EVIDENCE_CAPABILITY_ORDER if item in declared
+        )
+        observable = {"file_change", "artifact_snapshot"}
+        if (
+            ordered != values
+            or declared - observable - {"agent_response_claim"}
+            or (declared and "agent_response_claim" not in declared)
+            or (declared and not observable.intersection(declared))
+        ):
+            raise ConfigurationError("Runtime Evidence capabilities are invalid")
+        self._evidence_capabilities = values
 
     def generate_case(self, context: CaseGenerationContext) -> Mapping[str, Any]:
         """Return a public Case shape after strategy and integrity validation."""
@@ -327,6 +349,7 @@ class OfficialCaseProvider:
         payload, repo_fingerprint = _safe_case_payload(
             context,
             allow_sensitive=self.allow_sensitive,
+            evidence_capabilities=self._evidence_capabilities,
         )
         response = self._run_operation(context, payload)
         return _normalized_case(

--- a/src/defuzex/providers/official_judge.py
+++ b/src/defuzex/providers/official_judge.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import threading
 from collections.abc import Mapping, Sequence
@@ -14,11 +13,12 @@ from ..backend import BackendClient, UploadPart, mapped_error, new_idempotency_k
 from ..contracts import JudgeBatchResult
 from ..errors import ConfigurationError, LimitExceededError, ProviderError
 from ..operations import PendingOperationStore, await_operation
-from ..privacy import enforce_sensitive_policy, scan_sensitive_json, scan_sensitive_text
-from ._evidence_projection import project_run_evidence
+from ..privacy import enforce_sensitive_policy, scan_sensitive_text
+from ._official_evidence_upload import JudgeUploadConfig as _JudgeConfig
+from ._official_evidence_upload import evidence_upload as _evidence_upload
+from ._official_evidence_upload import judge_upload_config as _judge_config
 from ._official_judgment import normalize_official_judgment as _normalize_judgment
 from ._official_wire import (
-    history_evidence,
     plain_json,
     required_text,
     validate_official_case_provenance,
@@ -26,17 +26,7 @@ from ._official_wire import (
 from .base import JudgeContext
 from .normalization import normalize_report
 
-_MAX_BATCH_ITEMS = 20
 _MAX_TRACKED_RUNS = 1024
-
-
-@dataclass(frozen=True, slots=True)
-class _JudgeConfig:
-    max_files: int
-    max_file_bytes: int
-    max_total_bytes: int
-    manifest_schema_version: str
-    max_batch_items: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,85 +37,6 @@ class _JudgeUpload:
     case_part: UploadPart | None
     log_parts: tuple[UploadPart, ...]
     idempotency_key: str
-
-
-def _judge_config(response: Mapping[str, Any]) -> _JudgeConfig:
-    max_files = response.get("max_files")
-    max_file_bytes = response.get("max_file_bytes")
-    max_total_bytes = response.get("max_total_bytes")
-    allowed = response.get("allowed_extensions")
-    manifest_schema_version = response.get("manifest_schema_version")
-    evidence_types = response.get("evidence_types")
-    max_batch_items = response.get("max_batch_items", _MAX_BATCH_ITEMS)
-    if (
-        isinstance(max_files, bool)
-        or not isinstance(max_files, int)
-        or max_files < 1
-        or isinstance(max_file_bytes, bool)
-        or not isinstance(max_file_bytes, int)
-        or max_file_bytes <= 0
-        or isinstance(max_total_bytes, bool)
-        or not isinstance(max_total_bytes, int)
-        or max_total_bytes <= 0
-        or not isinstance(allowed, list)
-        or ".json" not in allowed
-        or not isinstance(manifest_schema_version, str)
-        or not manifest_schema_version
-        or not isinstance(evidence_types, list)
-        or "raw_log" not in evidence_types
-        or isinstance(max_batch_items, bool)
-        or not isinstance(max_batch_items, int)
-        or max_batch_items < 1
-    ):
-        raise ProviderError(
-            "The Backend returned invalid Judge upload configuration",
-            code="invalid_response",
-        )
-    return _JudgeConfig(
-        max_files=max_files,
-        max_file_bytes=max_file_bytes,
-        max_total_bytes=max_total_bytes,
-        manifest_schema_version=manifest_schema_version,
-        max_batch_items=max_batch_items,
-    )
-
-
-def _evidence_upload(
-    context: JudgeContext, config: _JudgeConfig, part_prefix: str
-) -> tuple[UploadPart, dict[str, Any], list[Any]]:
-    evidence = {
-        "schema_version": "defuzex.run_evidence.v1",
-        "run_status": context.run_status,
-        "history": history_evidence(context),
-        "summary": plain_json(context.evidence_summary),
-    }
-    findings = list(scan_sensitive_json(evidence, location="judge_evidence"))
-    evidence, evidence_bytes = project_run_evidence(
-        evidence,
-        max_utf8_bytes=min(config.max_file_bytes, config.max_total_bytes),
-    )
-    filename = "defuzex-run-evidence.json"
-    part = UploadPart(
-        name=f"{part_prefix}log" if part_prefix else "logs",
-        filename=filename,
-        content_type="application/json",
-        data=evidence_bytes,
-    )
-    manifest = {
-        "schema_version": config.manifest_schema_version,
-        "files": [
-            {
-                "name": filename,
-                "sha256": hashlib.sha256(evidence_bytes).hexdigest(),
-                "evidence_type": "raw_log",
-            }
-        ],
-    }
-    return (
-        part,
-        manifest,
-        findings,
-    )
 
 
 def _custom_case_part(
@@ -329,7 +240,7 @@ class OfficialJudgeProvider:
         idempotency_key: str | None = None,
     ) -> _JudgeUpload:
         run_id = self._run_id(context)
-        log_part, manifest, findings = _evidence_upload(context, config, part_prefix)
+        log_parts, manifest, findings = _evidence_upload(context, config, part_prefix)
         metadata: dict[str, Any] = {
             "status": self._submission_status(context),
             "force": False,
@@ -351,7 +262,7 @@ class OfficialJudgeProvider:
             metadata=metadata,
             case_id=case_id,
             case_part=case_part,
-            log_parts=(log_part,),
+            log_parts=log_parts,
             idempotency_key=idempotency_key or self._idempotency_key(run_id),
         )
 

--- a/src/defuzex/tracking/evidence.py
+++ b/src/defuzex/tracking/evidence.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any
 
+from .._runtime_evidence import build_runtime_evidence, runtime_submission_id
 from ..contracts import (
     CaptureComponent,
     CaptureStatus,
@@ -230,8 +231,27 @@ class EvidenceCollector:
             "allow_sensitive": self.allow_sensitive,
             "sensitive_detected": bool(findings),
         }
+        trace_evidence = None
         if prepared_traces is not None and prepared_traces.evidence is not None:
-            extensions["trace_evidence"] = prepared_traces.evidence
+            trace_evidence = prepared_traces.evidence
+            extensions["trace_evidence"] = trace_evidence
+        if self.run_id and self.case_id:
+            built = build_runtime_evidence(
+                run_id=self.run_id,
+                input_id=input_id,
+                step_id=input_id,
+                submission_id=runtime_submission_id(self.run_id, input_id),
+                root=self.root,
+                status=status,
+                output=output,
+                error=error,
+                file_evidence=prepared_files.evidence,
+                logs=prepared_logs.segments,
+                trace_evidence=trace_evidence,
+            )
+            extensions["runtime_evidence"] = built.evidence
+            missing.extend(built.missing)
+            dropped_count += built.dropped_count
         record = {
             "input_id": input_id,
             "status": status,


### PR DESCRIPTION
## Summary
- add the closed `defuzex.runtime_evidence.v1` envelope and exact typed-component validation
- negotiate machine-derived Case evidence capabilities only with compatible public services
- upload typed Runtime Evidence through the existing Official Judge boundary, with legacy fallback
- document ordering, limits, privacy, and framework-neutral capture semantics

## Validation
- Ruff format/check
- canonical private SDK suite against this public source: 189 passed, 1 skipped
- compileall and credential-free minimal local flow
- wheel/sdist build and twine check
- clean wheel install/import/version smoke
- detect-secrets: 0 findings

No private tests, acceptance assets, internal services, credentials, or private evaluation data are included.