### PR TITLE
feat(otel): automatically reuse configured provider

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -244,7 +244,7 @@ typed component union，只传关联 ID、顺序、路径/大小、结果枚举�
 
 ## OpenTelemetry 适配
 
-`otel.py` 通过用户提供的 SDK `TracerProvider.add_span_processor()` 增加一个处理器。它不调用全局 `set_tracer_provider()`，因此可与已有 processor/exporter 和 instrumentation 共存。未安装 `[otel]` 时，核心包不导入 OpenTelemetry，也不改变原有行为。
+`otel.py` 通过 SDK `TracerProvider.add_span_processor()` 增加一个处理器。显式 capture 始终优先；未传 capture 时，`create_run()` 惰性复用已经配置的兼容全局 Provider，并按 Provider 身份幂等复用 capture。它不调用全局 `set_tracer_provider()`，因此可与已有 processor/exporter 和 instrumentation 共存。未安装 `[otel]` 或没有兼容 Provider 时，Run 正常继续并记录稳定的 `trace_auto_capture_unavailable`；真正的自动附着失败记录 `trace_auto_attach_failed`，两者都不阻断 Run。
 
 span 在 start 时绑定到 capture 当前唯一 active step，因此同进程线程池不依赖 `ContextVar` 继承；在 end 时才映射和导出。父 span 可以先于或后于 child 结束，JSON 使用 ID 保留关系，并按开始时间稳定排序。step prepare 会 force flush，然后冻结本次 Evidence；commit 才累计整个 Run 的字节预算，abort 可恢复同一 association。
 

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -214,7 +214,48 @@ Before official upload, KUMA scans output, errors, paths, diffs, explicit logs, 
 
 ## OpenTelemetry
 
-The optional adapter captures ended spans from the same process and current Input. It adds a standard processor to the supplied `TracerProvider`; it does not replace the application's provider:
+OpenTelemetry (OTel) is the standard observability API used by Agent frameworks and instrumentation to emit spans. KUMA maps spans that were **actually emitted in the same process** into bounded Evidence. It does not invent Agent activity and is not an OTel Collector, backend, or trace UI.
+
+Install OTel support only when trace capture is needed; the core package does not require it:
+
+```bash
+python -m pip install "kuma-defuzex[otel]"
+```
+
+`create_run()` now follows this precedence:
+
+| Environment | Run behavior | Trace behavior | Warning |
+| --- | --- | --- | --- |
+| Explicit `trace_evidence` capture | Continues | Uses the supplied capture | None |
+| Compatible global SDK `TracerProvider` already configured | Continues | Reuses it automatically | None |
+| OTel missing or no compatible global provider | Continues | No Trace Evidence | `trace_auto_capture_unavailable` |
+| Automatic attachment fails | Continues | Degrades to no Trace Evidence | `trace_auto_attach_failed` |
+
+The warnings are Evidence-completeness signals in `run.runtime_warnings`; they never block `get_input()`, `submit()`, or Judge. Installing the extra alone does not create spans. A framework or instrumentation must configure a global SDK provider and emit spans. In that common case, no KUMA-specific setup is needed:
+
+```python
+from opentelemetry import trace
+
+from kuma import create_run
+
+run = create_run(
+    repo_path=".",
+    requirement_path="requirement.md",
+    allow_local=True,
+)
+tracer = trace.get_tracer("my-agent")
+
+while (test_input := run.get_input()) is not None:
+    with tracer.start_as_current_span("agent.solve"):
+        output = my_agent(test_input)
+    report = run.submit(output)
+```
+
+If the application has no compatible provider, continue with `run.submit(output)` and optionally show a user-facing notice when `trace_auto_capture_unavailable` is present.
+
+### Explicit configuration remains supported
+
+Use the existing explicit API for a non-global provider or custom limits. Explicit capture always wins over automatic discovery, and KUMA never replaces or resets a global provider:
 
 ```python
 from opentelemetry.sdk.trace import TracerProvider
@@ -235,7 +276,7 @@ run = create_run(
 )
 ```
 
