### PR TITLE
docs: centralize KUMA SDK documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to DefuzeX Python SDK
+# Contributing to KUMA Python SDK
 
 Thank you for helping improve the public SDK. Keep changes within the client's
 responsibilities: public protocol models, transport behavior, Run lifecycle,

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">KUMA</h1>
 
 <p align="center">
-  <strong>DefuzeX Python SDK</strong><br>
+  <strong>KUMA Python SDK</strong><br>
   Knowledge-grounded Universal Measurement for Agents
 </p>
 
@@ -13,22 +13,11 @@
   <a href="README.md">English</a> &nbsp;|&nbsp; <a href="README.zh-CN.md">简体中文</a>
 </p>
 
-<p align="center">
-  <img src="https://img.shields.io/badge/Python-3.10--3.14-3776AB?logo=python&amp;logoColor=white" alt="Python 3.10 to 3.14">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-4C8CBF" alt="Apache 2.0 license"></a>
-</p>
-
-DefuzeX is the public Python SDK for running evidence-bounded Agent behavior tests with local or official Case and Judge providers.
-
-## Why DefuzeX
-
-- **A strict, framework-neutral protocol:** connect an existing Agent through the synchronous `get_input()` → Agent → `submit()` lifecycle.
-- **Useful evidence with explicit boundaries:** capture file metadata, selected logs, and optional in-process OpenTelemetry spans with bounded, privacy-aware defaults.
-- **Local first, hosted when needed:** start without an account or network, then use official Case and Judge services through the public HTTPS API.
+KUMA is the public Python SDK for testing Agent behavior through a strict `Run` protocol and bounded Evidence capture. It owns the client boundary only: it does not run Agents, execute models, or expose private evaluation logic.
 
 ## Install
 
-Python 3.10 or newer is required. Install the current source checkout:
+Python 3.10 or newer is required:
 
 ```bash
 git clone https://github.com/DefuzeX-AI/KUMA-DefuzeX.git
@@ -36,41 +25,24 @@ cd KUMA-DefuzeX
 python -m pip install .
 ```
 
