### PR TITLE
docs: explain selective Docker storage cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ defuzex quickstart
 
 [English SDK guide](docs/sdk-guide.md) · [简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [Runtime Evidence contract](docs/runtime-evidence.md)
 
+Docker builds retain local images and cache; review [local Docker storage](docs/sdk-guide.md#local-docker-storage) periodically.
+
 ## Project
 
 [Security](SECURITY.md) · [Contributing](CONTRIBUTING.md) · [Apache License 2.0](LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,6 +43,8 @@ defuzex quickstart
 
 [简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [English SDK guide](docs/sdk-guide.md) · [Runtime Evidence 合同](docs/runtime-evidence.md)
 
+Docker 构建会保留本地镜像与缓存；请定期检查[本地 Docker 存储](docs/sdk-guide.zh-CN.md#本地-docker-存储)。
+
 ## 项目链接
 
 [安全策略](SECURITY.md) · [贡献说明](CONTRIBUTING.md) · [Apache License 2.0](LICENSE)

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -251,6 +251,38 @@ docker build -f examples/full_stack/Dockerfile.user-flow -t defuzex-user-flow .
 
 See the [full-stack example guide](../examples/full_stack/USER_GUIDE.md) for its exact workspace and runtime requirements.
 
+### Local Docker storage
+
+Docker builds retain local images and build cache. Periodically inspect Docker Desktop's **Images** and **Builds** views, or use this read-only command to review disk usage:
+
+```bash
+docker system df
+```
+
+Reclaim space selectively, only after confirming that the target is no longer needed:
+
+```bash
+docker image rm <explicit-image:tag>
+```
+
+This removes only the named image or tag; do not remove an image required by a running container, including a necessary database image.
+
+```bash
+docker image prune
+```
+
+Without `-a`, this prompts before removing dangling images only. Review the prompt before confirming.
+
+```bash
+docker builder prune
+```
+
+This prompts before removing unused build cache. Confirm that slower rebuilds are acceptable. In Docker Desktop, likewise delete only project images or build cache that you have confirmed are unused.
+
+> **Warning:** Do not use or automate `docker system prune -a --volumes` as a default cleanup step. It can remove resources belonging to other projects, images needed by stopped containers, build cache, and persistent volumes. Never delete running containers, required database images, or required volumes.
+
+KUMA supplies Docker build and runtime materials, but does not manage the Docker daemon lifecycle or reclaim storage on the user's behalf.
+
 ## Errors, retries, and timeouts
 
 Catch stable SDK errors through `DefuzeError`:

--- a/docs/sdk-guide.zh-CN.md
+++ b/docs/sdk-guide.zh-CN.md
@@ -251,6 +251,38 @@ docker build -f examples/full_stack/Dockerfile.user-flow -t defuzex-user-flow .
 
 示例所需的工作区和运行参数见[完整流程示例指南](../examples/full_stack/USER_GUIDE.md)。
 
+### 本地 Docker 存储
+
+Docker 构建会保留本地镜像与 build cache。请定期检查 Docker Desktop 的 **Images** 和 **Builds** 页面，或用以下只读命令查看磁盘占用：
+
+```bash
+docker system df
+```
+
+确认目标不再需要后，再选择性回收空间：
+
+```bash
+docker image rm <明确镜像:标签>
+```
+
+此命令只移除指定镜像或标签；不要移除运行中容器或必要数据库依赖的镜像。
+
+```bash
+docker image prune
+```
+
+不带 `-a` 时，此命令会在确认后仅移除 dangling 镜像。确认前请检查提示信息。
+
+```bash
+docker builder prune
+```
+
+此命令会在确认后移除未使用的 build cache；请先确认可以接受后续构建变慢。使用 Docker Desktop 时，同样只删除已确认不再使用的项目镜像或构建缓存。
+
+> **警告：** 不要把 `docker system prune -a --volumes` 作为默认清理方式，也不要自动执行。它可能删除其他项目的资源、停止容器仍需的镜像、构建缓存和持久卷。切勿删除运行中的容器、必要的数据库镜像或必要的 volume。
+
+KUMA 只提供 Docker 构建与运行材料，不接管用户 Docker daemon 的生命周期，也不会代替用户回收磁盘空间。
+
 ## 错误、重试与超时
 
 通过 `DefuzeError` 捕获稳定 SDK 错误：


### PR DESCRIPTION
## Summary
- add aligned English and Simplified Chinese guidance for reviewing local Docker image and build-cache usage
- document selective, confirmation-based cleanup commands and their impact
- add one short README link per language to the canonical storage guidance

## Safety boundary
- KUMA provides Docker build and runtime materials but does not manage the Docker daemon or reclaim storage
- `docker system prune -a --volumes` is documented only as a command that must not be used or automated by default
- no Docker images, containers, volumes, or cache were inspected, started, or removed while preparing this change
- no SDK, CLI, dependency, CI, or repository-setting changes

## Validation
- 61 local Markdown links and anchors valid across 12 Markdown files
- Markdown fences balanced; 9 Python documentation blocks parsed
- English/Chinese README and SDK-guide heading structures aligned; 4/4 storage commands aligned
- Docker client help accepted `system df`, `image rm`, `image prune`, and `builder prune` without contacting the daemon
- `python -m ruff check --exclude '*.ipynb' .`
- `python -m ruff format --check --exclude '*.ipynb' .`
- `python -m compileall -q src examples`
- `python -m defuzex quickstart`
- `python examples/minimal_local.py`
- `python -m build` and `python -m twine check`
- added-line secret/boundary scan passed; 0 added legacy display-brand occurrences
- `git diff --check`