-Span counts, attributes, events, text, and total Run bytes are bounded. A restrictive allowlist excludes prompts, completions, source, log bodies, keys, and credentials. Explicit `submit(output)` remains the portable fallback; omitted output works only when supported Agent/Workflow spans expose a valid final output. KUMA does not provide an OTLP receiver, cross-process correlation, trace UI, or storage service.
+Span counts, attributes, events, text, and total Run bytes are bounded. A restrictive allowlist excludes prompts, completions, source, log bodies, keys, and credentials. Explicit `submit(output)` remains the portable fallback; omitted output works only when supported Agent/Workflow spans expose a valid final output. Automatic capture currently covers spans; ordinary logs remain governed by the existing explicit Submission log contract. KUMA does not provide an OTLP receiver, cross-process correlation, trace UI, or storage service.
 
 ## Docker and runtime security
 

--- a/docs/sdk-guide.zh-CN.md
+++ b/docs/sdk-guide.zh-CN.md
@@ -214,7 +214,48 @@ print(report)
 
 ## OpenTelemetry
 
-可选 adapter 只采集同一进程、当前 Input 中已结束的 span。它向用户提供的 `TracerProvider` 添加标准 processor，不会替换应用已有的 provider：
+OpenTelemetry（OTel）是 Agent 框架和 instrumentation 用来产生 span 的标准可观测性接口。KUMA 只把**同一进程中真实产生**的 span 映射为有界 Evidence；它不会伪造 Agent 行为，也不是 OTel Collector、后端或 Trace UI。
+
+仅在需要 Trace Evidence 时安装可选能力，核心包不强制依赖 OTel：
+
+```bash
+python -m pip install "kuma-defuzex[otel]"
+```
+
+`create_run()` 现在按以下优先级工作：
+
+| 当前环境 | Run 行为 | Trace 行为 | 提示 |
+| --- | --- | --- | --- |
+| 显式传入 `trace_evidence` capture | 正常继续 | 使用显式 capture | 无 |
+| 已配置兼容的全局 SDK `TracerProvider` | 正常继续 | 自动复用 | 无 |
+| 未安装 OTel 或没有兼容的全局 Provider | 正常继续 | 无 Trace Evidence | `trace_auto_capture_unavailable` |
+| 自动附着失败 | 正常继续 | 降级为无 Trace | `trace_auto_attach_failed` |
+
+这些 warning 只表示 Evidence 完整性，记录在 `run.runtime_warnings`，不会阻断 `get_input()`、`submit()` 或 Judge。只安装 extra 不会凭空产生 span；Agent 框架或 instrumentation 还必须配置全局 SDK Provider 并实际发出 span。常见情况下无需任何 KUMA 专属设置：
+
+```python
+from opentelemetry import trace
+
+from kuma import create_run
+
+run = create_run(
+    repo_path=".",
+    requirement_path="requirement.md",
+    allow_local=True,
+)
+tracer = trace.get_tracer("my-agent")
+
+while (test_input := run.get_input()) is not None:
+    with tracer.start_as_current_span("agent.solve"):
+        output = my_agent(test_input)
+    report = run.submit(output)
+```
+
+如果应用没有兼容 Provider，继续使用 `run.submit(output)` 即可；需要时可将 `trace_auto_capture_unavailable` 转换成面向用户的非阻断提示。
+
+### 仍然支持显式配置
+
+非全局 Provider 或自定义资源上限继续使用原有显式 API。显式 capture 始终优先于自动发现，KUMA 也永远不会替换或重置全局 Provider：
 
 ```python
 from opentelemetry.sdk.trace import TracerProvider
@@ -235,7 +276,7 @@ run = create_run(
 )
 ```
 
-span 数量、属性、事件、文本和整个 Run 的字节数均有上限。拒绝式 allowlist 会排除 prompt、completion、源码、日志正文、Key 与凭证。显式 `submit(output)` 始终是可移植的回退；只有受支持的 Agent/Workflow span 提供合法最终输出时才能省略 output。KUMA 不提供 OTLP receiver、跨进程关联、Trace UI 或存储服务。
+span 数量、属性、事件、文本和整个 Run 的字节数均有上限。拒绝式 allowlist 会排除 prompt、completion、源码、日志正文、Key 与凭证。显式 `submit(output)` 始终是可移植的回退；只有受支持的 Agent/Workflow span 提供合法最终输出时才能省略 output。自动捕获当前覆盖 span；普通日志仍遵循既有的显式 Submission 日志合同。KUMA 不提供 OTLP receiver、跨进程关联、Trace UI 或存储服务。
 
 ## Docker 与运行时安全
 

--- a/src/kuma/api.py
+++ b/src/kuma/api.py
@@ -43,6 +43,29 @@ def configure(*, api_key: str) -> Path:
     return write_api_key(api_key)
 
 