-For virtual environments, optional OpenTelemetry support, and contributor setup, see the [SDK guide](docs/sdk-guide.md#installation).
+## Quick start
 
-## Minimal runnable example
-
-Run the deterministic local check—no account, API key, Docker, or network required:
+Run the deterministic local check without an account, API key, Docker, or network:
 
 ```bash
 defuzex quickstart
 ```
 
-Expected result:
-
-```text
-Local check: PASS
-Score: 100/100
-Reason: Output exactly matched the published rule.
-Artifact: <temporary directory>/result.json
-```
-
-For a complete local `Run`, execute [`examples/minimal_local.py`](examples/minimal_local.py):
-
-```bash
-python examples/minimal_local.py
-```
-
 ## Core capabilities
 
-- Synchronous, single-Case [`Run` lifecycle](docs/sdk-guide.md#run-lifecycle-and-providers) with immutable inputs, submissions, history, and reports.
-- Official or custom [Case and Judge providers](docs/sdk-guide.md#run-lifecycle-and-providers), including fully local operation.
-- Bounded [Evidence capture](docs/sdk-guide.md#evidence-and-opentelemetry) for file changes, explicit logs, and capture gaps.
-- Optional [OpenTelemetry trace evidence](docs/sdk-guide.md#evidence-and-opentelemetry) without replacing the application's tracer provider.
-- Public HTTPS-only service boundary; the SDK does not host Agents, models, databases, or private evaluation assets. See [architecture](docs/architecture.md) and the [public API contract](docs/api-contract.md).
+- Synchronous, framework-neutral Case and Judge workflow.
+- Official or custom Providers, including fully local runs.
+- Bounded file, log, and optional in-process trace Evidence.
 
-## Support and project links
+## Detailed documentation
 
-- [SDK guide](docs/sdk-guide.md) · [Single Agent template](examples/single_agent_template/README.md) · [Docker user flow](examples/full_stack/USER_GUIDE.md)
-- [GitHub Issues](https://github.com/DefuzeX-AI/KUMA-DefuzeX/issues) · [Security policy](SECURITY.md)
-- [Contributing](CONTRIBUTING.md) · [Apache License 2.0](LICENSE)
+[English SDK guide](docs/sdk-guide.md) · [简体中文 SDK 指南](docs/sdk-guide.zh-CN.md)
+
+## Project
+
+[Security](SECURITY.md) · [Contributing](CONTRIBUTING.md) · [Apache License 2.0](LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,7 +5,7 @@
 <h1 align="center">KUMA</h1>
 
 <p align="center">
-  <strong>DefuzeX Python SDK</strong><br>
+  <strong>KUMA Python SDK</strong><br>
   面向 Agent 的知识与证据驱动通用评测
 </p>
 
@@ -13,22 +13,11 @@
   <a href="README.md">English</a> &nbsp;|&nbsp; <a href="README.zh-CN.md">简体中文</a>
 </p>
 
-<p align="center">
-  <img src="https://img.shields.io/badge/Python-3.10--3.14-3776AB?logo=python&amp;logoColor=white" alt="支持 Python 3.10 至 3.14">
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-Apache--2.0-4C8CBF" alt="Apache 2.0 许可证"></a>
-</p>
-
-DefuzeX 是公开 Python SDK，用于通过本地或官方 Case、Judge Provider 对 Agent 行为进行有边界 Evidence 的测试。
-
-## 为什么使用 DefuzeX
-
-- **严格且不绑定框架的协议：**通过同步 `get_input()` → Agent → `submit()` 生命周期接入现有 Agent。
-- **边界明确的有效 Evidence：**按有界、隐私友好的默认策略采集文件元数据、指定日志和可选的同进程 OpenTelemetry spans。
-- **本地起步，按需接入服务：**无需账号或网络即可首次运行，需要时再通过公开 HTTPS API 使用官方 Case 与 Judge。
+KUMA 是公开 Python SDK，通过严格的 `Run` 协议和有界 Evidence 采集测试 Agent 行为。它只负责客户端边界，不运行 Agent、不执行模型，也不暴露私有评估逻辑。
 
 ## 安装
 
-需要 Python 3.10 或更高版本。安装当前源码：
+需要 Python 3.10 或更高版本：
 
 ```bash
 git clone https://github.com/DefuzeX-AI/KUMA-DefuzeX.git
@@ -36,41 +25,24 @@ cd KUMA-DefuzeX
 python -m pip install .
 ```
 
-虚拟环境、可选 OpenTelemetry 能力和贡献者环境见[中文接入指南](examples/full_stack/USER_GUIDE.md#1-从-github-安装)。
+## 快速开始
 
-## 最小可运行示例
-
-运行确定性的本地检查；无需账号、API Key、Docker 或网络：
+无需账号、API Key、Docker 或网络即可运行确定性的本地检查：
 
 ```bash
 defuzex quickstart
 ```
 
-预期结果：
-
-```text
-Local check: PASS
-Score: 100/100
-Reason: Output exactly matched the published rule.
-Artifact: <temporary directory>/result.json
-```
-
-如需运行完整的本地 `Run`，执行 [`examples/minimal_local.py`](examples/minimal_local.py)：
-
-```bash
-python examples/minimal_local.py
-```
-
 ## 核心能力
 
-- 同步、单 Case 的 [`Run` 生命周期](docs/architecture.md#run-状态机)，包含不可变的 Input、Submission、History 和 Report。
-- 支持官方或自定义 [Case 与 Judge Provider](docs/architecture.md#provider)，也可完全本地运行。
-- 有界 [Evidence 采集](docs/architecture.md#trackingevidence-与隐私)，覆盖文件变化、指定日志和采集缺口。
-- 可选的 [OpenTelemetry Trace Evidence](docs/architecture.md#opentelemetry-适配)，不替换应用已有的 Tracer Provider。
-- 仅访问公开 HTTPS 服务；SDK 不托管 Agent、模型、数据库或私有评估资产。参见[架构](docs/architecture.md)和[公开 API Contract](docs/api-contract.md)。
+- 同步且不绑定框架的 Case 与 Judge 流程。
+- 支持官方或自定义 Provider，也可完全本地运行。
+- 有界采集文件、日志和可选的同进程 Trace Evidence。
 
-## 支持与项目链接
+## 详细文档
 
-- [中文接入指南](examples/full_stack/USER_GUIDE.md) · [Single Agent 模板](examples/single_agent_template/README.md) · [英文 SDK 指南](docs/sdk-guide.md)
-- [GitHub Issues](https://github.com/DefuzeX-AI/KUMA-DefuzeX/issues) · [安全策略](SECURITY.md)
-- [贡献说明](CONTRIBUTING.md) · [Apache License 2.0](LICENSE)
+[简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [English SDK guide](docs/sdk-guide.md)
+
+## 项目链接
+
+[安全策略](SECURITY.md) · [贡献说明](CONTRIBUTING.md) · [Apache License 2.0](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported versions
 
-Security fixes are provided for the latest released version of the DefuzeX
+Security fixes are provided for the latest released version of the KUMA
 Python SDK. Upgrade to the latest release before reporting a problem that may
 already have been fixed.
 

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,4 +1,4 @@
-# DefuzeX SDK API Contract
+# KUMA SDK API Contract
 
 Base URL：`https://defuzex.ai/api/agentdefuze`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,13 +1,13 @@
 # SDK v4 架构
 
-本文描述当前 `defuzex` Python 包的模块边界、同步用户 API、内部 v2 operation 流程和关键不变量。公开 HTTP 字段与路径另见 [API Contract](api-contract.md)；使用方式见[中文用户接入指南](../examples/full_stack/USER_GUIDE.md)或[英文 SDK 指南](sdk-guide.md)。
+本文描述当前 `defuzex` Python 包的模块边界、同步用户 API、内部 v2 operation 流程和关键不变量。公开 HTTP 字段与路径另见 [API Contract](api-contract.md)；使用方式见[简体中文 SDK 指南](sdk-guide.zh-CN.md)或[英文 SDK 指南](sdk-guide.md)。
 
 ## 系统边界与数据归属
 
 ```mermaid
 flowchart LR
     Agent["User Agent process"]
-    SDK["DefuzeX Python SDK<br/>public protocol, Run, Evidence"]
+    SDK["KUMA Python SDK<br/>public protocol, Run, Evidence"]
     Backend["Website Backend<br/>public HTTPS control plane"]
     Core["Private Core MCP<br/>Case, Rubric, Judge"]
     Model["Model provider"]

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -1,10 +1,12 @@
-# DefuzeX Python SDK guide
+# KUMA Python SDK guide
 
-This guide holds the detailed setup and integration material intentionally kept out of the project homepage. For the Chinese integration path, see the [中文用户接入指南](../examples/full_stack/USER_GUIDE.md).
+[English](sdk-guide.md) | [简体中文](sdk-guide.zh-CN.md)
+
+This is the canonical user guide for KUMA configuration and integration. The package, CLI, environment variables, and wire fields retain their existing `defuzex` / `DEFUZEX_*` technical identifiers.
 
 ## Installation
 
-DefuzeX supports Python 3.10 through 3.14. Install from the current source repository in an isolated environment:
+KUMA supports Python 3.10 through 3.14. Install the current source repository in an isolated environment:
 
 ```bash
 git clone https://github.com/DefuzeX-AI/KUMA-DefuzeX.git
@@ -12,7 +14,7 @@ cd KUMA-DefuzeX
 python -m venv .venv
 ```
 
-On Windows PowerShell:
+Windows PowerShell:
 
 ```powershell
 .\.venv\Scripts\Activate.ps1
@@ -20,7 +22,7 @@ python -m pip install --upgrade pip
 python -m pip install .
 ```
 
-On Linux or macOS:
+Linux or macOS:
 
 ```bash
 source .venv/bin/activate
@@ -28,31 +30,33 @@ python -m pip install --upgrade pip
 python -m pip install .
 ```
 
-Install the optional in-process OpenTelemetry adapter from the checkout only when needed:
+Optional OpenTelemetry support:
 
 ```bash
 python -m pip install ".[otel]"
 ```
 
-Contributors should follow [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the editable development install and canonical checks.
+Contributors should use the editable development setup in [`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
-## Account-free first run
+## Local quickstart
 
-`defuzex quickstart` runs a deterministic exact-match check in an SDK-owned temporary directory. It reads no user repository and requires no account, API key, Docker, or network:
+The CLI quickstart runs a deterministic exact-match check in an SDK-owned temporary directory. It reads no user repository and requires no account, API key, Docker, or network:
 
 ```bash
 defuzex quickstart
 ```
 
-Use `defuzex quickstart --fail-demo` to inspect the deterministic failure path and non-zero exit status. [`examples/minimal_local.py`](../examples/minimal_local.py) demonstrates a complete local `Run` with a custom Case Provider and no Judge:
+Use `defuzex quickstart --fail-demo` to exercise the deterministic failure path. A complete local `Run` with a custom Case Provider and no Judge is also available:
 
 ```bash
 python examples/minimal_local.py
 ```
 
-## Official service setup
+## Configuration
 
-Official Case or Judge providers require a DefuzeX API key beginning with `dfx_`. Supply it through the process environment or the local user credential store; never place it in source, Notebook output, or Git.
+### API key
+
+Official Case or Judge Providers require a KUMA API key beginning with `dfx_`. Keep it in the process environment or user credential store; never place it in source, Notebook output, logs, or Git.
 
 Windows PowerShell:
 
@@ -68,7 +72,7 @@ export DEFUZEX_API_KEY="dfx_your_key_here"
 defuzex whoami
 ```
 
-The SDK can validate and atomically save the key without contacting the network:
+The SDK can validate and atomically store the key without a network request:
 
 ```python
 from defuzex import configure
@@ -77,7 +81,13 @@ credential_path = configure(api_key="dfx_your_key_here")
 print(credential_path)
 ```
 
-Credential resolution order is an explicit function argument, `DEFUZEX_API_KEY`, then the user credential file.
+Credential precedence is: `create_run(api_key=...)`, `DEFUZEX_API_KEY`, then the user credential file.
+
+| Environment variable | Purpose |
+|---|---|
+| `DEFUZEX_API_KEY` | Credential for official Providers |
+| `DEFUZEX_CONFIG_HOME` | Override the user credential directory |
+| `DEFUZEX_BASE_URL` | Override the accepted public or loopback API base URL; non-loopback URLs must use HTTPS |
 
 ### Requirement file
 
@@ -102,11 +112,11 @@ Diagnose the requested defect, apply a bounded fix, and run relevant checks.
 Do not read credentials or access paths outside the repository.
 ```
 
-The official service currently accepts text Inputs. Custom Case Providers can use locally validated structured Inputs.
+`agent_description`, `input_type`, and all three headings are required. Official Cases currently accept text Inputs. Structured Inputs require a custom Case Provider plus a locally validated JSON Schema declared through `input_schema`.
 
 ### Agent integration
 
-The user owns the Agent invocation; the SDK owns the Run protocol. Replace the deterministic body below with the existing Agent call:
+The user owns Agent execution; KUMA owns the synchronous `Run` protocol. Replace the deterministic function body with the existing Agent call:
 
 ```python
 from typing import Any
@@ -132,47 +142,79 @@ print(run.state)
 print(report)
 ```
 
-Production runs should place the SDK and Agent in the same controlled container and omit `allow_local=True`. The [Single Agent template](../examples/single_agent_template/README.md) provides a framework-neutral adapter with explicit timeout and failure handling.
+`get_input()` returns the JSON-compatible payload; `get_input(full=True)` returns an immutable `DefuzeXInput`. Completed submissions require finite JSON-compatible output. Do not advance one Run concurrently.
 
-## Run lifecycle and providers
+## Providers and Run lifecycle
 
-One `Run` follows a strict synchronous sequence:
+### Provider combinations
 
-1. `create_run()` validates configuration and obtains one Case.
-2. `get_input()` delivers the current Input.
-3. The user invokes the Agent.
-4. `submit()` records the result and Evidence atomically.
-5. Steps 2–4 repeat until the Case ends; an enabled Judge then returns a `TestReport`.
-
-Do not advance one Run concurrently. Call `run.cancel()` when abandoning it early.
-
-| Case provider | Judge provider | Behavior |
+| Case Provider | Judge Provider | Behavior |
 |---|---|---|
 | omitted | omitted | Official Case and Judge; API key required |
 | omitted | custom | Official Case with local Judge; API key required |
 | custom | omitted | Local Case with official Judge; API key required |
-| custom | custom | Fully local; the Case carries its public evaluation rule |
+| custom | custom | Fully local |
 | any | `judge=False` | Complete after the final submission without a Judge |
 
-Common `create_run()` controls include:
+Custom Case Providers require `max_inputs`. Provider outputs are normalized and validated before entering the Run.
 
-| Option | Purpose |
+### Run state machine
+
+The normal sequence is `ready` → `input_delivered` → `submitting`, returning to `ready` for another Input or moving to `completed`. An enabled Judge uses `judging` → `report_ready`.
+
+| State | Meaning |
 |---|---|
-| `repo_path`, `requirement_path` | Select the evaluated repository and requirement |
-| `case_provider`, `judge_provider` | Replace either official boundary with a custom Provider |
-| `max_inputs` | Bound custom Case input count |
-| `allow_local` | Explicitly permit trusted local development outside Docker |
-| `track_files`, `upload_diff`, `save_local` | Control file Evidence and local step records |
-| `timeout`, `operation_wait_timeout`, `max_retries` | Bound public HTTP attempts and official operation polling |
-| `trace_evidence` | Attach the optional in-process Trace capture |
+| `ready` | The next Input may be delivered |
+| `input_delivered` | The current Input awaits exactly one submission |
+| `submitting` | The submission and Evidence transaction are committing |
+| `completed` | Input processing ended; a Judge may run or retry |
+| `judging` | The synchronous Judge call is in progress |
+| `report_ready` | A validated `TestReport` is available |
+| `cancelled` | The caller cancelled the Run and released runtime state |
+| `failed` | Runtime finalization failed |
 
-The Python API remains synchronous while official single-Case and Judge requests use bounded server operations internally. See [SDK architecture](architecture.md#create_run-编排与调用流程) for the complete sequence and [public API contract](api-contract.md) for the HTTP boundary.
+Repeated `get_input()` calls before `submit()` return the same Input. Invalid ordering raises `InputProtocolError`. Call `run.cancel()` when abandoning a Run.
 
-## Evidence and OpenTelemetry
+### `create_run()` parameters
 
-Each `get_input()` to `submit()` interval is one Evidence transaction. File tracking records metadata by default; `logs=[...]` reads only explicitly named file increments. Capture status, missing reasons, dropped counts, and runtime warnings expose incomplete or degraded capture.
+| Parameter | Default | Purpose |
+|---|---:|---|
+| `repo_path` | `"."` | Repository evaluated by the Agent |
+| `requirement_path` | `None` | Requirement file; official Case Providers require it |
+| `case_provider` | `None` | Custom Case Provider; omitted selects the official Provider |
+| `judge_provider` | `None` | Custom Judge Provider; omitted selects the official Provider when judging |
+| `strategy` | `"auto"` | Automatic selection or an explicit strategy ID |
+| `max_inputs` | `None` | Positive Input bound; required for custom Cases |
+| `judge` | `True` | Run the configured Judge after the final Input |
+| `on_failure` | `"continue"` | Continue or stop after a failed submission |
+| `allow_local` | `False` | Permit trusted development outside Docker |
+| `track_files` | `True` | Capture bounded file metadata around each Input |
+| `upload_diff` | `False` | Include bounded text diffs in file Evidence |
+| `save_local` | `False` | Save submission records under `.defuzex/runs/` |
+| `allow_sensitive` | `False` | Explicit override for ordinary Evidence scanning; does not relax Trace allowlists |
+| `timeout` | `300.0` | Per-request public HTTP timeout in seconds |
+| `operation_wait_timeout` | `600.0` | Total wait bound for one official Case or Judge operation |
+| `max_retries` | `2` | Automatic transient retry count, from 0 through 5 |
+| `api_key` | `None` | Per-call credential with highest precedence |
+| `trace_evidence` | `None` | Capture returned by `configure_trace_evidence()` |
 
-OpenTelemetry support is optional and stays in process. DefuzeX adds a standard processor to the provided `TracerProvider`; it does not replace the global provider:
+`on_failure` accepts only `continue` or `stop`. The Python API is synchronous; `wait=False` is not supported.
+
+## Evidence, files, logs, and privacy
+
+Each `get_input()` to `submit()` interval is one Evidence transaction. Evidence commits only after the immutable Submission is appended to History; a failed submission build does not advance log offsets or Trace budgets.
+
+- Repository metadata is bounded and contains paths, types, sizes, and a fingerprint—not repository file contents.
+- File tracking records hashes, sizes, modes, and change types by default. Text content enters Evidence only when `upload_diff=True`.
+- `submit(..., logs=[...])` reads increments only from explicitly selected files and requires Evidence capture to be enabled.
+- `save_local=True` writes structured records under `.defuzex/runs/<run_id>/submissions/`; local persistence does not replace official submission.
+- `CaptureStatus`, `missing`, `dropped_count`, and `runtime_warnings` expose partial or degraded capture.
+
+Before official upload, KUMA scans output, errors, paths, diffs, explicit logs, and custom Cases for sensitive material. The API key is used for authorization and is not added to Evidence. `allow_sensitive=True` is an explicit ordinary-Evidence override, not a substitute for isolation or secret hygiene.
+
+## OpenTelemetry
+
+The optional adapter captures ended spans from the same process and current Input. It adds a standard processor to the supplied `TracerProvider`; it does not replace the application's provider:
 
 ```python
 from opentelemetry.sdk.trace import TracerProvider
@@ -193,23 +235,23 @@ run = create_run(
 )
 ```
 
-Only ended spans associated with the current Input are captured. A restrictive allowlist, size limits, and sensitive-data checks apply. Explicit `submit(output)` remains the portable fallback when Agent instrumentation does not expose a supported final output. The SDK does not provide an OTLP receiver, cross-process correlation, trace UI, or trace storage. See [OpenTelemetry architecture](architecture.md#opentelemetry-适配) for mapping and transaction details.
+Span counts, attributes, events, text, and total Run bytes are bounded. A restrictive allowlist excludes prompts, completions, source, log bodies, keys, and credentials. Explicit `submit(output)` remains the portable fallback; omitted output works only when supported Agent/Workflow spans expose a valid final output. KUMA does not provide an OTLP receiver, cross-process correlation, trace UI, or storage service.
 
-## Docker and runtime safety
+## Docker and runtime security
 
-`allow_local=True` is a development switch, not a sandbox. The user remains responsible for the Agent's file, command, network, and secret permissions. Evidence scanning complements container isolation and least privilege; it does not replace them.
+Official production runs require the SDK and Agent in the same controlled container by default. `allow_local=True` is a development switch, not a sandbox. The user remains responsible for the Agent's file, command, network, resource, and secret permissions.
 
-The public user-flow image is a build-validation example:
+Build the supplied user-flow example:
 
 ```bash
 docker build -f examples/full_stack/Dockerfile.user-flow -t defuzex-user-flow .
 ```
 
-The [Docker user-flow guide](../examples/full_stack/USER_GUIDE.md) and [Notebook](../examples/full_stack/defuzex_v4_real_user_flow.ipynb) describe the full user-owned Agent path and its prerequisites.
+See the [full-stack example guide](../examples/full_stack/USER_GUIDE.md) for its exact workspace and runtime requirements.
 
-## Troubleshooting
+## Errors, retries, and timeouts
 
-Catch stable public errors through `DefuzeError`:
+Catch stable SDK errors through `DefuzeError`:
 
 ```python
 from defuzex.errors import DefuzeError
@@ -220,21 +262,31 @@ except DefuzeError as exc:
     print(exc.code, exc.retryable, exc.request_id)
 ```
 
+Common subclasses include `ConfigurationError`, `AuthenticationError`, `PermissionDeniedError`, `ValidationError`, `SensitiveDataError`, `LimitExceededError`, `InputProtocolError`, `ProviderError`, `DefuzeTimeoutError`, `ServiceBusyError`, and `ServiceError`.
+
+`timeout` bounds one public HTTP attempt. `operation_wait_timeout` bounds the complete official single-Case or Judge operation. POST retries reuse a stable idempotency key; only server-declared transient failures are retried within `max_retries`, and `ServiceBusyError` is not retried automatically.
+
+An operation timeout retains bounded recovery metadata without storing credentials, request content, Evidence, or results. Judge retry requires the original Run and History; the high-level API cannot rebuild a lost Run from only `run_id` after process exit.
+
+## Troubleshooting
+
 | Symptom | Action |
 |---|---|
-| Missing API key | Use fully local Providers or `judge=False`, or configure a valid key |
-| `DockerRequiredError` | Run SDK and Agent in one container; use `allow_local=True` only for trusted development |
-| `submit()` returns `None` | Check whether more Inputs remain, whether Judge is disabled, and inspect `run.state` |
-| Operation timeout | Preserve the original Run, inspect `retryable`, and retry without changing protocols |
-| Missing OTel output | Submit an explicit JSON-compatible output or install and attach `[otel]` correctly |
-| Sensitive-data rejection | Remove credentials or sensitive content from output, paths, logs, and uploaded diffs |
-
-Only server-declared transient failures are retried within `max_retries`. Public server internals are not exposed through SDK exceptions.
+| Missing API key | Configure a valid key or use fully local Providers / `judge=False` |
+| Requirement rejected | Check UTF-8, front matter, required headings, and structured-input schema |
+| `DockerRequiredError` | Use one controlled container; enable `allow_local=True` only for trusted development |
+| `submit()` returns `None` | Check remaining Inputs, `judge`, `run.state`, and `run.history` |
+| `input_protocol` | Alternate one `get_input()` with one `submit()` and avoid concurrent advancement |
+| Sensitive-data rejection | Remove secrets from output, paths, logs, diffs, and custom Cases |
+| Operation timeout | Keep the original Run, inspect `retryable`, and retry without changing protocols |
+| Missing Trace output | Submit explicit JSON output or install and attach `[otel]` correctly |
 
 ## Reference
 
-- [SDK architecture](architecture.md)
+- [Architecture](architecture.md)
 - [Public API contract](api-contract.md)
-- [Chinese integration guide](../examples/full_stack/USER_GUIDE.md)
-- [Contributing](../CONTRIBUTING.md)
+- [Minimal local example](../examples/minimal_local.py)
+- [Single Agent template](../examples/single_agent_template/README.md)
+- [Full-stack example](../examples/full_stack/USER_GUIDE.md)
 - [Security policy](../SECURITY.md)
+- [Contributing](../CONTRIBUTING.md)

--- a/docs/sdk-guide.zh-CN.md
+++ b/docs/sdk-guide.zh-CN.md
@@ -1,0 +1,292 @@
+# KUMA Python SDK 指南
+
+[English](sdk-guide.md) | [简体中文](sdk-guide.zh-CN.md)
+
+本文是 KUMA 配置与接入的规范用户指南。Python 包、CLI、环境变量和 wire 字段继续使用现有的 `defuzex` / `DEFUZEX_*` 技术标识。
+
+## 安装
+
+KUMA 支持 Python 3.10 至 3.14。建议在隔离环境中安装当前源码：
+
+```bash
+git clone https://github.com/DefuzeX-AI/KUMA-DefuzeX.git
+cd KUMA-DefuzeX
+python -m venv .venv
+```
+
+Windows PowerShell：
+
+```powershell
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install .
+```
+
+Linux 或 macOS：
+
+```bash
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install .
+```
+
+按需安装 OpenTelemetry 能力：
+
+```bash
+python -m pip install ".[otel]"
+```
+
+贡献者请按 [`CONTRIBUTING.md`](../CONTRIBUTING.md) 使用可编辑开发环境。
+
+## 本地快速开始
+
+CLI quickstart 会在 SDK 自有临时目录中执行确定性的精确匹配检查，不读取用户仓库，也不需要账号、API Key、Docker 或网络：
+
+```bash
+defuzex quickstart
+```
+
+`defuzex quickstart --fail-demo` 可验证确定性失败路径。另有一个使用自定义 Case Provider、关闭 Judge 的完整本地 `Run`：
+
+```bash
+python examples/minimal_local.py
+```
+
+## 配置
+
+### API Key
+
+官方 Case 或 Judge Provider 需要以 `dfx_` 开头的 KUMA API Key。请通过进程环境或用户凭证存储提供，不要写入源码、Notebook 输出、日志或 Git。
+
+Windows PowerShell：
+
+```powershell
+$env:DEFUZEX_API_KEY = "dfx_your_key_here"
+defuzex whoami
+```
+
+Linux 或 macOS：
+
+```bash
+export DEFUZEX_API_KEY="dfx_your_key_here"
+defuzex whoami
+```
+
+SDK 也可在不访问网络的情况下验证并原子保存 Key：
+
+```python
+from defuzex import configure
+
+credential_path = configure(api_key="dfx_your_key_here")
+print(credential_path)
+```
+
+凭证优先级为：`create_run(api_key=...)`、`DEFUZEX_API_KEY`、用户凭证文件。
+
+| 环境变量 | 用途 |
+|---|---|
+| `DEFUZEX_API_KEY` | 官方 Provider 使用的凭证 |
+| `DEFUZEX_CONFIG_HOME` | 覆盖用户凭证目录 |
+| `DEFUZEX_BASE_URL` | 覆盖允许的公开或 loopback API 地址；非 loopback 地址必须使用 HTTPS |
+
+### Requirement 文件
+
+官方 Case Provider 要求显式提供 UTF-8 requirement 文件，包含 YAML front matter 和三个章节：
+
+```markdown
+---
+agent_description: A repository maintenance agent
+input_type: text
+---
+
+## Production Use Scenario
+
+Maintain a Python repository without changing its public interface.
+
+## Behaviors to Test
+
+Diagnose the requested defect, apply a bounded fix, and run relevant checks.
+
+## Known Limitations or Prohibited Behaviors
+
+Do not read credentials or access paths outside the repository.
+```
+
+`agent_description`、`input_type` 和三个标题均为必填。官方 Case 当前接受文本 Input；结构化 Input 需要自定义 Case Provider，并通过 `input_schema` 声明本地验证的 JSON Schema。
+
+### 接入 Agent
+
+用户负责执行 Agent，KUMA 负责同步 `Run` 协议。将下面的确定性函数体替换为现有 Agent 调用：
+
+```python
+from typing import Any
+
+from defuzex import create_run
+
+
+def execute_agent(test_input: Any) -> dict[str, Any]:
+    return {"result": str(test_input)}
+
+
+run = create_run(
+    repo_path=".",
+    requirement_path="requirement.md",
+    allow_local=True,  # 仅用于可信的本地开发。
+)
+
+report = None
+while (test_input := run.get_input()) is not None:
+    report = run.submit(execute_agent(test_input))
+
+print(run.state)
+print(report)
+```
+
+`get_input()` 返回兼容 JSON 的 payload；`get_input(full=True)` 返回不可变的 `DefuzeXInput`。成功的 Submission 必须包含有限且兼容 JSON 的输出。同一个 Run 不得并发推进。
+
+## Provider 与 Run 生命周期
+
+### Provider 组合
+
+| Case Provider | Judge Provider | 行为 |
+|---|---|---|
+| 省略 | 省略 | 官方 Case 与 Judge；需要 API Key |
+| 省略 | 自定义 | 官方 Case 与本地 Judge；需要 API Key |
+| 自定义 | 省略 | 本地 Case 与官方 Judge；需要 API Key |
+| 自定义 | 自定义 | 完全本地 |
+| 任意 | `judge=False` | 最后一次提交后结束，不运行 Judge |
+
+自定义 Case Provider 必须设置 `max_inputs`。Provider 输出进入 Run 前会被归一化并验证。
+
+### Run 状态机
+
+正常流程为 `ready` → `input_delivered` → `submitting`；如有后续 Input 则回到 `ready`，否则进入 `completed`。启用 Judge 后继续执行 `judging` → `report_ready`。
+
+| 状态 | 含义 |
+|---|---|
+| `ready` | 可以交付下一个 Input |
+| `input_delivered` | 当前 Input 等待且只允许一次提交 |
+| `submitting` | 正在提交并提交 Evidence 事务 |
+| `completed` | Input 已处理完；可运行或重试 Judge |
+| `judging` | 同步 Judge 调用正在执行 |
+| `report_ready` | 已取得验证后的 `TestReport` |
+| `cancelled` | 调用者取消 Run，并释放运行时状态 |
+| `failed` | 运行时收尾失败 |
+
+在 `submit()` 前重复调用 `get_input()` 会返回同一 Input。非法顺序会抛出 `InputProtocolError`。不再继续时应调用 `run.cancel()`。
+
+### `create_run()` 参数
+
+| 参数 | 默认值 | 用途 |
+|---|---:|---|
+| `repo_path` | `"."` | Agent 被测仓库 |
+| `requirement_path` | `None` | Requirement 文件；官方 Case Provider 必填 |
+| `case_provider` | `None` | 自定义 Case Provider；省略时使用官方 Provider |
+| `judge_provider` | `None` | 自定义 Judge Provider；启用 Judge 且省略时使用官方 Provider |
+| `strategy` | `"auto"` | 自动选择或显式 strategy ID |
+| `max_inputs` | `None` | 正数 Input 上限；自定义 Case 必填 |
+| `judge` | `True` | 最后一个 Input 后运行已配置的 Judge |
+| `on_failure` | `"continue"` | Submission 失败后继续或停止 |
+| `allow_local` | `False` | 允许在 Docker 外进行可信开发运行 |
+| `track_files` | `True` | 在每个 Input 前后采集有界文件元数据 |
+| `upload_diff` | `False` | 在文件 Evidence 中加入有界文本 diff |
+| `save_local` | `False` | 将 Submission 记录保存到 `.defuzex/runs/` |
+| `allow_sensitive` | `False` | 显式覆盖普通 Evidence 扫描；不会放宽 Trace allowlist |
+| `timeout` | `300.0` | 单次公开 HTTP 请求超时，单位为秒 |
+| `operation_wait_timeout` | `600.0` | 单次官方 Case 或 Judge operation 的总等待上限 |
+| `max_retries` | `2` | 瞬态失败自动重试次数，取值 0 至 5 |
+| `api_key` | `None` | 优先级最高的本次调用凭证 |
+| `trace_evidence` | `None` | `configure_trace_evidence()` 返回的 capture |
+
+`on_failure` 只接受 `continue` 或 `stop`。Python API 保持同步，不支持 `wait=False`。
+
+## Evidence、文件、日志与隐私
+
+每次 `get_input()` 到 `submit()` 是一个 Evidence 事务。只有不可变 Submission 成功加入 History 后才会提交 Evidence；Submission 构造失败不会推进日志 offset 或 Trace 预算。
+
+- Repo metadata 有明确上限，只包含路径、类型、大小和 fingerprint，不包含仓库文件正文。
+- 默认文件追踪只记录 hash、大小、mode 和变化类型；仅 `upload_diff=True` 时文本内容才进入 Evidence。
+- `submit(..., logs=[...])` 只读取显式指定文件的增量，并要求启用 Evidence 采集。
+- `save_local=True` 将结构化记录写入 `.defuzex/runs/<run_id>/submissions/`；本地记录不能替代官方提交。
+- `CaptureStatus`、`missing`、`dropped_count` 和 `runtime_warnings` 用于呈现采集不完整或降级。
+
+上传到官方服务前，KUMA 会扫描 output、error、路径、diff、显式日志和自定义 Case 中的敏感内容。API Key 仅用于鉴权，不会加入 Evidence。`allow_sensitive=True` 只是普通 Evidence 的显式覆盖，不能替代隔离与 secret 管理。
+
+## OpenTelemetry
+
+可选 adapter 只采集同一进程、当前 Input 中已结束的 span。它向用户提供的 `TracerProvider` 添加标准 processor，不会替换应用已有的 provider：
+
+```python
+from opentelemetry.sdk.trace import TracerProvider
+
+from defuzex import create_run
+from defuzex.otel import TraceEvidenceLimits, configure_trace_evidence
+
+provider = TracerProvider()
+trace_evidence = configure_trace_evidence(
+    provider,
+    limits=TraceEvidenceLimits(max_spans=100, max_total_bytes=256_000),
+)
+run = create_run(
+    repo_path=".",
+    requirement_path="requirement.md",
+    allow_local=True,
+    trace_evidence=trace_evidence,
+)
+```
+
+span 数量、属性、事件、文本和整个 Run 的字节数均有上限。拒绝式 allowlist 会排除 prompt、completion、源码、日志正文、Key 与凭证。显式 `submit(output)` 始终是可移植的回退；只有受支持的 Agent/Workflow span 提供合法最终输出时才能省略 output。KUMA 不提供 OTLP receiver、跨进程关联、Trace UI 或存储服务。
+
+## Docker 与运行时安全
+
+官方正式运行默认要求 SDK 与 Agent 位于同一个受控容器。`allow_local=True` 是开发开关，不是沙箱。用户仍需限制 Agent 的文件、命令、网络、资源和 secret 权限。
+
+构建仓库提供的用户流程示例：
+
+```bash
+docker build -f examples/full_stack/Dockerfile.user-flow -t defuzex-user-flow .
+```
+
+示例所需的工作区和运行参数见[完整流程示例指南](../examples/full_stack/USER_GUIDE.md)。
+
+## 错误、重试与超时
+
+通过 `DefuzeError` 捕获稳定 SDK 错误：
+
+```python
+from defuzex.errors import DefuzeError
+
+try:
+    report = run.judge()
+except DefuzeError as exc:
+    print(exc.code, exc.retryable, exc.request_id)
+```
+
+常见子类包括 `ConfigurationError`、`AuthenticationError`、`PermissionDeniedError`、`ValidationError`、`SensitiveDataError`、`LimitExceededError`、`InputProtocolError`、`ProviderError`、`DefuzeTimeoutError`、`ServiceBusyError` 和 `ServiceError`。
+
+`timeout` 限制单次公开 HTTP 尝试；`operation_wait_timeout` 限制完整的官方单 Case 或 Judge operation。POST 重试会复用稳定幂等键；只有服务端声明的瞬态失败才会在 `max_retries` 范围内重试，`ServiceBusyError` 不会自动重试。
+
+operation 超时只保留有界恢复元数据，不保存凭证、请求正文、Evidence 或结果。Judge 重试需要保留原 Run 与 History；进程退出并丢失 Run 后，高层 API 不能只通过 `run_id` 重建。
+
+## 故障排查
+
+| 现象 | 处理 |
+|---|---|
+| 缺少 API Key | 配置有效 Key，或使用完全本地 Provider / `judge=False` |
+| Requirement 被拒绝 | 检查 UTF-8、front matter、必需标题和结构化 Input schema |
+| `DockerRequiredError` | 使用同一个受控容器；仅可信开发环境设置 `allow_local=True` |
+| `submit()` 返回 `None` | 检查剩余 Input、`judge`、`run.state` 与 `run.history` |
+| `input_protocol` | 严格交替执行一次 `get_input()` 与一次 `submit()`，不要并发推进 |
+| 敏感数据被拒绝 | 从 output、路径、日志、diff 与自定义 Case 中移除 secret |
+| operation 超时 | 保留原 Run，检查 `retryable`，不要切换协议后重试 |
+| 缺少 Trace 输出 | 显式提交 JSON 输出，或正确安装并 attach `[otel]` |
+
+## 参考
+
+- [架构](architecture.md)
+- [公开 API Contract](api-contract.md)
+- [最小本地示例](../examples/minimal_local.py)
+- [Single Agent 模板](../examples/single_agent_template/README.md)
+- [完整流程示例](../examples/full_stack/USER_GUIDE.md)
+- [安全策略](../SECURITY.md)
+- [贡献说明](../CONTRIBUTING.md)

--- a/examples/full_stack/USER_GUIDE.md
+++ b/examples/full_stack/USER_GUIDE.md
@@ -1,181 +1,82 @@
-# DefuzeX SDK 用户接入指南
+# KUMA full-stack user-flow example
 
-本指南面向已经拥有可调用 Agent 的用户。DefuzeX SDK 不替用户选择模型或启动 Agent；它负责生成公开 Case、驱动 Run、采集 Evidence，并返回 Judge 报告。
+This file covers only the supplied mini-SWE-agent example. General SDK installation, API key setup, requirement format, Run protocol, Evidence, OpenTelemetry, Docker boundaries, and troubleshooting live in the canonical [English guide](../../docs/sdk-guide.md) and [简体中文指南](../../docs/sdk-guide.zh-CN.md).
 
-```text
-DefuzeX Case -> 用户 Agent -> output/Evidence -> DefuzeX Judge
-```
+## What this example runs
 
-SDK 只访问 `https://defuzex.ai/api/agentdefuze`。Backend、Core MCP、模型和数据库由 DefuzeX 托管，用户无需启动这些服务。
+The example combines the KUMA SDK and mini-SWE-agent in one Docker container. It requests an official Case and Judge, executes each Case step against the mounted workspace, records bounded Trace and log Evidence, and writes the public Judge result locally.
 
-## 1. 从 GitHub 安装
+Two entry points are provided:
 
-需要 Python 3.10 或更高版本。
+- [`Dockerfile.user-flow`](Dockerfile.user-flow) with [`docker_user_flow.py`](docker_user_flow.py) for a direct container run.
+- [`defuzex_v4_real_user_flow.ipynb`](defuzex_v4_real_user_flow.ipynb) for the guided Windows/WSL flow.
+
+Both paths invoke real external services and may incur model or service cost.
+
+## Prepare the workspace
+
+Use a disposable or fully committed Git workspace. The direct Docker example expects the mounted root to contain:
+
+- `requirement.md` in the accepted format;
+- `calculator.py`, the only source file this example may modify;
+- tests runnable with `python -m unittest discover -v`.
+
+Export these values before running the example:
+
+- `DEFUZEX_BASE_URL`
+- `DEFUZEX_API_KEY`
+- `DEEPSEEK_API_KEY`
+
+Do not place populated credentials in the workspace or repository.
+
+## Build the image
+
+From the SDK repository root:
 
 ```bash
-git clone https://github.com/DefuzeX-AI/KUMA-DefuzeX.git
-cd KUMA-DefuzeX
-python -m venv .venv
+docker build -f examples/full_stack/Dockerfile.user-flow -t defuzex-user-flow .
 ```
 
-Windows PowerShell：
+## Run the container
+
+Windows PowerShell:
 
 ```powershell
-.\.venv\Scripts\Activate.ps1
-python -m pip install --upgrade pip
-python -m pip install -e .
+$workspace = (Resolve-Path "C:\path\to\workspace").Path
+docker run --rm `
+  --env DEFUZEX_BASE_URL `
+  --env DEFUZEX_API_KEY `
+  --env DEEPSEEK_API_KEY `
+  --mount "type=bind,source=$workspace,target=/workspace" `
+  defuzex-user-flow
 ```
 
-Linux/macOS：
+Linux or macOS:
 
 ```bash
-source .venv/bin/activate
-python -m pip install --upgrade pip
-python -m pip install -e .
+workspace="$(pwd)"
+docker run --rm \
+  --env DEFUZEX_BASE_URL \
+  --env DEFUZEX_API_KEY \
+  --env DEEPSEEK_API_KEY \
+  --mount "type=bind,source=$workspace,target=/workspace" \
+  defuzex-user-flow
 ```
 
-验证安装：
+The script rejects non-Docker execution and missing environment variables. It also blocks out-of-scope source changes and fails when the Agent does not submit successfully or the final Judge report is absent.
 
-```bash
-python -c "import defuzex; print(defuzex.__version__)"
-```
+## Run the Notebook
 
-## 2. 配置 DefuzeX API Key
+The Notebook requires Windows, WSL, Jupyter, the two API keys above, and the configured public base URL. Set environment variables before starting Jupyter, open [`defuzex_v4_real_user_flow.ipynb`](defuzex_v4_real_user_flow.ipynb), then follow its cells to select the Agent workspace.
 
-官方 Case 和 Judge 使用 `dfx_` Key。Key 只应保存在环境变量或用户凭证文件中。
+The Notebook can modify the selected repository. Choose only a disposable workspace or one with all prior work committed.
 
-Windows PowerShell：
+## Outputs
 
-```powershell
-$env:DEFUZEX_API_KEY = "dfx_<public-id>.<secret>"
-defuzex whoami
-```
+The direct flow writes example artifacts under `.defuzex/mini-swe-agent/` in the mounted workspace:
 
-Linux/macOS：
+- compact Agent trajectory and verification Evidence;
+- per-step unittest logs;
+- the final public `judge-report.json`.
 
-```bash
-export DEFUZEX_API_KEY="dfx_<public-id>.<secret>"
-defuzex whoami
-```
-
-也可以使用 `defuzex.configure(api_key=...)` 写入当前用户的凭证目录。不要把 Key 写入源码、Notebook 输出或 Git。
-
-Agent 自己使用的模型 Key 不属于 DefuzeX SDK 配置，应由用户的 Agent 单独管理。
-
-## 3. 编写 requirement
-
-官方 Case Provider 要求一个非空 UTF-8 requirement 文件。它描述测试场景和行为边界，不用于直接写出缺陷答案。
-
-创建 `requirement.md`：
-
-```markdown
----
-agent_description: A repository maintenance agent
-input_type: text
----
-
-## Production Use Scenario
-
-Maintain a Python repository in a bounded workspace.
-
-## Behaviors to Test
-
-Inspect the repository, follow the Case, make minimal changes, verify them, and report evidence.
-
-## Known Limitations or Prohibited Behaviors
-
-Do not expose credentials, modify tests, add unnecessary dependencies, or access paths outside the repository.
-```
-
-YAML front matter 和三个二级标题都是必需项；空文件会在联网前被 SDK 拒绝。当前官方 Case 仅支持 `input_type: text`。
-
-## 4. 接入用户 Agent
-
-把 `execute_agent()` 替换成用户已有的 Agent 调用。返回值必须可以序列化为 JSON。
-
-```python
-from typing import Any
-
-from defuzex import create_run
-
-
-def execute_agent(case_input: Any) -> dict[str, Any]:
-    # 示例：return my_agent.invoke(case_input)
-    raise NotImplementedError
-
-
-run = create_run(
-    repo_path="/path/to/agent-workspace",
-    requirement_path="requirement.md",
-    allow_local=True,
-    track_files=True,
-    upload_diff=False,
-    save_local=True,
-)
-
-report = None
-while (case_input := run.get_input(full=True)) is not None:
-    output = execute_agent(case_input.payload)
-    report = run.submit(output)
-
-print(report.status, report.confidence)
-```
-
-协议顺序必须是：一次 `get_input()`、一次 Agent 执行、一次 `submit()`。不要让多个线程同时推进同一个 Run。
-
-## 5. 提交日志和 Evidence
-
-文件 Evidence 由 `track_files=True` 自动采集。需要提交 Agent 日志时，显式传入日志文件：
-
-```python
-report = run.submit(
-    output,
-    logs=["agent-trajectory.json", "test-results.log"],
-)
-```
-
-日志使用增量采集并受服务端动态大小限制。不要把 API Key、环境变量转储或其他秘密写入日志。`upload_diff=False` 默认不上传源码 diff。
-
-支持标准 OpenTelemetry Agent/Workflow 最终输出的 Agent，可以使用 `defuzex.otel.configure_trace_evidence()` 并调用 `run.submit()`；不支持标准 OTel 输出时，继续使用显式 `run.submit(output)`。完整 OTel 说明见[架构文档](../../docs/architecture.md#opentelemetry-适配)。
-
-## 6. 检查结果
-
-成功完成后：
-
-```python
-assert run.state == "report_ready"
-assert report is not None
-assert all(item.submission.status == "completed" for item in run.history)
-
-print("Run:", run.run_id)
-print("Judge:", report.status)
-print("Confidence:", report.confidence)
-print("Issues:", list(report.issues))
-print("Evidence gaps:", list(report.evidence_gaps))
-```
-
-`save_local=True` 会把本地步骤记录写到用户仓库的 `.defuzex/` 目录。Private Rubric、模型配置和服务端凭据不会进入 SDK 或该目录。
-
-## 7. 本地开发与正式运行
-
-- `allow_local=True`：仅用于可信仓库的开发和内部演示，不提供沙箱。
-- 正式模式：SDK 与 Agent 应位于同一受控容器，且不要传 `allow_local=True`。
-- 用户负责 Agent 的文件、命令、网络和 secret 权限；Evidence 扫描不能替代隔离和最小权限。
-
-## 8. 真实用户流程教程
-
-[defuzex_v4_real_user_flow.ipynb](./defuzex_v4_real_user_flow.ipynb) 使用 mini-SWE-agent 和 DeepSeek 演示完整用户侧流程。它会弹窗选择 Agent 工作目录，并真实修改所选仓库；只应选择可丢弃或已提交的安全 Git 工作区。
-
-该 Notebook 需要 Windows、WSL、有效的 `DEFUZEX_API_KEY` 和 `DEEPSEEK_API_KEY`。两项凭据都只从启动 Jupyter 前设置的环境变量读取；Notebook 不保存执行输出，也不包含凭据。Backend 与 Core 仍由官方服务托管，本教程不会启动或直连私有服务。
-
-## 9. 常见错误
-
-- `requirement_required` / `requirement_invalid`：检查 front matter、三个必需标题和非空正文。
-- `authentication_error`：检查 `dfx_` Key 是否有效。
-- `permission_denied`：Key 缺少 Case 或 Judge scope。
-- `sensitive_data`：output、日志、路径或 diff 命中了敏感信息策略。
-- `log_size_exceeded`：减少日志内容；不要静默截断 Agent 最终输出。
-- `service_busy`：当前请求未执行，稍后发起一个新 Run。
-- `input_protocol`：检查 `get_input()` 与 `submit()` 是否严格交替。
-
-稳定错误处理、Provider 组合和常用参数见[英文 SDK 指南](../../docs/sdk-guide.md)。
+It prints the official Case Inputs, final report, captured span names, final `calculator.py`, and artifact path. These outputs are example-specific; general result handling is documented in the canonical SDK guides.

--- a/examples/single_agent_template/README.md
+++ b/examples/single_agent_template/README.md
@@ -1,6 +1,6 @@
-# DefuzeX Single Agent Template
+# KUMA Single Agent Template
 
-This framework-neutral template connects one Agent call to the public DefuzeX `Run` protocol. It contains no model client, Agent framework, production transport mock, service credential, or deployment logic.
+This framework-neutral template connects one Agent call to the public KUMA `Run` protocol. It contains no model client, Agent framework, production transport mock, service credential, or deployment logic.
 
 ## Ownership boundary
 


### PR DESCRIPTION
## Summary

- Keep `README.md` and `README.zh-CN.md` as aligned, concise KUMA project homepages.
- Make `docs/sdk-guide.md` and `docs/sdk-guide.zh-CN.md` the paired canonical SDK guides.
- Keep the full-stack guide specific to that example and link general topics to canonical docs.
- Standardize human-facing product naming to KUMA while preserving real `defuzex` compatibility identifiers.
- Reconcile upstream Runtime Evidence additions without restoring old branding, badges, or duplicated README detail.

## README size

- English: 76 lines / 321 words → 48 lines / 168 words.
- 简体中文: 76 lines / 195 words → 48 lines / 110 words.

## Brand and compatibility scan

- Legacy DefuzeX product-name matches in scoped human-facing Markdown: **0**.
- Retained technical identifiers: package/import/CLI `defuzex`, `DEFUZEX_*` environment variables, public API type `DefuzeXInput`, `.defuzex` runtime paths, protocol/schema identifiers, current public endpoint, repository/asset/example artifact names.
- No source/API/package rename is included.

## Conflict resolution

- Absorbed upstream `main` at `f30d0592d70048efdf327db326ec5cb3548e90bc` in merge commit `83207d83a9fdafd5e63201256a1aa61829ccde88`.
- Resolved only `README.md` and `README.zh-CN.md` manually.
- Preserved KUMA naming, independent English/Chinese pages, concise homepage scope, public HTTPS/client boundaries, and the upstream canonical hash-only Runtime Evidence contract.
- Final PR diff against upstream remains 10 Markdown files only.

## Local validation

- Markdown links/anchors: **59 valid across 12 Markdown files**.
- Python documentation blocks: **9 parsed**; all fences balanced.
- `create_run`: **all 18 keyword-only parameters documented in both guides**.
- Secret/private-endpoint scan of final PR-added lines: **0 matches**.
- Legacy display-brand scan: **0 matches**.
- README structure: **5 aligned H2 sections per language**.
- Ruff check and format check: passed.
- Compile: passed.
- CLI help and credential-free quickstart: passed (100/100).
- `examples/minimal_local.py`: passed (`completed`, one submission).
- Wheel/sdist build and Twine checks: passed.
- Full-stack Docker image build: passed as `defuzex-user-flow:pr4-merge-gate`.

## Scope and limitation

Documentation only relative to current upstream `main`; no SDK behavior, dependency, version, CI, release, or repository-setting change is introduced by this PR. The credentialed hosted flow was not run because it requires real API keys, external services, and cost.

## GitHub CI

All 10 required checks passed in [workflow run 32892908664](https://github.com/DefuzeX-AI/KUMA-DefuzeX/actions/runs/32892908664): Quality, Package, Docker build, Windows, macOS, and Python 3.10–3.14.
