### PR TITLE
docs: feature real full-stack SDK example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,51 @@ Run the deterministic local check without an account, API key, Docker, or networ
 kuma quickstart
 ```
 
+## Real end-to-end example
+
+The repository includes a runnable [Docker user flow](examples/full_stack/docker_user_flow.py) that exercises the complete official path:
+
+```text
+KUMA SDK → public Backend → Core evaluation service → public Judgment
+```
+
+The example requests an official Case, passes every Case step to mini-SWE-agent, submits bounded file/log/OTel Evidence, obtains the official Judgment, and writes its public fields to `.kuma/mini-swe-agent/judge-report.json`.
+
+Its central Run loop is:
+
+```python
+run = create_run(
+    repo_path=REPO,
+    requirement_path=REQUIREMENT,
+    track_files=True,
+    save_local=True,
+    trace_evidence=trace_evidence,
+)
+
+report = None
+while (case_input := run.get_input(full=True)) is not None:
+    result = run_mini_swe_agent(str(case_input.payload), step_index)
+    log_keys = {"evidence_log", "test_log", "trajectory_log"}
+    output = {key: value for key, value in result.items() if key not in log_keys}
+    report = run.submit(output, logs=[result["evidence_log"]])
+    step_index += 1
+```
+
+The linked source contains the Agent adapter, bounded execution, verification, and report persistence used by the actual run. To execute it, prepare a disposable workspace as described in the [full-stack guide](examples/full_stack/USER_GUIDE.md), set `KUMA_BASE_URL`, `KUMA_API_KEY`, and `DEEPSEEK_API_KEY`, then run:
+
+```bash
+docker build -f examples/full_stack/Dockerfile.user-flow -t kuma-user-flow .
+workspace=/absolute/path/to/prepared-workspace
+docker run --rm \
+  --env KUMA_BASE_URL \
+  --env KUMA_API_KEY \
+  --env DEEPSEEK_API_KEY \
+  --mount "type=bind,source=$workspace,target=/workspace" \
+  kuma-user-flow
+```
+
+This flow calls real services and may consume service credit and model budget. KUMA sends requests only to the configured public Backend; it never asks the user for a private Core address or credential.
+
 ## Core capabilities
 
 - Synchronous, framework-neutral Case and Judge workflow.

--- a/README.md
+++ b/README.md
@@ -33,35 +33,9 @@ kuma quickstart
 
 ## Real end-to-end example
 
-The repository includes a runnable [Docker user flow](examples/full_stack/docker_user_flow.py) that exercises the complete official path:
+The runnable [Docker example](examples/full_stack/docker_user_flow.py) performs the real flow: obtain an official Case, run each step with mini-SWE-agent, submit Evidence, receive the official Judgment, and save it as `.kuma/mini-swe-agent/judge-report.json`.
 
-```text
-KUMA SDK → public Backend → Core evaluation service → public Judgment
-```
-
-The example requests an official Case, passes every Case step to mini-SWE-agent, submits bounded file/log/OTel Evidence, obtains the official Judgment, and writes its public fields to `.kuma/mini-swe-agent/judge-report.json`.
-
-Its central Run loop is:
-
-```python
-run = create_run(
-    repo_path=REPO,
-    requirement_path=REQUIREMENT,
-    track_files=True,
-    save_local=True,
-    trace_evidence=trace_evidence,
-)
-
-report = None
-while (case_input := run.get_input(full=True)) is not None:
-    result = run_mini_swe_agent(str(case_input.payload), step_index)
-    log_keys = {"evidence_log", "test_log", "trajectory_log"}
-    output = {key: value for key, value in result.items() if key not in log_keys}
-    report = run.submit(output, logs=[result["evidence_log"]])
-    step_index += 1
-```
-
-The linked source contains the Agent adapter, bounded execution, verification, and report persistence used by the actual run. To execute it, prepare a disposable workspace as described in the [full-stack guide](examples/full_stack/USER_GUIDE.md), set `KUMA_BASE_URL`, `KUMA_API_KEY`, and `DEEPSEEK_API_KEY`, then run:
+Prepare a disposable Agent workspace using the [short guide](examples/full_stack/USER_GUIDE.md), set `KUMA_BASE_URL`, `KUMA_API_KEY`, and `DEEPSEEK_API_KEY`, then run from this repository:
 
 ```bash
 docker build -f examples/full_stack/Dockerfile.user-flow -t kuma-user-flow .
@@ -74,7 +48,7 @@ docker run --rm \
   kuma-user-flow
 ```
 
-This flow calls real services and may consume service credit and model budget. KUMA sends requests only to the configured public Backend; it never asks the user for a private Core address or credential.
+This calls real services and may use service credit and model budget. KUMA needs only the public Backend URL and user keys—never a private Core address.
 
 ## Core capabilities
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,51 @@ python -m pip install "kuma-defuzex==0.1.0"
 kuma quickstart
 ```
 
