### PR TITLE
fix(sdk): preserve Case operation until validation

### DIFF
--- a/src/kuma/providers/official_case.py
+++ b/src/kuma/providers/official_case.py
@@ -355,15 +355,18 @@ class OfficialCaseProvider:
             allow_sensitive=self.allow_sensitive,
             evidence_capabilities=self._evidence_capabilities,
         )
-        response = self._run_operation(context, payload)
-        return _normalized_case(
-            response,
-            context=context,
+        return self._run_operation(
+            context,
+            payload,
             repo_fingerprint=repo_fingerprint,
         )
 
     def _run_operation(
-        self, context: CaseGenerationContext, payload: Mapping[str, Any]
+        self,
+        context: CaseGenerationContext,
+        payload: Mapping[str, Any],
+        *,
+        repo_fingerprint: str,
     ) -> Mapping[str, Any]:
         store = _case_operation_store(
             context,
@@ -383,12 +386,20 @@ class OfficialCaseProvider:
                 **kwargs,
             )
 
+        def accept_result(response: Mapping[str, Any]) -> Mapping[str, Any]:
+            return _normalized_case(
+                response,
+                context=context,
+                repo_fingerprint=repo_fingerprint,
+            )
+
         return await_operation(
             self.client,
             store,
             key_factory=lambda: new_idempotency_key("casegen"),
             start=start_operation,
             wait_timeout=self.operation_wait_timeout,
+            accept_result=accept_result,
         )
 
 

--- a/src/kuma/transport/operations.py
+++ b/src/kuma/transport/operations.py
@@ -341,8 +341,9 @@ def await_operation(
     key_factory: Callable[[], str],
     start: StartOperation,
     wait_timeout: float,
+    accept_result: Callable[[Mapping[str, Any]], Mapping[str, Any]] | None = None,
 ) -> Mapping[str, Any]:
-    """Start or resume one operation and synchronously return its public result."""
+    """Return one accepted public result while preserving resumable state."""
 
     deadline = time.monotonic() + validate_operation_wait_timeout(wait_timeout)
     state = store.load_or_create(key_factory)
@@ -376,8 +377,9 @@ def await_operation(
             continue
         status, result, error = _poll_response(response, state.operation_id or "")
         if status == "succeeded" and result is not None:
+            accepted = result if accept_result is None else accept_result(result)
             store.clear()
-            return result
+            return accepted
         if status == "failed" and error is not None:
             store.clear()
             raise mapped_error(error[0], retryable=error[1])


### PR DESCRIPTION
## Summary
- validate the complete public Case result before clearing resumable operation state
- preserve the same operation ID and idempotency key when result validation fails
- keep callers without a result validator behavior-compatible

## Validation
- Ruff format/check
- compileall, CLI, and deterministic local quickstart
- offline operation retry regression (POST + GET, then GET-only resume)
- wheel/sdist build, Twine, install/import/version smoke
- Docker user-flow image build

No public wire, Backend, publishing, or deployment changes.