### PR TITLE
fix(ci): make release version check dependency-free

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,8 +34,9 @@ jobs:
         run: |
           python - <<'PY'
           import os
-          from kuma._version import __version__
+          import runpy
 
+          __version__ = runpy.run_path("src/kuma/_version.py")["__version__"]
           tag = os.environ["RELEASE_TAG"]
           if tag not in {__version__, f"v{__version__}"}:
               raise SystemExit(


### PR DESCRIPTION
## Fix
Read `src/kuma/_version.py` with the standard-library `runpy` module instead of importing `kuma` before runtime dependencies are installed.

The first `v0.1.0` release run stopped at this guard before build or upload; PyPI received no distributions.

## Validation
- exact guard passed under `python -S` with `RELEASE_TAG=v0.1.0`
- workflow YAML, OIDC permission, and `pypi` environment assertions passed
- no package behavior or wire contract changes