### PR TITLE
ci: add trusted PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pypi-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+      - name: Verify release commit is on main
+        run: git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+      - name: Verify release tag matches package version
+        run: |
+          python - <<'PY'
+          import os
+          from defuzex._version import __version__
+
+          tag = os.environ["RELEASE_TAG"]
+          if tag not in {__version__, f"v{__version__}"}:
+              raise SystemExit(
+                  f"Release tag {tag!r} does not match package version {__version__!r}"
+              )
+          PY
+        env:
+          PYTHONPATH: src
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+      - name: Build wheel and source distribution
+        run: python -m build
+      - name: Validate package metadata
+        run: python -m twine check dist/*
+      - name: Upload distributions
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish distributions
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1


### PR DESCRIPTION
## Summary
- add a release-only PyPI Trusted Publishing workflow
- build and validate wheel/sdist before publishing
- use GitHub OIDC with no stored PyPI token
- pin every third-party action to a full commit SHA

## Safety
- triggers only when a GitHub Release is published
- verifies the release commit belongs to `main`
- requires the release tag to match the package version
- uses the protected `pypi` GitHub environment boundary

## Validation
- workflow YAML and permission assertions passed locally
- Ruff format/check, compileall, CLI and minimal-local smoke passed
- wheel/sdist build and `twine check` passed

This PR does not publish a package and does not change the current package identity or version.