+## 真实全流程示例
+
+仓库提供了一个可直接运行的 [Docker 用户流程](examples/full_stack/docker_user_flow.py)，覆盖完整的官方调用链：
+
+```text
+KUMA SDK → 公网 Backend → Core 评测服务 → 公共 Judgment
+```
+
+该示例会获取官方 Case，把每个 Case 步骤交给 mini-SWE-agent，提交有界的文件、日志和 OTel Evidence，取得官方 Judgment，并将其中的公共字段保存到 `.kuma/mini-swe-agent/judge-report.json`。
+
+示例的核心 Run 循环如下：
+
+```python
+run = create_run(
+    repo_path=REPO,
+    requirement_path=REQUIREMENT,
+    track_files=True,
+    save_local=True,
+    trace_evidence=trace_evidence,
+)
+
+report = None
+while (case_input := run.get_input(full=True)) is not None:
+    result = run_mini_swe_agent(str(case_input.payload), step_index)
+    log_keys = {"evidence_log", "test_log", "trajectory_log"}
+    output = {key: value for key, value in result.items() if key not in log_keys}
+    report = run.submit(output, logs=[result["evidence_log"]])
+    step_index += 1
+```
+
+链接的源码包含真实运行使用的 Agent adapter、有界执行、验证和报告持久化逻辑。按照[全流程指南](examples/full_stack/USER_GUIDE.md)准备一次性工作区，设置 `KUMA_BASE_URL`、`KUMA_API_KEY` 和 `DEEPSEEK_API_KEY`，然后执行：
+
+```bash
+docker build -f examples/full_stack/Dockerfile.user-flow -t kuma-user-flow .
+workspace=/absolute/path/to/prepared-workspace
+docker run --rm \
+  --env KUMA_BASE_URL \
+  --env KUMA_API_KEY \
+  --env DEEPSEEK_API_KEY \
+  --mount "type=bind,source=$workspace,target=/workspace" \
+  kuma-user-flow
+```
+
+该流程会调用真实服务，可能消耗服务 Credit 和模型预算。KUMA 只请求用户配置的公网 Backend，不要求用户提供私有 Core 地址或凭据。
+
 ## 核心能力
 
 - 同步且不绑定框架的 Case 与 Judge 流程。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,35 +33,9 @@ kuma quickstart
 
 ## 真实全流程示例
 
-仓库提供了一个可直接运行的 [Docker 用户流程](examples/full_stack/docker_user_flow.py)，覆盖完整的官方调用链：
+可运行的 [Docker 示例](examples/full_stack/docker_user_flow.py)会完成真实流程：获取官方 Case、用 mini-SWE-agent 执行每个步骤、提交 Evidence、取得官方 Judgment，并保存为 `.kuma/mini-swe-agent/judge-report.json`。
 
-```text
-KUMA SDK → 公网 Backend → Core 评测服务 → 公共 Judgment
-```
-
-该示例会获取官方 Case，把每个 Case 步骤交给 mini-SWE-agent，提交有界的文件、日志和 OTel Evidence，取得官方 Judgment，并将其中的公共字段保存到 `.kuma/mini-swe-agent/judge-report.json`。
-
-示例的核心 Run 循环如下：
-
-```python
-run = create_run(
-    repo_path=REPO,
-    requirement_path=REQUIREMENT,
-    track_files=True,
-    save_local=True,
-    trace_evidence=trace_evidence,
-)
-
-report = None
-while (case_input := run.get_input(full=True)) is not None:
-    result = run_mini_swe_agent(str(case_input.payload), step_index)
-    log_keys = {"evidence_log", "test_log", "trajectory_log"}
-    output = {key: value for key, value in result.items() if key not in log_keys}
-    report = run.submit(output, logs=[result["evidence_log"]])
-    step_index += 1
-```
-
-链接的源码包含真实运行使用的 Agent adapter、有界执行、验证和报告持久化逻辑。按照[全流程指南](examples/full_stack/USER_GUIDE.md)准备一次性工作区，设置 `KUMA_BASE_URL`、`KUMA_API_KEY` 和 `DEEPSEEK_API_KEY`，然后执行：
+按照[简短指南](examples/full_stack/USER_GUIDE.md)准备一次性 Agent 工作区，设置 `KUMA_BASE_URL`、`KUMA_API_KEY` 和 `DEEPSEEK_API_KEY`，然后在本仓库执行：
 
 ```bash
 docker build -f examples/full_stack/Dockerfile.user-flow -t kuma-user-flow .
@@ -74,7 +48,7 @@ docker run --rm \
   kuma-user-flow
 ```
 
-该流程会调用真实服务，可能消耗服务 Credit 和模型预算。KUMA 只请求用户配置的公网 Backend，不要求用户提供私有 Core 地址或凭据。
+该流程会调用真实服务，可能消耗服务 Credit 和模型预算。KUMA 只需要公网 Backend 地址和用户密钥，不需要私有 Core 地址。
 
 ## 核心能力
 


### PR DESCRIPTION
## Summary
- add a real end-to-end Docker flow to the English and Chinese landing pages
- link the existing canonical mini-SWE-agent implementation instead of duplicating it
- show the actual Run loop, required environment variables, bounded Evidence, public Judgment artifact, and cost boundary

## Validation
- local Markdown links: pass
- README Python blocks parse: pass
- Ruff format/check: pass
- compileall: pass
- local deterministic example with repository source: pass
- wheel/sdist build and Twine check: pass
- diff secret-pattern scan: 0 hits

The paid full-stack flow was not executed; this PR documents the already tracked real example without making a production request.