### PR TITLE
docs: define complete public API reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,8 @@ jobs:
       - run: python -m pip install ".[dev]"
       - run: python -m ruff check --exclude "*.ipynb" .
       - run: python -m ruff format --check --exclude "*.ipynb" .
-      - run: python -m compileall -q src examples
+      - run: python tools/verify_public_api_docs.py
+      - run: python -m compileall -q src examples tools
 
   test:
     name: Python ${{ matrix.python-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,8 @@ run the canonical checks:
 ```bash
 python -m ruff format --check --exclude "*.ipynb" .
 python -m ruff check --exclude "*.ipynb" .
-python -m compileall -q src examples
+python tools/verify_public_api_docs.py
+python -m compileall -q src examples tools
 kuma quickstart
 python examples/minimal_local.py
 python -m build
@@ -43,6 +44,13 @@ Maintainers run those private checks before accepting a release.
 - Never commit API keys, `.env` files, local paths, private Rubrics, model prompts,
   service addresses, databases, or user data.
 - Explain compatibility, security, and privacy effects in the pull request.
+- Keep public API documentation synchronized with signatures and behavior. Each
+  argument must state its type, required/default value, units or accepted range,
+  sentinel meaning, and security-relevant effects. Document returns, stable
+  exceptions, state/resource side effects, retries, and a minimal verified
+  example where those details are not obvious. Run
+  `python tools/verify_public_api_docs.py`; it detects signature/table drift but
+  does not replace human semantic review.
 
 By submitting a contribution, you agree that it is licensed under the Apache
 License 2.0. Report security issues privately as described in

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ kuma quickstart
 
 ## Detailed documentation
 
-[English SDK guide](docs/sdk-guide.md) · [简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [Runtime Evidence contract](docs/runtime-evidence.md)
+[English SDK guide](docs/sdk-guide.md) · [Python API reference](docs/api-reference.md) · [简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [中文 API 参考](docs/api-reference.zh-CN.md) · [Runtime Evidence contract](docs/runtime-evidence.md)
 
 ## Project
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,7 +39,7 @@ kuma quickstart
 
 ## 详细文档
 
-[简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [English SDK guide](docs/sdk-guide.md) · [Runtime Evidence 合同](docs/runtime-evidence.md)
+[简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [中文 API 参考](docs/api-reference.zh-CN.md) · [English SDK guide](docs/sdk-guide.md) · [Python API reference](docs/api-reference.md) · [Runtime Evidence 合同](docs/runtime-evidence.md)
 
 ## 项目链接
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,209 @@
+# KUMA Python API reference
+
+[简体中文](api-reference.zh-CN.md) | English
+
+This page documents the stable user-facing Python entry points. Types, defaults,
+ranges, side effects, and failure behavior match the current implementation.
+KUMA uses keyword-only arguments for its main APIs so call sites remain readable.
+
+## `configure`
+
+```python
+from kuma import configure
+
+credential_path = configure(api_key="dfx_your_key_here")
+```
+
+<!-- api-parameters:configure:start -->
+
+| Argument | Type | Required/default | Meaning |
+| --- | --- | --- | --- |
+| `api_key` | `str` | Required | Printable ASCII KUMA credential beginning with `dfx_`; maximum 512 encoded bytes, with no whitespace or control characters. |
+
+<!-- api-parameters:configure:end -->
+
+Returns the absolute `Path` of the atomically written user credential file. The
+function makes no network request. `KUMA_CONFIG_HOME` redirects the credential
+directory. Invalid keys raise `ConfigurationError`; filesystem failures remain
+real `OSError` values. The file contains the key and must never be printed or
+committed.
+
+## `create_run`
+
+```python
+from kuma import create_run
+
+run = create_run(
+    repo_path=".",
+    requirement_path="requirement.md",
+)
+```
+
+<!-- api-parameters:create_run:start -->
+
+| Argument | Type | Required/default | Meaning |
+| --- | --- | --- | --- |
+| `repo_path` | `str \| os.PathLike[str]` | `"."` | Repository root visible to the Agent. It is expanded and resolved to an absolute path. |
+| `requirement_path` | `str \| os.PathLike[str] \| None` | `None` | UTF-8 requirement file. Official Case generation requires it; a custom Provider can explicitly opt out. |
+| `case_provider` | `CaseProvider \| callable \| None` | `None` | Custom Case source. `None` uses the official authenticated Provider. |
+| `judge_provider` | `JudgeProvider \| callable \| None` | `None` | Custom Judge. `None` uses the official Provider when `judge=True`. |
+| `strategy` | `str` | `"auto"` | `"auto"` delegates selection to the service; another non-empty value is an explicit strategy ID. Unknown strategies are not silently replaced. |
+| `max_inputs` | `int \| None` | `None` | Positive Case Input upper bound. Custom Case Providers require a value; official mode uses the public service policy when omitted. |
+| `judge` | `bool` | `True` | Run the configured Judge after the final Submission. `False` leaves `run.report` as `None`. |
+| `on_failure` | `str` | `"continue"` | `"continue"` advances after `failed`, `timeout`, or `aborted`; `"stop"` closes the Run immediately. |
+| `allow_local` | `bool` | `False` | Permit trusted development outside Docker. This does not sandbox the Agent or relax validation/privacy rules. |
+| `track_files` | `bool` | `True` | Capture bounded file metadata before and after each Input. |
+| `upload_diff` | `bool` | `False` | Include bounded text diffs. Requires `track_files=True` and may expose repository text to the configured Judge. |
+| `save_local` | `bool` | `False` | Atomically save Submission JSON under `.kuma/runs/<run_id>/`. It does not replace official submission. |
+| `allow_sensitive` | `bool` | `False` | Allow ordinary Evidence flagged by the scanner. It never relaxes the OTel allowlist. |
+| `timeout` | `float` | `300.0` seconds | Positive finite timeout for one public HTTP attempt. This is not the total operation wait. |
+| `operation_wait_timeout` | `float` | `600.0` seconds | Positive finite total wait for one official asynchronous Case or Judge operation. Timeout preserves recovery metadata. |
+| `max_retries` | `int` | `2` | Automatic transient retry count, inclusive range 0–5. Idempotent POST retries reuse one key. |
+| `api_key` | `str \| None` | `None` | Per-call `dfx_` key. Resolution order is this value, `KUMA_API_KEY`, then the user credential file. |
+| `trace_evidence` | `TraceEvidenceCapture \| None` | `None` | Explicit capture returned by `configure_trace_evidence()`. When omitted, KUMA attempts safe global-provider reuse and otherwise adds a non-blocking warning. |
+
+<!-- api-parameters:create_run:end -->
+
+Returns a synchronous `Run` in `ready` state. Configuration, credential,
+isolation, Provider, Case, and public-service failures raise a `KumaError`
+subclass with stable `code`, `retryable`, and optional `request_id` fields.
+Creating a Run may read the requirement and bounded repository metadata, create
+`.kuma/`, acquire the one-active-Run lock, and call the public Backend when an
+official Provider is selected.
+
+## `Run`
+
+### `get_input`
+
+<!-- api-parameters:get_input:start -->
+
+| Argument | Type | Required/default | Meaning |
+| --- | --- | --- | --- |
+| `full` | `bool` | `False` | `False` returns only the JSON-compatible payload; `True` returns immutable `KumaInput` metadata and payload. |
+
+<!-- api-parameters:get_input:end -->
+
+Returns the current Input without advancing, or `None` after all Inputs are
+committed. Repeated calls before `submit()` return the same Input. Invalid Run
+ordering raises `InputProtocolError`.
+
+### `submit`
+
+<!-- api-parameters:submit:start -->
+
+| Argument | Type | Required/default | Meaning |
+| --- | --- | --- | --- |
+| `output` | finite JSON-compatible value | Omitted | Agent result. Explicit output wins; omission is valid for `completed` only when supported OTel instrumentation supplied a final Agent/Workflow output. Explicit `None` is not a completed result. |
+| `status` | `str` | `"completed"` | One of `"completed"`, `"failed"`, `"timeout"`, or `"aborted"`. |
+| `error` | `str \| None` | `None` | Caller-safe summary for a non-completed Submission. Never include secrets or raw tracebacks. |
+| `logs` | `list[str \| Path] \| None` | `None` | Log files whose bounded new bytes are captured. Evidence must be enabled; scope and sensitive-data checks apply. |
+| `wait` | `bool` | `True` | Keep `True` when the final Submission triggers Judge. Background Judge polling is not public API. |
+
+<!-- api-parameters:submit:end -->
+
+Returns `TestReport` only when the final Submission completes Judge; otherwise
+returns `None`. Submission, Evidence offsets, local records, and Trace byte budget
+commit transactionally. Invalid output/state raises `ValidationError` or
+`InputProtocolError`; capture and Judge failures remain stable `KumaError` values.
+
+### `judge`
+
+<!-- api-parameters:judge:start -->
+
+| Argument | Type | Required/default | Meaning |
+| --- | --- | --- | --- |
+| `wait` | `bool` | `True` | Must remain `True`; official operation polling is synchronous and bounded internally. |
+
+<!-- api-parameters:judge:end -->
+
+Returns the validated `TestReport`. A failed attempt restores `completed` state,
+so retry reuses History and pending operation metadata. Calling before completion
+raises `InputProtocolError`; `wait=False` raises `ConfigurationError`.
+
+### `cancel`
+
+`cancel()` has no arguments and returns `None`. It releases Evidence state,
+temporary runtime files, and the active-Run lock. Repeated cancellation is safe;
+invalid commit/failure states raise `InputProtocolError`.
+
+### Read-only properties
+
+| Property | Type | Meaning |
+| --- | --- | --- |
+| `run_id` | `str` | Public identifier generated for this Run. |
+| `case_id` | `str` | Public Case identifier; never contains a private Rubric. |
+| `state` | `RunState` | Current lifecycle state. |
+| `history` | `tuple[HistoryItem, ...]` | Immutable committed Input/Submission pairs. |
+| `report` | `TestReport \| None` | Final validated Judgment after `report_ready`. |
+| `runtime_warnings` | `tuple[str, ...]` | Stable non-fatal Evidence degradation codes. |
+
+## `KumaClient`
+
+Use `KumaClient` for authenticated configuration reads without opening a Run.
+
+<!-- api-parameters:KumaClient:start -->
+
+| Argument | Type | Required/default | Meaning |
+| --- | --- | --- | --- |
+| `api_key` | `str \| None` | `None` | Optional `dfx_` key using the normal environment/file fallback. Read methods require a resolved key. |
+| `base_url` | `str` | Public KUMA URL | Public Backend API base. Remote URLs require HTTPS; loopback HTTP is allowed for local integration. Credentials in URLs are rejected. |
+| `timeout` | `float` | `30.0` seconds | Positive finite timeout for each GET request. |
+| `transport` | public transport callable \| `None` | `None` | Explicit test/integration HTTP boundary. Ordinary users should not provide it. |
+
+<!-- api-parameters:KumaClient:end -->
+
+`entitlements()`, `strategies()`, and `judge_config()` take no arguments and
+return validated public mappings. They may raise `KumaAuthenticationError`,
+`KumaPermissionError`, or `KumaRateLimitError`; none contacts MCP, a model, or a
+database directly.
+
+## OpenTelemetry
+
+Install `kuma-defuzex[otel]` before importing `kuma.otel`.
+
+<!-- api-parameters:configure_trace_evidence:start -->
+
+| Argument | Type | Required/default | Meaning |
+| --- | --- | --- | --- |
+| `tracer_provider` | OTel SDK Provider \| `None` | `None` | Existing Provider exposing `add_span_processor`; `None` selects the current global Provider. KUMA never replaces it. |
+| `limits` | `TraceEvidenceLimits \| None` | `None` | Bounded capture configuration. `None` uses the defaults below. |
+
+<!-- api-parameters:configure_trace_evidence:end -->
+
+Returns a `TraceEvidenceCapture` for `create_run(trace_evidence=...)`. Invalid
+Providers or limits raise `ConfigurationError`.
+
+<!-- api-parameters:TraceEvidenceLimits:start -->
+
+| Argument | Type | Required/default | Meaning |
+| --- | --- | --- | --- |
+| `max_spans` | positive `int` | `200` | Maximum ended spans retained per Run. |
+| `max_attributes` | positive `int` | `32` | Maximum allowlisted attributes retained per span. |
+| `max_events_per_span` | positive `int` | `20` | Maximum allowlisted events retained per span. |
+| `max_text_length` | positive `int` | `256` characters | Maximum retained Unicode characters for one allowed text value. |
+| `max_total_bytes` | positive `int` | `512000` bytes | Maximum compact JSON bytes across committed Trace envelopes for one Run; must fit the minimum envelope. |
+
+<!-- api-parameters:TraceEvidenceLimits:end -->
+
+## Public result contracts
+
+The main immutable contracts are exported from `kuma`:
+
+| Type | Important fields and meaning |
+| --- | --- |
+| `KumaInput` | `run_id`, `case_id`, `input_id`, zero-based `index`, `payload_type`, frozen `payload`, public constraints, schema version, and public extensions. |
+| `Submission` | Correlated IDs, terminal step `status`, JSON output/error, capture completeness, bounded logs/file Evidence, dropped/missing counters, schema version, and extensions. |
+| `HistoryItem` | One `KumaInput` paired with its ID-matching `Submission`. |
+| `TestReport` | `report_id`, `run_id`, `status` (`pass`, `issue`, or `insufficient_evidence`), confidence, stop reason, public issues/evidence gaps, and extensions. |
+| `CaptureStatus` | Completeness for file snapshot/diff, logs, sensitive scan, and traces. Each component is `complete`, `partial`, `failed`, or `skipped`. |
+
+Private Rubrics, prompts, model settings, and Core records are not part of these
+objects. The hash-only upload format is defined separately in the
+[Runtime Evidence contract](runtime-evidence.md).
+
+## Error fields
+
+Catch `KumaError` for normal SDK failures. `str(exc)` is a safe user-facing
+message. Program logic should use `exc.code`, `exc.retryable`, and
+`exc.request_id`; `exc.details` is a bounded public mapping and should be logged
+only through an application-approved allowlist.

--- a/docs/api-reference.zh-CN.md
+++ b/docs/api-reference.zh-CN.md
@@ -1,0 +1,177 @@
+# KUMA Python API 参考
+
+简体中文 | [English](api-reference.md)
+
+本文记录稳定的用户侧 Python API。参数类型、默认值、范围、副作用和失败语义均以当前实现为准。KUMA 的主要 API 使用仅关键字参数，调用时应保留参数名。
+
+## `configure`
+
+```python
+from kuma import configure
+
+credential_path = configure(api_key="dfx_your_key_here")
+```
+
+<!-- api-parameters:configure:start -->
+
+| 参数 | 类型 | 必填/默认值 | 用法 |
+| --- | --- | --- | --- |
+| `api_key` | `str` | 必填 | 以 `dfx_` 开头的可打印 ASCII KUMA 凭证；编码后最多 512 字节，不允许空白或控制字符。 |
+
+<!-- api-parameters:configure:end -->
+
+返回原子写入的用户凭证文件绝对 `Path`，不发送网络请求。`KUMA_CONFIG_HOME` 可改变凭证目录。非法 Key 抛出 `ConfigurationError`，文件系统失败保留为真实 `OSError`。该文件含 Key，禁止打印或提交。
+
+## `create_run`
+
+```python
+from kuma import create_run
+
+run = create_run(repo_path=".", requirement_path="requirement.md")
+```
+
+<!-- api-parameters:create_run:start -->
+
+| 参数 | 类型 | 必填/默认值 | 用法 |
+| --- | --- | --- | --- |
+| `repo_path` | `str \| os.PathLike[str]` | `"."` | Agent 可见的仓库根目录；会展开并解析成绝对路径。 |
+| `requirement_path` | `str \| os.PathLike[str] \| None` | `None` | UTF-8 Requirement 文件。官方 Case 必须提供；自定义 Provider 可明确不要求。 |
+| `case_provider` | `CaseProvider \| callable \| None` | `None` | 自定义 Case 来源；`None` 使用官方鉴权 Provider。 |
+| `judge_provider` | `JudgeProvider \| callable \| None` | `None` | 自定义 Judge；当 `judge=True` 时，`None` 使用官方 Provider。 |
+| `strategy` | `str` | `"auto"` | `"auto"` 让服务选择；其他非空值是显式策略 ID。未知策略不会被静默替换。 |
+| `max_inputs` | `int \| None` | `None` | 正整数 Case Input 上限。自定义 Case Provider 必须提供；官方模式省略时遵循公开服务策略。 |
+| `judge` | `bool` | `True` | 最后一次 Submission 后执行 Judge；`False` 时 `run.report` 保持 `None`。 |
+| `on_failure` | `str` | `"continue"` | `"continue"` 在 failed/timeout/aborted 后继续；`"stop"` 立即结束 Run。 |
+| `allow_local` | `bool` | `False` | 允许可信的非 Docker 开发运行；不会创建沙箱，也不会放松校验或隐私规则。 |
+| `track_files` | `bool` | `True` | 每个 Input 前后采集有界文件元数据。 |
+| `upload_diff` | `bool` | `False` | 加入有界文本 diff；要求 `track_files=True`，并可能把仓库文本交给所配置的 Judge。 |
+| `save_local` | `bool` | `False` | 原子保存 Submission JSON 到 `.kuma/runs/<run_id>/`；不替代官方提交。 |
+| `allow_sensitive` | `bool` | `False` | 允许普通 Evidence 中被扫描器命中的内容；绝不放宽 OTel allowlist。 |
+| `timeout` | `float` | `300.0` 秒 | 单次公网 HTTP 尝试的正有限超时，不是整个 operation 的等待时间。 |
+| `operation_wait_timeout` | `float` | `600.0` 秒 | 一次官方异步 Case/Judge operation 的正有限总等待上限；超时保留恢复元数据。 |
+| `max_retries` | `int` | `2` | 自动瞬态重试次数，范围 0–5；幂等 POST 重试复用同一个 Key。 |
+| `api_key` | `str \| None` | `None` | 本次调用的 `dfx_` Key；解析顺序为本参数、`KUMA_API_KEY`、用户凭证文件。 |
+| `trace_evidence` | `TraceEvidenceCapture \| None` | `None` | `configure_trace_evidence()` 返回的显式 capture；省略时安全尝试复用全局 Provider，否则仅记录非阻断 warning。 |
+
+<!-- api-parameters:create_run:end -->
+
+返回处于 `ready` 状态的同步 `Run`。配置、凭证、隔离、Provider、Case 或公网服务失败会抛出具体 `KumaError` 子类，并提供稳定的 `code`、`retryable` 和可选 `request_id`。创建过程可能读取 Requirement 和有界仓库元数据、创建 `.kuma/`、获取单 active Run 锁，并在使用官方 Provider 时调用公开 Backend。
+
+## `Run`
+
+### `get_input`
+
+<!-- api-parameters:get_input:start -->
+
+| 参数 | 类型 | 必填/默认值 | 用法 |
+| --- | --- | --- | --- |
+| `full` | `bool` | `False` | `False` 仅返回 JSON-compatible payload；`True` 返回不可变 `KumaInput` 元数据和 payload。 |
+
+<!-- api-parameters:get_input:end -->
+
+返回当前 Input 且不推进状态；全部提交后返回 `None`。在 `submit()` 前重复调用返回同一个 Input。非法顺序抛出 `InputProtocolError`。
+
+### `submit`
+
+<!-- api-parameters:submit:start -->
+
+| 参数 | 类型 | 必填/默认值 | 用法 |
+| --- | --- | --- | --- |
+| `output` | 有限 JSON-compatible 值 | 省略 | Agent 结果。显式值优先；仅当受支持 OTel instrumentation 提供最终 Agent/Workflow 输出时，completed Submission 才能省略。显式 `None` 不是成功结果。 |
+| `status` | `str` | `"completed"` | 只能是 `"completed"`、`"failed"`、`"timeout"` 或 `"aborted"`。 |
+| `error` | `str \| None` | `None` | 非 completed Submission 的安全摘要；不得包含 secret 或原始 traceback。 |
+| `logs` | `list[str \| Path] \| None` | `None` | 采集有界新增内容的日志文件；必须启用 Evidence，且仍受目录与敏感数据校验。 |
+| `wait` | `bool` | `True` | 最后一次 Submission 触发 Judge 时必须保持 `True`；公共 API 不暴露后台轮询。 |
+
+<!-- api-parameters:submit:end -->
+
+只有最后一次 Submission 完成 Judge 时返回 `TestReport`，其他情况返回 `None`。Submission、Evidence offset、本地记录和 Trace 字节预算按事务提交。非法输出/状态抛出 `ValidationError` 或 `InputProtocolError`；采集和 Judge 失败保留稳定 `KumaError`。
+
+### `judge`
+
+<!-- api-parameters:judge:start -->
+
+| 参数 | 类型 | 必填/默认值 | 用法 |
+| --- | --- | --- | --- |
+| `wait` | `bool` | `True` | 必须为 `True`；官方 operation 在内部同步、有界轮询。 |
+
+<!-- api-parameters:judge:end -->
+
+返回验证后的 `TestReport`。失败时恢复 `completed`，重试会复用 History 和 pending operation。Run 未完成时抛出 `InputProtocolError`；`wait=False` 抛出 `ConfigurationError`。
+
+### `cancel`
+
+`cancel()` 没有参数并返回 `None`，会释放 Evidence 状态、临时运行文件和 active Run 锁。重复取消安全；不允许隐藏提交中/失败状态时抛出 `InputProtocolError`。
+
+### 只读属性
+
+| 属性 | 类型 | 含义 |
+| --- | --- | --- |
+| `run_id` | `str` | 当前 Run 的公开标识。 |
+| `case_id` | `str` | 公开 Case 标识，不包含 Private Rubric。 |
+| `state` | `RunState` | 当前生命周期状态。 |
+| `history` | `tuple[HistoryItem, ...]` | 已提交的不可变 Input/Submission 对。 |
+| `report` | `TestReport \| None` | `report_ready` 后的最终验证 Judgment。 |
+| `runtime_warnings` | `tuple[str, ...]` | 非致命 Evidence 降级稳定代码。 |
+
+## `KumaClient`
+
+不创建 Run、只读取鉴权配置时使用 `KumaClient`。
+
+<!-- api-parameters:KumaClient:start -->
+
+| 参数 | 类型 | 必填/默认值 | 用法 |
+| --- | --- | --- | --- |
+| `api_key` | `str \| None` | `None` | 可选 `dfx_` Key，沿用环境变量/凭证文件回退；读取方法必须最终取得 Key。 |
+| `base_url` | `str` | KUMA 公开 URL | 公开 Backend API base；远程地址必须 HTTPS，本地集成可用 loopback HTTP，拒绝 URL credentials。 |
+| `timeout` | `float` | `30.0` 秒 | 每次公开配置 GET 请求的正有限超时；不控制 Run operation 的总等待时间。 |
+| `transport` | 公共 transport callable \| `None` | `None` | 测试/集成 HTTP 边界；普通用户不要传。 |
+
+<!-- api-parameters:KumaClient:end -->
+
+`entitlements()`、`strategies()` 和 `judge_config()` 均无参数，返回验证后的公开 mapping。它们可能抛出 `KumaAuthenticationError`、`KumaPermissionError` 或 `KumaRateLimitError`，不会直连 MCP、模型或数据库。
+
+## OpenTelemetry
+
+导入 `kuma.otel` 前安装 `kuma-defuzex[otel]`。
+
+<!-- api-parameters:configure_trace_evidence:start -->
+
+| 参数 | 类型 | 必填/默认值 | 用法 |
+| --- | --- | --- | --- |
+| `tracer_provider` | OTel SDK Provider \| `None` | `None` | 现有且提供 `add_span_processor` 的 Provider；`None` 选择当前全局 Provider，KUMA 绝不替换它。 |
+| `limits` | `TraceEvidenceLimits \| None` | `None` | 有界采集配置；`None` 使用下列默认值。 |
+
+<!-- api-parameters:configure_trace_evidence:end -->
+
+返回供 `create_run(trace_evidence=...)` 使用的 `TraceEvidenceCapture`；非法 Provider 或限制抛出 `ConfigurationError`。
+
+<!-- api-parameters:TraceEvidenceLimits:start -->
+
+| 参数 | 类型 | 必填/默认值 | 用法 |
+| --- | --- | --- | --- |
+| `max_spans` | 正 `int` | `200` | 单 Run 最多保留的结束 span 数。 |
+| `max_attributes` | 正 `int` | `32` | 每个 span 最多保留的 allowlisted attributes 数。 |
+| `max_events_per_span` | 正 `int` | `20` | 每个 span 最多保留的 allowlisted events 数。 |
+| `max_text_length` | 正 `int` | `256` 字符 | 单个允许文本值最多保留的 Unicode 字符数。 |
+| `max_total_bytes` | 正 `int` | `512000` 字节 | 单 Run 已提交 Trace envelope 的紧凑 JSON 总字节上限；必须能容纳最小 envelope。 |
+
+<!-- api-parameters:TraceEvidenceLimits:end -->
+
+## 公共结果契约
+
+主要不可变类型从 `kuma` 导出：
+
+| 类型 | 重要字段与含义 |
+| --- | --- |
+| `KumaInput` | `run_id`、`case_id`、`input_id`、从零开始的 `index`、`payload_type`、冻结的 `payload`、公开 constraints、schema version 和公开 extensions。 |
+| `Submission` | 关联 ID、步骤终态 `status`、JSON output/error、采集完整性、有界 logs/file Evidence、dropped/missing 计数、schema version 和 extensions。 |
+| `HistoryItem` | 一个 `KumaInput` 与 ID 完全匹配的 `Submission`。 |
+| `TestReport` | `report_id`、`run_id`、`status`（`pass`、`issue` 或 `insufficient_evidence`）、confidence、stop reason、公开 issues/evidence gaps 和 extensions。 |
+| `CaptureStatus` | file snapshot/diff、logs、sensitive scan、traces 的完整性；每项为 `complete`、`partial`、`failed` 或 `skipped`。 |
+
+这些对象不包含 Private Rubric、Prompt、模型设置或 Core 记录。仅哈希上传格式见 [Runtime Evidence 合同](runtime-evidence.md)。
+
+## 错误字段
+
+普通 SDK 失败统一捕获 `KumaError`。`str(exc)` 是安全的用户文案；程序判断使用 `exc.code`、`exc.retryable` 和 `exc.request_id`。`exc.details` 是有界公开 mapping，也只应通过应用自己的 allowlist 记录。

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -175,28 +175,10 @@ Repeated `get_input()` calls before `submit()` return the same Input. Invalid or
 
 ### `create_run()` parameters
 
-| Parameter | Default | Purpose |
-|---|---:|---|
-| `repo_path` | `"."` | Repository evaluated by the Agent |
-| `requirement_path` | `None` | Requirement file; official Case Providers require it |
-| `case_provider` | `None` | Custom Case Provider; omitted selects the official Provider |
-| `judge_provider` | `None` | Custom Judge Provider; omitted selects the official Provider when judging |
-| `strategy` | `"auto"` | Automatic selection or an explicit strategy ID |
-| `max_inputs` | `None` | Positive Input bound; required for custom Cases |
-| `judge` | `True` | Run the configured Judge after the final Input |
-| `on_failure` | `"continue"` | Continue or stop after a failed submission |
-| `allow_local` | `False` | Permit trusted development outside Docker |
-| `track_files` | `True` | Capture bounded file metadata around each Input |
-| `upload_diff` | `False` | Include bounded text diffs in file Evidence |
-| `save_local` | `False` | Save submission records under `.kuma/runs/` |
-| `allow_sensitive` | `False` | Explicit override for ordinary Evidence scanning; does not relax Trace allowlists |
-| `timeout` | `300.0` | Per-request public HTTP timeout in seconds |
-| `operation_wait_timeout` | `600.0` | Total wait bound for one official Case or Judge operation |
-| `max_retries` | `2` | Automatic transient retry count, from 0 through 5 |
-| `api_key` | `None` | Per-call credential with highest precedence |
-| `trace_evidence` | `None` | Capture returned by `configure_trace_evidence()` |
-
-`on_failure` accepts only `continue` or `stop`. The Python API is synchronous; `wait=False` is not supported.
+The [Python API reference](api-reference.md#create_run) is authoritative for
+every argument's type, default, accepted values, side effects, return value, and
+failure behavior. `on_failure` accepts only `continue` or `stop`. The Python API
+is synchronous and does not support `wait=False`.
 
 ## Evidence, files, logs, and privacy
 
@@ -325,6 +307,7 @@ An operation timeout retains bounded recovery metadata without storing credentia
 ## Reference
 
 - [Architecture](architecture.md)
+- [Python API reference](api-reference.md)
 - [Public API contract](api-contract.md)
 - [Runtime Evidence contract](runtime-evidence.md)
 - [Minimal local example](../examples/minimal_local.py)

--- a/docs/sdk-guide.zh-CN.md
+++ b/docs/sdk-guide.zh-CN.md
@@ -175,28 +175,7 @@ print(report)
 
 ### `create_run()` 参数
 
-| 参数 | 默认值 | 用途 |
-|---|---:|---|
-| `repo_path` | `"."` | Agent 被测仓库 |
-| `requirement_path` | `None` | Requirement 文件；官方 Case Provider 必填 |
-| `case_provider` | `None` | 自定义 Case Provider；省略时使用官方 Provider |
-| `judge_provider` | `None` | 自定义 Judge Provider；启用 Judge 且省略时使用官方 Provider |
-| `strategy` | `"auto"` | 自动选择或显式 strategy ID |
-| `max_inputs` | `None` | 正数 Input 上限；自定义 Case 必填 |
-| `judge` | `True` | 最后一个 Input 后运行已配置的 Judge |
-| `on_failure` | `"continue"` | Submission 失败后继续或停止 |
-| `allow_local` | `False` | 允许在 Docker 外进行可信开发运行 |
-| `track_files` | `True` | 在每个 Input 前后采集有界文件元数据 |
-| `upload_diff` | `False` | 在文件 Evidence 中加入有界文本 diff |
-| `save_local` | `False` | 将 Submission 记录保存到 `.kuma/runs/` |
-| `allow_sensitive` | `False` | 显式覆盖普通 Evidence 扫描；不会放宽 Trace allowlist |
-| `timeout` | `300.0` | 单次公开 HTTP 请求超时，单位为秒 |
-| `operation_wait_timeout` | `600.0` | 单次官方 Case 或 Judge operation 的总等待上限 |
-| `max_retries` | `2` | 瞬态失败自动重试次数，取值 0 至 5 |
-| `api_key` | `None` | 优先级最高的本次调用凭证 |
-| `trace_evidence` | `None` | `configure_trace_evidence()` 返回的 capture |
-
-`on_failure` 只接受 `continue` 或 `stop`。Python API 保持同步，不支持 `wait=False`。
+[Python API 参考](api-reference.zh-CN.md#create_run)是每个参数的类型、默认值、允许值、副作用、返回值和失败行为的权威说明。`on_failure` 只接受 `continue` 或 `stop`。Python API 保持同步，不支持 `wait=False`。
 
 ## Evidence、文件、日志与隐私
 
@@ -325,6 +304,7 @@ operation 超时只保留有界恢复元数据，不保存凭证、请求正文�
 ## 参考
 
 - [架构](architecture.md)
+- [Python API 参考](api-reference.zh-CN.md)
 - [公开 API Contract](api-contract.md)
 - [Runtime Evidence 合同](runtime-evidence.md)
 - [最小本地示例](../examples/minimal_local.py)

--- a/src/kuma/api.py
+++ b/src/kuma/api.py
@@ -35,9 +35,22 @@ from .transport.backend import DEFAULT_BASE_URL, BackendClient
 def configure(*, api_key: str) -> Path:
     """Validate and atomically persist an API key in the user credential store.
 
-    The function returns the written path and performs no network request.
-    ``KUMA_CONFIG_HOME`` can redirect the user-level location for isolated
-    development and tests.
+    Args:
+        api_key: Printable ASCII KUMA credential beginning with ``dfx_``. The
+            encoded value must be at most 512 bytes and contain no whitespace or
+            control characters.
+
+    Returns:
+        Absolute path of the atomically written ``credentials.json`` file.
+
+    Raises:
+        ConfigurationError: The key format is invalid or a credential location
+            cannot be resolved.
+        OSError: The credential directory or file cannot be written.
+
+    This function performs no network request. ``KUMA_CONFIG_HOME`` redirects
+    the user-level location for isolated development and tests. The file contains
+    the credential, so callers must not print or commit it.
     """
 
     return write_api_key(api_key)
@@ -379,21 +392,55 @@ def create_run(
 ) -> Run:
     """Create one complete Case and return its synchronous strict-handshake Run.
 
-    Official Providers use the deployed authenticated Backend endpoints. Custom
-    Providers remain entirely local unless paired with an official Provider.
-    Runtime, requirement, repository metadata, Case output, and Provider
-    combinations are validated before the first Input can be delivered.
+    Args:
+        repo_path: Repository root visible to the Agent. Defaults to the current
+            directory and is resolved to an absolute path.
+        requirement_path: UTF-8 requirement file used for Case generation.
+            Official Case generation requires it; a custom Provider may opt out.
+        case_provider: ``CaseProvider`` or compatible callable. ``None`` selects
+            the official authenticated Provider.
+        judge_provider: ``JudgeProvider`` or compatible callable. ``None``
+            selects the official Provider when ``judge=True``.
+        strategy: ``"auto"`` or an explicit server strategy ID. The SDK never
+            invents or silently substitutes an unknown strategy.
+        max_inputs: Positive upper bound for Case Inputs. Custom Case Providers
+            require an explicit value; ``None`` uses the official service policy.
+        judge: Whether to request a final Judgment after the last Submission.
+        on_failure: ``"continue"`` advances after a non-completed Submission;
+            ``"stop"`` closes the Run immediately.
+        allow_local: Permit a trusted non-Docker development run. It does not
+            create a sandbox or relax privacy and protocol validation.
+        track_files: Capture bounded file metadata before and after each Input.
+        upload_diff: Include bounded text diffs; requires ``track_files=True``
+            and may expose repository text to the configured Judge.
+        save_local: Persist structured Submission records beneath
+            ``.kuma/runs/<run_id>/`` using atomic replacement.
+        allow_sensitive: Permit ordinary Evidence that triggers the sensitive
+            scanner. It never relaxes the OpenTelemetry allowlist.
+        timeout: Positive finite per-request HTTP timeout in seconds.
+        operation_wait_timeout: Positive finite total wait in seconds for one
+            official asynchronous Case or Judge operation.
+        max_retries: Automatic transient HTTP retries, inclusive range 0 through
+            5. Idempotent POST retries reuse the same request key.
+        api_key: Per-call ``dfx_`` credential. ``None`` falls back to
+            ``KUMA_API_KEY`` and then the user credential file.
+        trace_evidence: Capture returned by
+            :func:`kuma.otel.configure_trace_evidence`. ``None`` attempts to
+            reuse a compatible configured global OTel Provider and otherwise
+            records a non-blocking runtime warning.
 
-    ``allow_local`` is an explicit development escape hatch; the default runtime
-    requires SDK and Agent to share a Docker container. When ``trace_evidence``
-    is omitted, an already-configured global OpenTelemetry SDK provider is
-    attached automatically; missing or unconfigured OTel only records a runtime
-    warning. Passing a capture from :func:`kuma.otel.configure_trace_evidence`
-    overrides automatic discovery.
+    Returns:
+        A synchronous :class:`kuma.run.Run` in ``ready`` state.
 
-    The caller owns Agent execution and must alternate :meth:`Run.get_input`
-    with exactly one :meth:`Run.submit` until no Inputs remain, or call
-    :meth:`Run.cancel` when abandoning the Run.
+    Raises:
+        KumaError: Configuration, authentication, Provider, runtime isolation,
+            Case validation, or public service validation fails. The concrete
+            subclass exposes stable ``code`` and ``retryable`` fields.
+
+    Official Providers use only the public Backend. Custom Providers remain
+    local unless paired with an official Provider. The caller owns Agent
+    execution and must alternate :meth:`Run.get_input` with one
+    :meth:`Run.submit`, or call :meth:`Run.cancel` when abandoning the Run.
     """
 
     config = _create_run_config(

--- a/src/kuma/client.py
+++ b/src/kuma/client.py
@@ -28,7 +28,24 @@ Transport = WireTransport
 
 
 class KumaClient:
-    """Compatibility client for account and public service configuration reads."""
+    """Read account and public service configuration without creating a Run.
+
+    Args:
+        api_key: Optional ``dfx_`` credential. ``None`` resolves
+            ``KUMA_API_KEY`` and then the user credential file. Construction may
+            remain unauthenticated, but read methods then raise
+            ``KumaAuthenticationError``.
+        base_url: Public Backend API base URL. Remote URLs require HTTPS;
+            loopback HTTP is accepted for local integration.
+        timeout: Positive finite timeout in seconds for each GET request.
+        transport: Optional test/integration transport implementing the public
+            wire callable contract. Ordinary users should leave it as ``None``.
+
+    Raises:
+        ConfigurationError: The URL, timeout, or resolved credential is invalid.
+
+    The client never contacts MCP, model providers, or databases directly.
+    """
 
     def __init__(
         self,
@@ -81,17 +98,25 @@ class KumaClient:
             ) from None
 
     def entitlements(self) -> Mapping[str, Any]:
-        """Return user, key scopes, subscription, and quota information."""
+        """Return public user, key-scope, subscription, and quota information.
+
+        Raises ``KumaAuthenticationError``, ``KumaPermissionError``, or
+        ``KumaRateLimitError`` for the corresponding public HTTP boundary.
+        """
 
         return self._read("/sdk/entitlements/")
 
     def strategies(self) -> Mapping[str, Any]:
-        """Return the Backend-managed active Case strategy configuration."""
+        """Return the Backend-managed public active Case strategy catalog.
+
+        This is an explicit discovery read; Case generation does not use it as a
+        client-side availability precheck.
+        """
 
         return self._read("/sdk/strategies/")
 
     def judge_config(self) -> Mapping[str, Any]:
-        """Return current public Judge upload limits and evidence types."""
+        """Return current public Judge upload limits and accepted Evidence types."""
 
         return self._read("/sdk/judge/config/")
 

--- a/src/kuma/evidence/trace.py
+++ b/src/kuma/evidence/trace.py
@@ -58,7 +58,22 @@ _MIN_TRACE_EVIDENCE_BYTES = json_size(_evidence_payload("r", "c", "i"))
 
 @dataclass(frozen=True, slots=True)
 class TraceEvidenceLimits:
-    """Bound capture; total bytes include compact envelopes committed per Run."""
+    """Resource limits for bounded in-process Trace Evidence.
+
+    Args:
+        max_spans: Maximum ended spans retained per Run; defaults to 200.
+        max_attributes: Maximum allowlisted attributes retained per span;
+            defaults to 32.
+        max_events_per_span: Maximum allowlisted events retained per span;
+            defaults to 20.
+        max_text_length: Maximum Unicode characters retained for one allowed text
+            value before truncation; defaults to 256.
+        max_total_bytes: Maximum compact JSON bytes across all Trace Evidence
+            envelopes committed by one Run; defaults to 512,000.
+
+    Every limit must be a positive integer. ``max_total_bytes`` must fit the
+    smallest valid envelope or construction raises ``ConfigurationError``.
+    """
 
     max_spans: int = 200
     max_attributes: int = 32

--- a/src/kuma/otel.py
+++ b/src/kuma/otel.py
@@ -117,10 +117,24 @@ def configure_trace_evidence(
 ) -> TraceEvidenceCapture:
     """Attach bounded Trace Evidence to an SDK-capable TracerProvider.
 
-    The provider is never replaced or reset, so existing instrumentation and
-    processors remain active. Call this once for the provider, then pass the
-    returned capture to :func:`kuma.create_run`. If no explicit provider is given,
-    the current global provider must expose ``add_span_processor``.
+    Args:
+        tracer_provider: Existing OpenTelemetry SDK ``TracerProvider`` or
+            compatible object exposing ``add_span_processor``. ``None`` selects
+            the current global provider.
+        limits: Optional :class:`TraceEvidenceLimits`; ``None`` uses bounded
+            defaults.
+
+    Returns:
+        Capture to pass as ``create_run(trace_evidence=...)``. Existing
+        instrumentation and exporters remain attached to their Provider.
+
+    Raises:
+        ConfigurationError: The selected Provider cannot accept a span processor
+            or the limits are invalid.
+
+    This function never replaces or resets the global Provider. Call it once for
+    an explicit Provider; automatic ``create_run`` discovery can reuse a
+    weak-referenceable configured Provider.
     """
 
     provider = tracer_provider or trace.get_tracer_provider()

--- a/src/kuma/run.py
+++ b/src/kuma/run.py
@@ -129,9 +129,18 @@ class Run:
     def get_input(self, *, full: bool = False) -> Any:
         """Deliver the current Input without advancing until it is submitted.
 
-        By default only the JSON-compatible payload is returned. ``full=True``
-        returns the immutable :class:`KumaInput` with public identifiers and
-        constraints. Repeated calls before ``submit`` return the same Input.
+        Args:
+            full: Return the immutable :class:`KumaInput` when ``True``; return
+                only its JSON-compatible payload when ``False``.
+
+        Returns:
+            The current payload or ``KumaInput``. Returns ``None`` after all
+            Inputs are committed. Repeated calls before :meth:`submit` return
+            the same Input and do not advance the Run.
+
+        Raises:
+            InputProtocolError: The Run cannot currently deliver an Input.
+            EvidenceCaptureError: Step-level Evidence initialization fails.
         """
 
         with self._mutex:
@@ -166,12 +175,33 @@ class Run:
     ) -> TestReport | None:
         """Validate and commit one result, then advance or judge synchronously.
 
-        When ``output`` is omitted, a completed submission uses the current
-        OpenTelemetry ``invoke_agent``/``invoke_workflow`` output. Agents without
-        that semantic-convention output pass ``output`` explicitly. Evidence
-        offsets, local final files, and Trace byte budgets advance only after the
-        Submission is successfully appended to history. On the final Input this
-        returns a report when Judge is enabled, otherwise ``None``.
+        Args:
+            output: Finite JSON-compatible Agent result. When omitted for a
+                completed Submission, KUMA uses a supported OTel
+                ``invoke_agent``/``invoke_workflow`` output. Explicit output has
+                priority; ``None`` is invalid for ``status="completed"``.
+            status: ``"completed"``, ``"failed"``, ``"timeout"``, or
+                ``"aborted"``.
+            error: Optional caller-safe error summary for a non-completed
+                Submission. Do not pass secrets or raw tracebacks.
+            logs: Optional log-file paths whose bounded increments are captured.
+                Evidence must be enabled; scope and sensitive checks still apply.
+            wait: Must remain ``True`` when the final Submission triggers Judge;
+                the public Run API does not expose background polling.
+
+        Returns:
+            Final :class:`TestReport` only when this is the last Input and Judge
+            completes; otherwise ``None``. The committed Submission is available
+            through :attr:`history`.
+
+        Raises:
+            InputProtocolError: No Input is currently delivered.
+            ValidationError: Output, status, error, or serialization is invalid.
+            EvidenceCaptureError: Requested Evidence cannot be captured safely.
+            KumaError: The final official or custom Judge fails.
+
+        Evidence offsets, local files, and Trace byte budgets advance only after
+        the immutable Submission is appended successfully.
         """
 
         with self._mutex:
@@ -321,7 +351,12 @@ class Run:
         return None
 
     def cancel(self) -> None:
-        """Cancel an unfinished Run and release its Evidence and runtime state."""
+        """Cancel an unfinished Run and release Evidence, files, and its lock.
+
+        The operation is idempotent for already-cancelled or report-ready Runs.
+        It raises :class:`InputProtocolError` when cancellation would hide a
+        failed or actively committing state.
+        """
 
         with self._mutex:
             if self._state == "report_ready":
@@ -343,10 +378,22 @@ class Run:
     def judge(self, *, wait: bool = True) -> TestReport:
         """Synchronously judge committed history for a completed Run.
 
-        ``wait=False`` is rejected because the public Run API remains synchronous.
-        The Official Provider waits on its bounded v2 operation internally. A
-        Provider failure leaves the Run completed so the caller may retry without
-        losing truthful history or pending-operation metadata.
+        Args:
+            wait: Must be ``True``. Official operation polling remains internal
+                and bounded by ``operation_wait_timeout`` from :func:`create_run`.
+
+        Returns:
+            Validated final :class:`TestReport`. Repeated calls after success
+            return the same report.
+
+        Raises:
+            ConfigurationError: ``wait=False`` is requested.
+            InputProtocolError: The Run is not completed and ready for Judge.
+            ProviderError: No Judge is configured or a custom Judge fails.
+            KumaError: The official Judge operation fails or times out.
+
+        A failure restores the ``completed`` state so retry reuses truthful
+        History and pending-operation metadata rather than creating a new result.
         """
 
         with self._mutex:

--- a/tools/verify_public_api_docs.py
+++ b/tools/verify_public_api_docs.py
@@ -1,0 +1,228 @@
+"""Fail when documented public API parameters drift from source signatures."""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = (ROOT / "docs/api-reference.md", ROOT / "docs/api-reference.zh-CN.md")
+MARKER = re.compile(
+    r"<!-- api-parameters:(?P<name>[A-Za-z_][A-Za-z0-9_]*):start -->"
+    r"(?P<body>.*?)"
+    r"<!-- api-parameters:(?P=name):end -->",
+    re.DOTALL,
+)
+
+
+@dataclass(frozen=True)
+class PublicApi:
+    """Describe one source callable or dataclass documented in both references."""
+
+    name: str
+    source: str
+    qualified_name: str
+    dataclass_fields: bool = False
+
+
+PUBLIC_APIS = (
+    PublicApi("configure", "src/kuma/api.py", "configure"),
+    PublicApi("create_run", "src/kuma/api.py", "create_run"),
+    PublicApi("get_input", "src/kuma/run.py", "Run.get_input"),
+    PublicApi("submit", "src/kuma/run.py", "Run.submit"),
+    PublicApi("judge", "src/kuma/run.py", "Run.judge"),
+    PublicApi("KumaClient", "src/kuma/client.py", "KumaClient.__init__"),
+    PublicApi(
+        "configure_trace_evidence",
+        "src/kuma/otel.py",
+        "configure_trace_evidence",
+    ),
+    PublicApi(
+        "TraceEvidenceLimits",
+        "src/kuma/evidence/trace.py",
+        "TraceEvidenceLimits",
+        dataclass_fields=True,
+    ),
+)
+
+
+def _find_node(tree: ast.AST, qualified_name: str) -> ast.AST:
+    """Resolve a top-level function, class method, or class by dotted name."""
+    current: ast.AST = tree
+    for part in qualified_name.split("."):
+        body = getattr(current, "body", ())
+        current = next(
+            (
+                node
+                for node in body
+                if isinstance(
+                    node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+                )
+                and node.name == part
+            ),
+            None,
+        )
+        if current is None:
+            raise ValueError(f"cannot find {qualified_name}")
+    return current
+
+
+def _callable_parameters(node: ast.AST) -> tuple[str, ...]:
+    """Return source-order user parameters while excluding method receivers."""
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        raise TypeError("expected a function node")
+    args = node.args
+    names = [item.arg for item in (*args.posonlyargs, *args.args, *args.kwonlyargs)]
+    if names and names[0] in {"self", "cls"}:
+        names.pop(0)
+    if args.vararg is not None:
+        names.append(args.vararg.arg)
+    if args.kwarg is not None:
+        names.append(args.kwarg.arg)
+    return tuple(names)
+
+
+def _dataclass_parameters(node: ast.AST) -> tuple[str, ...]:
+    """Return annotated public dataclass fields in declaration order."""
+    if not isinstance(node, ast.ClassDef):
+        raise TypeError("expected a class node")
+    return tuple(
+        child.target.id
+        for child in node.body
+        if isinstance(child, ast.AnnAssign)
+        and isinstance(child.target, ast.Name)
+        and not child.target.id.startswith("_")
+    )
+
+
+def _source_contract(api: PublicApi) -> tuple[tuple[str, ...], str]:
+    """Read one public signature and its owning callable or class docstring."""
+    tree = ast.parse((ROOT / api.source).read_text(encoding="utf-8"))
+    node = _find_node(tree, api.qualified_name)
+    parameters = (
+        _dataclass_parameters(node)
+        if api.dataclass_fields
+        else _callable_parameters(node)
+    )
+    doc_owner = (
+        _find_node(tree, api.qualified_name.removesuffix(".__init__"))
+        if api.qualified_name.endswith(".__init__")
+        else node
+    )
+    docstring = ast.get_docstring(doc_owner) or ""
+    return parameters, docstring
+
+
+def _documented_tables(path: Path) -> dict[str, tuple[tuple[str, ...], ...]]:
+    """Parse marked four-column parameter tables from one Markdown reference."""
+    text = path.read_text(encoding="utf-8")
+    tables: dict[str, tuple[tuple[str, ...], ...]] = {}
+    for match in MARKER.finditer(text):
+        rows: list[tuple[str, ...]] = []
+        for line in match.group("body").splitlines():
+            if not line.lstrip().startswith("| `"):
+                continue
+            cells = tuple(
+                cell.strip().replace(r"\|", "|")
+                for cell in re.split(r"(?<!\\)\|", line.strip().strip("|"))
+            )
+            if len(cells) != 4:
+                raise ValueError(
+                    f"{path}: {match.group('name')} row must have 4 columns"
+                )
+            rows.append(cells)
+        tables[match.group("name")] = tuple(rows)
+    return tables
+
+
+def _parameter_name(cell: str) -> str:
+    """Extract the identifier from a backtick-delimited parameter cell."""
+    if not (cell.startswith("`") and cell.endswith("`")):
+        raise ValueError(f"parameter name must use backticks: {cell}")
+    return cell[1:-1]
+
+
+def _validate_table(
+    path: Path,
+    name: str,
+    expected_parameters: tuple[str, ...],
+    rows: tuple[tuple[str, ...], ...],
+) -> list[str]:
+    """Validate one marked table against a source-order parameter list."""
+    errors: list[str] = []
+    try:
+        actual_parameters = tuple(_parameter_name(row[0]) for row in rows)
+    except ValueError as exc:
+        return [f"{path}: {name}: {exc}"]
+    if actual_parameters != expected_parameters:
+        errors.append(
+            f"{path}: {name} parameters {actual_parameters} "
+            f"!= source {expected_parameters}"
+        )
+    for parameter, row in zip(actual_parameters, rows, strict=True):
+        if any(not cell for cell in row[1:]):
+            errors.append(f"{path}: {name}.{parameter} has an empty field")
+        if len(row[3]) < 20:
+            errors.append(f"{path}: {name}.{parameter} description is too vague")
+    return errors
+
+
+def _validate_document(
+    path: Path, source_contracts: dict[str, tuple[tuple[str, ...], str]]
+) -> list[str]:
+    """Validate marker coverage and every parameter table in one language."""
+    try:
+        tables = _documented_tables(path)
+    except ValueError as exc:
+        return [str(exc)]
+    errors: list[str] = []
+    expected_targets = set(source_contracts)
+    if set(tables) != expected_targets:
+        errors.append(
+            f"{path}: marker set {sorted(tables)} != {sorted(expected_targets)}"
+        )
+    for name, (parameters, _) in source_contracts.items():
+        errors.extend(_validate_table(path, name, parameters, tables.get(name, ())))
+    return errors
+
+
+def _validate_source_docstrings(
+    source_contracts: dict[str, tuple[tuple[str, ...], str]],
+) -> list[str]:
+    """Require source docstrings to mention every public parameter by name."""
+    errors: list[str] = []
+    for name, (parameters, docstring) in source_contracts.items():
+        if not docstring:
+            errors.append(f"source docstring missing for {name}")
+            continue
+        errors.extend(
+            f"source docstring for {name} omits {parameter}"
+            for parameter in parameters
+            if parameter not in docstring
+        )
+    return errors
+
+
+def main() -> int:
+    """Validate bilingual table coverage, order, content, and source docstrings."""
+    source_contracts = {api.name: _source_contract(api) for api in PUBLIC_APIS}
+    errors = _validate_source_docstrings(source_contracts)
+
+    for path in DOCS:
+        errors.extend(_validate_document(path, source_contracts))
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print(
+        f"Public API documentation verified: {len(PUBLIC_APIS)} APIs, "
+        f"{len(DOCS)} languages"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add complete English and Chinese references for the stable Python entry points
- document argument types, defaults, ranges, returns, errors, side effects, retries, and privacy boundaries
- expand public source docstrings without changing runtime behavior
- add a standard-library signature/table drift verifier to the public Quality job

## Verification
- `python tools/verify_public_api_docs.py`
- Ruff format/check
- compileall for src/examples/tools
- Markdown local-link and Python-fence validation
- offline `kuma quickstart` and `examples/minimal_local.py`
- wheel/sdist build, Twine check, clean wheel import/version smoke

No official API, model, payment, deployment, or PyPI action was used.