### PR TITLE
fix(package): use available PyPI distribution name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           cache: pip
       - run: python -m pip install --upgrade pip
       - run: python -m pip install .
-      - run: python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma')"
+      - run: python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma-defuzex')"
       - run: python -m kuma --help
       - run: python examples/minimal_local.py
 
@@ -57,7 +57,7 @@ jobs:
           cache: pip
       - run: python -m pip install --upgrade pip
       - run: python -m pip install .
-      - run: python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma')"
+      - run: python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma-defuzex')"
       - run: python -m kuma --help
       - run: python examples/minimal_local.py
 
@@ -72,7 +72,7 @@ jobs:
           cache: pip
       - run: python -m pip install --upgrade pip
       - run: python -m pip install .
-      - run: python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma')"
+      - run: python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma-defuzex')"
       - run: python -m kuma --help
       - run: python examples/minimal_local.py
 
@@ -93,12 +93,12 @@ jobs:
         run: |
           python -m venv /tmp/kuma-wheel
           /tmp/kuma-wheel/bin/python -m pip install dist/*.whl
-          /tmp/kuma-wheel/bin/python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma')"
+          /tmp/kuma-wheel/bin/python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma-defuzex')"
       - name: Install and verify sdist
         run: |
           python -m venv /tmp/kuma-sdist
           /tmp/kuma-sdist/bin/python -m pip install dist/*.tar.gz
-          /tmp/kuma-sdist/bin/python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma')"
+          /tmp/kuma-sdist/bin/python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma-defuzex')"
 
   docker-smoke:
     name: Docker build

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ KUMA is the public Python SDK for testing Agent behavior through a strict `Run` 
 Python 3.10 or newer is required:
 
 ```bash
-python -m pip install "kuma==0.1.0"
+python -m pip install "kuma-defuzex==0.1.0"
 ```
 
 ## Quick start

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,7 +20,7 @@ KUMA 是公开 Python SDK，通过严格的 `Run` 协议和有界 Evidence 采�
 需要 Python 3.10 或更高版本：
 
 ```bash
-python -m pip install "kuma==0.1.0"
+python -m pip install "kuma-defuzex==0.1.0"
 ```
 
 ## 快速开始

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -17,7 +17,7 @@ Windows PowerShell:
 ```powershell
 .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
-python -m pip install "kuma==0.1.0"
+python -m pip install "kuma-defuzex==0.1.0"
 ```
 
 Linux or macOS:
@@ -25,13 +25,13 @@ Linux or macOS:
 ```bash
 source .venv/bin/activate
 python -m pip install --upgrade pip
-python -m pip install "kuma==0.1.0"
+python -m pip install "kuma-defuzex==0.1.0"
 ```
 
 Optional OpenTelemetry support:
 
 ```bash
-python -m pip install "kuma[otel]==0.1.0"
+python -m pip install "kuma-defuzex[otel]==0.1.0"
 ```
 
 Contributors should use the editable development setup in [`CONTRIBUTING.md`](../CONTRIBUTING.md).

--- a/docs/sdk-guide.zh-CN.md
+++ b/docs/sdk-guide.zh-CN.md
@@ -17,7 +17,7 @@ Windows PowerShell：
 ```powershell
 .\.venv\Scripts\Activate.ps1
 python -m pip install --upgrade pip
-python -m pip install "kuma==0.1.0"
+python -m pip install "kuma-defuzex==0.1.0"
 ```
 
 Linux 或 macOS：
@@ -25,13 +25,13 @@ Linux 或 macOS：
 ```bash
 source .venv/bin/activate
 python -m pip install --upgrade pip
-python -m pip install "kuma==0.1.0"
+python -m pip install "kuma-defuzex==0.1.0"
 ```
 
 按需安装 OpenTelemetry 能力：
 
 ```bash
-python -m pip install "kuma[otel]==0.1.0"
+python -m pip install "kuma-defuzex[otel]==0.1.0"
 ```
 
 贡献者请按 [`CONTRIBUTING.md`](../CONTRIBUTING.md) 使用可编辑开发环境。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "kuma"
+name = "kuma-defuzex"
 dynamic = ["version"]
 description = "Authenticated KUMA Python SDK for Agent behavior testing services."
 readme = "README.md"

--- a/src/kuma/otel.py
+++ b/src/kuma/otel.py
@@ -17,7 +17,7 @@ try:
     )
 except ImportError as exc:  # pragma: no cover - exercised without the optional extra
     raise ImportError(
-        'OpenTelemetry Trace Evidence requires: pip install "kuma[otel]"'
+        'OpenTelemetry Trace Evidence requires: pip install "kuma-defuzex[otel]"'
     ) from exc
 
 


### PR DESCRIPTION
Use the available PyPI distribution name kuma-defuzex while preserving the public Python import and CLI name kuma. Update install documentation and package metadata smoke checks accordingly.\n\nLocal gates: Ruff format/check, compileall, deterministic quickstart, build, twine check, clean wheel install/import/CLI.