+def _resolve_trace_evidence(
+    configured: TraceEvidenceCapture | None,
+) -> tuple[TraceEvidenceCapture | None, str | None]:
+    if configured is not None:
+        if not isinstance(configured, TraceEvidenceCapture):
+            raise ConfigurationError(
+                "trace_evidence must come from kuma.otel.configure_trace_evidence()"
+            )
+        return configured, None
+    try:
+        from .otel import _automatic_trace_evidence
+    except ImportError:
+        return None, "trace_auto_capture_unavailable"
+    try:
+        capture = _automatic_trace_evidence()
+        if capture is None:
+            return None, "trace_auto_capture_unavailable"
+        return capture, None
+    except Exception:
+        # Optional observability must never turn a valid Run into a failed Run.
+        return None, "trace_auto_attach_failed"
+
+
 def _adapted_providers(
     *,
     config: CreateRunConfig,
@@ -114,7 +137,6 @@ def _create_run_config(
     timeout: float,
     operation_wait_timeout: float,
     max_retries: int,
-    trace_evidence: TraceEvidenceCapture | None,
 ) -> CreateRunConfig:
     config = resolve_create_run_config(
         {
@@ -134,12 +156,6 @@ def _create_run_config(
     )
     if config.upload_diff and not config.track_files:
         raise ConfigurationError("upload_diff requires track_files=True")
-    if trace_evidence is not None and not isinstance(
-        trace_evidence, TraceEvidenceCapture
-    ):
-        raise ConfigurationError(
-            "trace_evidence must come from kuma.otel.configure_trace_evidence()"
-        )
     return config
 
 
@@ -259,6 +275,7 @@ def _assemble_run(
     official_case: bool,
     official_judge: bool,
     trace_evidence: TraceEvidenceCapture | None,
+    trace_auto_warning: str | None,
 ) -> Run:
     requirement, context = _case_generation_context(
         resolved_repo=resolved_repo,
@@ -287,6 +304,8 @@ def _assemble_run(
         official_judge=official_judge,
         trace_evidence=trace_evidence,
     )
+    if trace_auto_warning is not None:
+        evidence.runtime_warnings.append(trace_auto_warning)
     return Run(
         run_id=run_id,
         case=case,
@@ -309,6 +328,7 @@ def _open_run(
     official_case: bool,
     official_judge: bool,
     trace_evidence: TraceEvidenceCapture | None,
+    trace_auto_warning: str | None,
 ) -> Run:
     run_id = f"run_{uuid.uuid4().hex}"
     runtime = RuntimeSession.open(
@@ -329,6 +349,7 @@ def _open_run(
             official_case=official_case,
             official_judge=official_judge,
             trace_evidence=trace_evidence,
+            trace_auto_warning=trace_auto_warning,
         )
     except BaseException:
         runtime.close()
@@ -364,8 +385,11 @@ def create_run(
     combinations are validated before the first Input can be delivered.
 
     ``allow_local`` is an explicit development escape hatch; the default runtime
-    requires SDK and Agent to share a Docker container. ``trace_evidence`` must
-    be the capture returned by :func:`kuma.otel.configure_trace_evidence`.
+    requires SDK and Agent to share a Docker container. When ``trace_evidence``
+    is omitted, an already-configured global OpenTelemetry SDK provider is
+    attached automatically; missing or unconfigured OTel only records a runtime
+    warning. Passing a capture from :func:`kuma.otel.configure_trace_evidence`
+    overrides automatic discovery.
 
     The caller owns Agent execution and must alternate :meth:`Run.get_input`
     with exactly one :meth:`Run.submit` until no Inputs remain, or call
@@ -385,8 +409,8 @@ def create_run(
         timeout=timeout,
         operation_wait_timeout=operation_wait_timeout,
         max_retries=max_retries,
-        trace_evidence=trace_evidence,
     )
+    trace_evidence, trace_auto_warning = _resolve_trace_evidence(trace_evidence)
     resolved_repo = Path(repo_path).expanduser().resolve()
     (
         adapted_case_provider,
@@ -418,6 +442,7 @@ def create_run(
         official_case=official_case,
         official_judge=official_judge,
         trace_evidence=trace_evidence,
+        trace_auto_warning=trace_auto_warning,
     )
 
 

--- a/src/kuma/otel.py
+++ b/src/kuma/otel.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import threading
+import weakref
 from collections.abc import Sequence
+from contextlib import suppress
 from typing import Any
 
 from .errors import ConfigurationError
@@ -19,6 +22,12 @@ except ImportError as exc:  # pragma: no cover - exercised without the optional 
     raise ImportError(
         'OpenTelemetry Trace Evidence requires: pip install "kuma-defuzex[otel]"'
     ) from exc
+
+
+_ATTACH_LOCK = threading.RLock()
+_ATTACHED_CAPTURES: weakref.WeakKeyDictionary[Any, TraceEvidenceCapture] = (
+    weakref.WeakKeyDictionary()
+)
 
 
 class TraceEvidenceSpanExporter(SpanExporter):
@@ -85,6 +94,22 @@ class TraceEvidenceSpanProcessor(SpanProcessor):
         self.exporter.shutdown()
 
 
+def _attach_trace_evidence(
+    provider: Any, limits: TraceEvidenceLimits | None
+) -> TraceEvidenceCapture:
+    add_processor = getattr(provider, "add_span_processor", None)
+    if not callable(add_processor):
+        raise ConfigurationError(
+            "Trace Evidence requires an SDK TracerProvider with add_span_processor()"
+        )
+    capture = TraceEvidenceCapture(limits)
+    exporter = TraceEvidenceSpanExporter(capture)
+    processor = TraceEvidenceSpanProcessor(exporter)
+    add_processor(processor)
+    capture._set_force_flush(processor.force_flush)
+    return capture
+
+
 def configure_trace_evidence(
     tracer_provider: Any | None = None,
     *,
@@ -99,17 +124,31 @@ def configure_trace_evidence(
     """
 
     provider = tracer_provider or trace.get_tracer_provider()
-    add_processor = getattr(provider, "add_span_processor", None)
-    if not callable(add_processor):
-        raise ConfigurationError(
-            "Trace Evidence requires an SDK TracerProvider with add_span_processor()"
-        )
-    capture = TraceEvidenceCapture(limits)
-    exporter = TraceEvidenceSpanExporter(capture)
-    processor = TraceEvidenceSpanProcessor(exporter)
-    add_processor(processor)
-    capture._set_force_flush(processor.force_flush)
-    return capture
+    with _ATTACH_LOCK:
+        capture = _attach_trace_evidence(provider, limits)
+        # Automatic mode can later reuse explicit configuration. Custom wrappers
+        # that cannot be weakly referenced remain available only through the
+        # explicit capture returned to their caller.
+        with suppress(TypeError):
+            _ATTACHED_CAPTURES[provider] = capture
+        return capture
+
+
+def _automatic_trace_evidence() -> TraceEvidenceCapture | None:
+    """Reuse or attach capture when the global OTel SDK is already configured."""
+
+    provider = trace.get_tracer_provider()
+    if not callable(getattr(provider, "add_span_processor", None)):
+        return None
+    with _ATTACH_LOCK:
+        try:
+            capture = _ATTACHED_CAPTURES.get(provider)
+        except TypeError:
+            return None
+        if capture is None:
+            capture = _attach_trace_evidence(provider, None)
+            _ATTACHED_CAPTURES[provider] = capture
+        return capture
 
 
 __all__ = [


### PR DESCRIPTION
## Summary

- automatically reuse an already configured global OpenTelemetry SDK `TracerProvider` when `trace_evidence` is omitted
- preserve the existing explicit `configure_trace_evidence(...)` path as the highest-priority configuration
- keep runs operational when OTel is absent, unconfigured, or automatic attachment fails, with stable Evidence-completeness warnings
- document installation, automatic behavior, explicit configuration, privacy, and same-process limits in English and Chinese

## Safety and compatibility

- does not install, replace, or reset the application's global provider
- reuses one capture per compatible provider instead of accumulating processors across sequential runs
- does not make OpenTelemetry a core dependency
- does not change Backend/Core wire contracts
- automatic capture covers actual spans emitted by existing instrumentation; ordinary logs retain their current explicit Submission contract

## Verification

- Ruff format/check: passed
- `compileall src examples`: passed
- CLI help and deterministic `minimal_local.py`: passed
- real OTel SDK global-provider capture: passed (one span, one processor across two sequential Runs)
- existing explicit-provider capture: passed
- unconfigured-provider non-blocking fallback: passed
- wheel/sdist build and Twine: passed
- clean base-wheel install without OTel plus local example: passed
- Docker user-flow image build: passed
- Markdown local links and Python fence compilation: passed
- package scope and changed-diff secret scan: passed

No network evaluation, model call, hosted Case generation, Judge, or package publication was performed.