### PR TITLE
fix(sdk): sync accepted runtime safeguards

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ kuma quickstart
 
 - Synchronous, framework-neutral Case and Judge workflow.
 - Official or custom Providers, including fully local runs.
-- Bounded file, log, and optional trace Evidence, plus a canonical hash-only Runtime Evidence contract.
+- Bounded file, log, and optional trace Evidence. Runtime Evidence v1 remains hash-only; when the official service explicitly advertises v2, the completed step may include the final Agent output after strict JSON, size, and sensitive-data checks.
 
 ## Detailed documentation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -35,7 +35,7 @@ kuma quickstart
 
 - 同步且不绑定框架的 Case 与 Judge 流程。
 - 支持官方或自定义 Provider，也可完全本地运行。
-- 有界采集文件、日志和可选 Trace Evidence，并提供规范、仅含哈希的 Runtime Evidence 合同。
+- 有界采集文件、日志和可选 Trace Evidence。Runtime Evidence v1 仍仅含哈希；仅当官方服务明确声明支持 v2 时，已完成步骤才可在严格 JSON、大小和敏感数据检查后携带 Agent 最终输出。
 
 ## 详细文档
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,17 +16,28 @@ credential_path = configure(api_key="dfx_your_key_here")
 
 <!-- api-parameters:configure:start -->
 
-| Argument | Type | Required/default | Meaning |
+| Argument | Type | Required/default | What it does and when to use it |
 | --- | --- | --- | --- |
-| `api_key` | `str` | Required | Printable ASCII KUMA credential beginning with `dfx_`; maximum 512 encoded bytes, with no whitespace or control characters. |
+| `api_key` | `str` | Required | Saves the credential KUMA will use for official Case and Judge requests. Copy the `dfx_...` value issued to you; it must be printable ASCII, contain no whitespace/control characters, and be at most 512 encoded bytes. You do not need this for fully local runs. |
 
 <!-- api-parameters:configure:end -->
 
-Returns the absolute `Path` of the atomically written user credential file. The
-function makes no network request. `KUMA_CONFIG_HOME` redirects the credential
-directory. Invalid keys raise `ConfigurationError`; filesystem failures remain
-real `OSError` values. The file contains the key and must never be printed or
-committed.
+**Returns:** the absolute `Path` of the atomically written user credential file.
+
+**Preconditions:** pass the complete platform-issued `dfx_...` value. If
+`KUMA_CONFIG_HOME` is set, it must name a directory this process may use for the
+credential file.
+
+**Postconditions:** on success, the returned file exists and contains the
+validated key. Atomic replacement prevents a partially written final file; a
+failed write removes its temporary file.
+
+**Raises:** `ConfigurationError` for an invalid key or unresolved credential
+location, and `OSError` for a real filesystem failure.
+
+**Side effects and security:** creates the credential directory if needed but
+makes no network request. The file contains the real key; never print, upload,
+or commit it.
 
 ## `create_run`
 
@@ -41,35 +52,49 @@ run = create_run(
 
 <!-- api-parameters:create_run:start -->
 
-| Argument | Type | Required/default | Meaning |
+| Argument | Type | Required/default | What it does and when to use it |
 | --- | --- | --- | --- |
-| `repo_path` | `str \| os.PathLike[str]` | `"."` | Repository root visible to the Agent. It is expanded and resolved to an absolute path. |
-| `requirement_path` | `str \| os.PathLike[str] \| None` | `None` | UTF-8 requirement file. Official Case generation requires it; a custom Provider can explicitly opt out. |
-| `case_provider` | `CaseProvider \| callable \| None` | `None` | Custom Case source. `None` uses the official authenticated Provider. |
-| `judge_provider` | `JudgeProvider \| callable \| None` | `None` | Custom Judge. `None` uses the official Provider when `judge=True`. |
-| `strategy` | `str` | `"auto"` | `"auto"` delegates selection to the service; another non-empty value is an explicit strategy ID. Unknown strategies are not silently replaced. |
-| `max_inputs` | `int \| None` | `None` | Positive Case Input upper bound. Custom Case Providers require a value; official mode uses the public service policy when omitted. |
-| `judge` | `bool` | `True` | Run the configured Judge after the final Submission. `False` leaves `run.report` as `None`. |
-| `on_failure` | `str` | `"continue"` | `"continue"` advances after `failed`, `timeout`, or `aborted`; `"stop"` closes the Run immediately. |
-| `allow_local` | `bool` | `False` | Permit trusted development outside Docker. This does not sandbox the Agent or relax validation/privacy rules. |
-| `track_files` | `bool` | `True` | Capture bounded file metadata before and after each Input. |
-| `upload_diff` | `bool` | `False` | Include bounded text diffs. Requires `track_files=True` and may expose repository text to the configured Judge. |
-| `save_local` | `bool` | `False` | Atomically save Submission JSON under `.kuma/runs/<run_id>/`. It does not replace official submission. |
-| `allow_sensitive` | `bool` | `False` | Allow ordinary Evidence flagged by the scanner. It never relaxes the OTel allowlist. |
-| `timeout` | `float` | `300.0` seconds | Positive finite timeout for one public HTTP attempt. This is not the total operation wait. |
-| `operation_wait_timeout` | `float` | `600.0` seconds | Positive finite total wait for one official asynchronous Case or Judge operation. Timeout preserves recovery metadata. |
-| `max_retries` | `int` | `2` | Automatic transient retry count, inclusive range 0–5. Idempotent POST retries reuse one key. |
-| `api_key` | `str \| None` | `None` | Per-call `dfx_` key. Resolution order is this value, `KUMA_API_KEY`, then the user credential file. |
-| `trace_evidence` | `TraceEvidenceCapture \| None` | `None` | Explicit capture returned by `configure_trace_evidence()`. When omitted, KUMA attempts safe global-provider reuse and otherwise adds a non-blocking warning. |
+| `repo_path` | `str \| os.PathLike[str]` | `"."` | Chooses the repository being tested. KUMA reads bounded metadata and, when enabled, observes file changes below this directory. Use `"."` when your Python process already runs at the repository root. |
+| `requirement_path` | `str \| os.PathLike[str] \| None` | `None` | Points to the UTF-8 file that describes what the Agent should do and which behaviors KUMA should test. Supply it for official Case generation. Omit it only when your custom Case Provider does not need a requirement file. |
+| `case_provider` | `CaseProvider \| callable \| None` | `None` | Chooses who creates the test Inputs. Leave `None` to request an official Case from KUMA; pass a callable when your application supplies its own local Case. |
+| `judge_provider` | `JudgeProvider \| callable \| None` | `None` | Chooses who evaluates all submitted results and builds the final report. Leave `None` for the official Judge, or pass a callable for your own local evaluation. Ignored when `judge=False`. |
+| `strategy` | `str` | `"auto"` | Controls how the official service chooses its Case-generation method. Keep `"auto"` unless the service has given you a specific strategy ID; an invalid ID fails instead of silently choosing something else. |
+| `max_steps` | `int \| None` | `None` | Limits how many test steps this Run may contain. For example, `3` allows one, two, or three steps—it does not force exactly three. `None` uses the official service limit; custom Case Providers require an explicit positive value. An explicit official value above the advertised limit fails before Case generation, and KUMA never truncates a returned Case. |
+| `judge` | `bool` | `True` | Controls whether KUMA evaluates the Run after the last Input. Keep `True` to receive a `TestReport`; use `False` when you only want to execute and record the Case, in which case `run.report` remains `None`. |
+| `on_failure` | `str` | `"continue"` | Decides what happens after you submit a step as `failed`, `timeout`, or `aborted`. `"continue"` delivers the next Input; `"stop"` ends the Run immediately. |
+| `allow_local` | `bool` | `False` | Allows the Run to start outside Docker for trusted local development. It only bypasses the Docker requirement: it does not sandbox the Agent, expand file access, or weaken validation and privacy checks. |
+| `track_files` | `bool` | `True` | Tells KUMA to compare repository file metadata before and after each Input so the Judge can see which files were created, modified, deleted, or renamed. Set `False` when file changes are irrelevant or unavailable. |
+| `upload_diff` | `bool` | `False` | Adds bounded changed text to file Evidence instead of sending only paths, hashes, sizes, and change types. Enable only when the Judge needs the actual diff and the repository text is safe to disclose; requires `track_files=True`. |
+| `save_local` | `bool` | `False` | Writes a local JSON copy of each committed Submission under `.kuma/runs/<run_id>/`. Use it for debugging or audit records. It does not replace submission to an official Judge. |
+| `allow_sensitive` | `bool` | `False` | Lets ordinary Evidence continue when KUMA's scanner flags content as potentially sensitive. Leave `False` unless you reviewed that content and intend to disclose it; this never allows secrets into OTel Trace Evidence. |
+| `timeout` | `float` | `300.0` seconds | Limits one HTTP connection attempt to the public KUMA service. Lower it to fail individual network calls sooner. It does not limit the total time spent waiting for Case generation or Judge completion. |
+| `operation_wait_timeout` | `float` | `600.0` seconds | Limits the total synchronous wait for one official Case or Judge operation, including polling. If it expires, KUMA raises a retryable timeout and keeps safe recovery metadata so the same operation can be resumed. |
+| `max_retries` | `int` | `2` | Sets how many additional attempts KUMA may make after a transient HTTP failure; accepted values are 0–5. Retries reuse the same idempotency key and do not intentionally create another Case or Judge operation. |
+| `api_key` | `str \| None` | `None` | Supplies the official-service credential for this Run only. Use it to override the environment or saved credential. With `None`, KUMA checks `KUMA_API_KEY` and then the user credential file. Fully local Provider combinations need no key. |
+| `trace_evidence` | `TraceEvidenceCapture \| None` | `None` | Supplies a specific in-process OTel capture and its limits for this Run. Pass the object returned by `configure_trace_evidence()` when you need explicit control. With `None`, KUMA safely reuses a compatible global Provider when available; otherwise the Run continues without Trace Evidence and records a warning. |
 
 <!-- api-parameters:create_run:end -->
 
-Returns a synchronous `Run` in `ready` state. Configuration, credential,
-isolation, Provider, Case, and public-service failures raise a `KumaError`
-subclass with stable `code`, `retryable`, and optional `request_id` fields.
-Creating a Run may read the requirement and bounded repository metadata, create
-`.kuma/`, acquire the one-active-Run lock, and call the public Backend when an
-official Provider is selected.
+**Returns:** a synchronous `Run` in `ready` state.
+
+**Preconditions:** `repo_path` identifies the repository the caller authorizes
+KUMA to inspect. Official Case generation needs a readable Requirement and a
+valid key. Unless `allow_local=True`, execution must be inside the supported
+container environment. Only one Run may own the local active-Run lock.
+
+**Postconditions:** the returned Run owns that lock and contains one validated
+Case. If `max_steps=N`, the Case contains from 1 through N Inputs, not exactly N.
+If setup fails after runtime acquisition, KUMA closes the runtime and releases
+the lock before re-raising the error.
+
+**Raises:** configuration, credential, isolation, Provider, Case, or public
+service failures raise a concrete `KumaError` subclass with stable `code`,
+`retryable`, and optional `request_id`.
+
+**Side effects and security:** reads the Requirement and bounded repository
+metadata, may create `.kuma/`, and may call only the public Backend for official
+Providers. It never contacts MCP, a model, or a database directly. Custom
+Providers run in the caller's process with that process's permissions.
 
 ## `Run`
 
@@ -77,65 +102,113 @@ official Provider is selected.
 
 <!-- api-parameters:get_input:start -->
 
-| Argument | Type | Required/default | Meaning |
+| Argument | Type | Required/default | What it does and when to use it |
 | --- | --- | --- | --- |
-| `full` | `bool` | `False` | `False` returns only the JSON-compatible payload; `True` returns immutable `KumaInput` metadata and payload. |
+| `full` | `bool` | `False` | Chooses how much information your Agent receives. Keep `False` to get only the actual task payload. Use `True` when your integration also needs identifiers, index, payload type, constraints, or extensions from the immutable `KumaInput`. |
 
 <!-- api-parameters:get_input:end -->
 
-Returns the current Input without advancing, or `None` after all Inputs are
-committed. Repeated calls before `submit()` return the same Input. Invalid Run
-ordering raises `InputProtocolError`.
+**Returns:** the current payload or immutable `KumaInput`; returns `None` after
+all Inputs are committed.
+
+**Preconditions:** the Run is `ready` or already `input_delivered`; submit the
+current Input before requesting a different one.
+
+**Postconditions:** first delivery changes `ready` to `input_delivered` and
+starts step Evidence. Repeated calls return the same Input without advancing
+state or history.
+
+**Raises and side effects:** invalid order raises `InputProtocolError`; Evidence
+startup may raise `EvidenceCaptureError`. The method may begin bounded capture,
+but it never calls Judge or appends history.
 
 ### `submit`
 
 <!-- api-parameters:submit:start -->
 
-| Argument | Type | Required/default | Meaning |
+| Argument | Type | Required/default | What it does and when to use it |
 | --- | --- | --- | --- |
-| `output` | finite JSON-compatible value | Omitted | Agent result. Explicit output wins; omission is valid for `completed` only when supported OTel instrumentation supplied a final Agent/Workflow output. Explicit `None` is not a completed result. |
-| `status` | `str` | `"completed"` | One of `"completed"`, `"failed"`, `"timeout"`, or `"aborted"`. |
-| `error` | `str \| None` | `None` | Caller-safe summary for a non-completed Submission. Never include secrets or raw tracebacks. |
-| `logs` | `list[str \| Path] \| None` | `None` | Log files whose bounded new bytes are captured. Evidence must be enabled; scope and sensitive-data checks apply. |
-| `wait` | `bool` | `True` | Keep `True` when the final Submission triggers Judge. Background Judge polling is not public API. |
+| `output` | finite JSON-compatible value | Omitted | Sends the Agent's result for the current Input—the value the Judge will evaluate. Pass it explicitly in normal integrations. It may be omitted only when supported OTel instrumentation captured a real final Agent/Workflow output; explicit `None` does not count as success. |
+| `status` | `str` | `"completed"` | Records how the current Input ended. Use `"completed"` for a usable result, `"failed"` for an Agent error, `"timeout"` when its deadline expired, or `"aborted"` when execution was intentionally stopped. This value also drives `on_failure`. |
+| `error` | `str \| None` | `None` | Provides a short, user-safe explanation when `status` is not `"completed"`. It becomes part of the Submission Evidence, so summarize the failure without secrets, file contents, or raw tracebacks. |
+| `logs` | `list[str \| Path] \| None` | `None` | Names local log files whose newly appended bytes should accompany this Submission. KUMA reads only a bounded increment and applies path and sensitive-data checks. Leave `None` when logs are not needed. |
+| `wait` | `bool` | `True` | Keeps final Judge execution synchronous: the last `submit()` returns only after the report or an error is available. The current public API requires `True`; background polling is not exposed. |
 
 <!-- api-parameters:submit:end -->
 
-Returns `TestReport` only when the final Submission completes Judge; otherwise
-returns `None`. Submission, Evidence offsets, local records, and Trace byte budget
-commit transactionally. Invalid output/state raises `ValidationError` or
-`InputProtocolError`; capture and Judge failures remain stable `KumaError` values.
+**Returns:** `TestReport` only when the final Submission completes Judge;
+otherwise `None`.
+
+**Preconditions:** one Input is currently delivered. A completed Submission has
+an explicit non-`None` output or a supported OTel-captured final output. Requested
+log paths are within the configured Evidence scope.
+
+**Postconditions:** success appends exactly one immutable history item and
+commits Evidence offsets, local records, and Trace byte budget together. A
+validation/preparation failure leaves the Input delivered. A final Judge failure
+leaves completed history available for `judge()` retry.
+
+**Raises:** protocol, output, serialization, or Evidence failures use the
+corresponding `InputProtocolError`, `ValidationError`, or
+`EvidenceCaptureError`; Judge failures retain stable `KumaError` types.
+
+**Side effects and security:** may read bounded file/log changes, atomically save
+a local Submission, and synchronously call Judge. Submitted output, errors,
+logs, diffs, and Evidence may cross the public Judge boundary; never include
+credentials, raw tracebacks, prompts, or unapproved file contents.
 
 ### `judge`
 
 <!-- api-parameters:judge:start -->
 
-| Argument | Type | Required/default | Meaning |
+| Argument | Type | Required/default | What it does and when to use it |
 | --- | --- | --- | --- |
-| `wait` | `bool` | `True` | Must remain `True`; official operation polling is synchronous and bounded internally. |
+| `wait` | `bool` | `True` | Makes `judge()` wait until a final report or error is available. The public Python API is synchronous, so callers must leave this as `True`; use `operation_wait_timeout` on `create_run()` to control the maximum wait. |
 
 <!-- api-parameters:judge:end -->
 
-Returns the validated `TestReport`. A failed attempt restores `completed` state,
-so retry reuses History and pending operation metadata. Calling before completion
-raises `InputProtocolError`; `wait=False` raises `ConfigurationError`.
+**Returns:** the validated `TestReport`; repeated calls after success return the
+same report.
+
+**Preconditions:** all Inputs have committed Submissions, the Run is `completed`,
+a Judge Provider is configured, and `wait=True`.
+
+**Postconditions:** success stores the report and changes state to
+`report_ready`. Failure restores `completed`, preserving immutable history,
+idempotency identity, and pending operation for retry.
+
+**Raises and side effects:** an incomplete Run raises `InputProtocolError`,
+`wait=False` raises `ConfigurationError`, and Provider/service failures retain
+stable `KumaError` types. The call synchronously invokes the configured Judge;
+retry does not create a second operation merely because polling failed.
 
 ### `cancel`
 
-`cancel()` has no arguments and returns `None`. It releases Evidence state,
-temporary runtime files, and the active-Run lock. Repeated cancellation is safe;
-invalid commit/failure states raise `InputProtocolError`.
+`cancel()` has no arguments.
+
+**Returns:** `None`.
+
+**Preconditions:** the Run is in a cancellable lifecycle state; a failed or
+actively committing state cannot be hidden by cancellation.
+
+**Postconditions:** an unfinished Run is `cancelled`, active Evidence is
+discarded, and runtime resources plus the active-Run lock are released. Calls on
+already `cancelled` or `report_ready` Runs are idempotent.
+
+**Raises and side effects:** invalid states raise `InputProtocolError`. The call
+removes validated temporary runtime files but does not submit or invoke Judge.
 
 ### Read-only properties
 
-| Property | Type | Meaning |
+| Property | Type | What it tells you |
 | --- | --- | --- |
-| `run_id` | `str` | Public identifier generated for this Run. |
-| `case_id` | `str` | Public Case identifier; never contains a private Rubric. |
-| `state` | `RunState` | Current lifecycle state. |
-| `history` | `tuple[HistoryItem, ...]` | Immutable committed Input/Submission pairs. |
-| `report` | `TestReport \| None` | Final validated Judgment after `report_ready`. |
-| `runtime_warnings` | `tuple[str, ...]` | Stable non-fatal Evidence degradation codes. |
+| `run_id` | `str` | Identifies this execution in logs, local artifacts, and public service records. |
+| `case_id` | `str` | Identifies the public Case being executed. It is safe to correlate but never exposes the private Rubric. |
+| `max_steps` | `int` | Reports how many steps the generated Case actually contains. It is at least 1 and never exceeds the explicit `create_run(max_steps=...)` limit, or the service/default limit when that argument was `None`. |
+| `state` | `RunState` | Shows which operation is currently legal, such as delivering an Input, submitting, judging, completed, or cancelled. |
+| `history` | `tuple[HistoryItem, ...]` | Contains every successfully committed Input and its matching Submission in execution order. It does not include an in-progress step. |
+| `report` | `TestReport \| None` | Holds the final Judge result after state becomes `report_ready`; it stays `None` before Judgment or when `judge=False`. |
+| `runtime_warnings` | `tuple[str, ...]` | Lists stable warning codes for non-fatal Evidence gaps, such as unavailable automatic Trace capture. The Run can still complete. |
 
 ## `KumaClient`
 
@@ -143,18 +216,27 @@ Use `KumaClient` for authenticated configuration reads without opening a Run.
 
 <!-- api-parameters:KumaClient:start -->
 
-| Argument | Type | Required/default | Meaning |
+| Argument | Type | Required/default | What it does and when to use it |
 | --- | --- | --- | --- |
-| `api_key` | `str \| None` | `None` | Optional `dfx_` key using the normal environment/file fallback. Read methods require a resolved key. |
-| `base_url` | `str` | Public KUMA URL | Public Backend API base. Remote URLs require HTTPS; loopback HTTP is allowed for local integration. Credentials in URLs are rejected. |
-| `timeout` | `float` | `30.0` seconds | Positive finite timeout for each GET request. |
-| `transport` | public transport callable \| `None` | `None` | Explicit test/integration HTTP boundary. Ordinary users should not provide it. |
+| `api_key` | `str \| None` | `None` | Authenticates configuration reads such as entitlements and available strategies. Pass a key only for this client, or leave `None` to use `KUMA_API_KEY` and then the saved credential. |
+| `base_url` | `str` | Public KUMA URL | Chooses the public Backend that receives the client's GET requests. Ordinary users should keep the default. Remote URLs must use HTTPS; loopback HTTP is allowed for local integration, and URLs containing credentials are rejected. |
+| `timeout` | `float` | `30.0` seconds | Sets how long each configuration GET may wait for a response before failing. It does not control Case/Judge operation polling. |
+| `transport` | public transport callable \| `None` | `None` | Replaces real HTTP with an explicitly supplied transport callable. This is for tests or controlled integrations; ordinary applications should leave it `None`. |
 
 <!-- api-parameters:KumaClient:end -->
 
-`entitlements()`, `strategies()`, and `judge_config()` take no arguments and
-return validated public mappings. They may raise `KumaAuthenticationError`,
-`KumaPermissionError`, or `KumaRateLimitError`; none contacts MCP, a model, or a
+**Preconditions:** construction validates the URL, timeout, and any discovered
+key but makes no request. Authenticated read methods require a valid key.
+
+**Postconditions:** a constructed client is reusable. `entitlements()`,
+`strategies()`, and `judge_config()` return validated public mappings and do not
+create a Run.
+
+**Raises and side effects:** construction raises `ConfigurationError` for local
+configuration errors. Read methods make one public Backend GET and may raise
+`KumaAuthenticationError`, `KumaPermissionError`, or `KumaRateLimitError`.
+Credential discovery may read the environment or user credential file; the key
+is never included in `repr(client)`, and no method contacts MCP, a model, or a
 database directly.
 
 ## OpenTelemetry
@@ -163,27 +245,50 @@ Install `kuma-defuzex[otel]` before importing `kuma.otel`.
 
 <!-- api-parameters:configure_trace_evidence:start -->
 
-| Argument | Type | Required/default | Meaning |
+| Argument | Type | Required/default | What it does and when to use it |
 | --- | --- | --- | --- |
-| `tracer_provider` | OTel SDK Provider \| `None` | `None` | Existing Provider exposing `add_span_processor`; `None` selects the current global Provider. KUMA never replaces it. |
-| `limits` | `TraceEvidenceLimits \| None` | `None` | Bounded capture configuration. `None` uses the defaults below. |
+| `tracer_provider` | OTel SDK Provider \| `None` | `None` | Selects the in-process OTel Provider from which KUMA receives ended spans. Pass your application's existing Provider when it is not global; `None` uses the current global Provider. KUMA adds a processor but never replaces or resets the Provider. |
+| `logger_provider` | OTel SDK Provider \| `None` | `None` | Selects an existing in-process OTel LoggerProvider for bounded native log metadata. Pass it for explicit OTel log capture; `None` leaves logs unattached in explicit mode. KUMA never replaces it. |
+| `limits` | `TraceEvidenceLimits \| None` | `None` | Controls how much Trace data one Run may retain. Pass custom limits for tighter memory/privacy budgets; `None` uses the bounded defaults below. |
 
 <!-- api-parameters:configure_trace_evidence:end -->
 
-Returns a `TraceEvidenceCapture` for `create_run(trace_evidence=...)`. Invalid
-Providers or limits raise `ConfigurationError`.
+**Returns:** a `TraceEvidenceCapture` for
+`create_run(trace_evidence=...)`.
+
+**Preconditions:** install the `otel` extra and configure an in-process OTel SDK
+Provider that accepts span processors. Pass a non-global Provider explicitly.
+
+**Postconditions:** one KUMA processor is attached and the returned capture can
+associate ended spans with a Run. Existing instrumentation and exporters remain
+installed.
+
+**Raises and side effects:** invalid Providers or limits raise
+`ConfigurationError`. Registration mutates the selected Provider; call once for
+an explicitly managed Provider. Only bounded allowlisted data is retained;
+prompts, completions, source, raw logs, credentials, and private Rubrics remain
+excluded.
 
 <!-- api-parameters:TraceEvidenceLimits:start -->
 
-| Argument | Type | Required/default | Meaning |
+| Argument | Type | Required/default | What happens when the limit is reached |
 | --- | --- | --- | --- |
-| `max_spans` | positive `int` | `200` | Maximum ended spans retained per Run. |
-| `max_attributes` | positive `int` | `32` | Maximum allowlisted attributes retained per span. |
-| `max_events_per_span` | positive `int` | `20` | Maximum allowlisted events retained per span. |
-| `max_text_length` | positive `int` | `256` characters | Maximum retained Unicode characters for one allowed text value. |
-| `max_total_bytes` | positive `int` | `512000` bytes | Maximum compact JSON bytes across committed Trace envelopes for one Run; must fit the minimum envelope. |
+| `max_spans` | positive `int` | `200` | After this many ended spans have been retained for a Run, additional spans are dropped and the Evidence reports the drop instead of growing memory without bound. |
+| `max_attributes` | positive `int` | `32` | Keeps at most this many safe, allowlisted attributes on each span; additional attributes are dropped and counted. Sensitive attributes remain rejected regardless of this number. |
+| `max_events_per_span` | positive `int` | `20` | Keeps at most this many safe OTel events on each span; later events are dropped and reported. |
+| `max_text_length` | positive `int` | `256` characters | Truncates each retained allowlisted text value to this many Unicode characters and records that truncation occurred. |
+| `max_total_bytes` | positive `int` | `512000` bytes | Caps the compact JSON size of all committed Trace envelopes in one Run. KUMA drops or truncates Trace data to stay within this budget; the value must still fit the smallest valid envelope. |
+| `max_log_records` | positive `int` | `200` | Keeps at most this many normalized OTel log records per step; excess records are dropped and reported. |
+| `max_log_bytes` | positive `int` | `128000` bytes | Caps structured OTel log artifacts committed across one Run; raw log bodies are not retained. |
 
 <!-- api-parameters:TraceEvidenceLimits:end -->
+
+**Preconditions:** every value is a positive integer and `max_total_bytes` is
+large enough for the required envelope.
+
+**Postconditions:** the immutable limits make capture drop or truncate excess
+Trace data with an explicit reason instead of exceeding the configured bounds.
+Increasing a limit never broadens the privacy allowlist.
 
 ## Public result contracts
 
@@ -198,7 +303,8 @@ The main immutable contracts are exported from `kuma`:
 | `CaptureStatus` | Completeness for file snapshot/diff, logs, sensitive scan, and traces. Each component is `complete`, `partial`, `failed`, or `skipped`. |
 
 Private Rubrics, prompts, model settings, and Core records are not part of these
-objects. The hash-only upload format is defined separately in the
+objects. Runtime Evidence v1 is hash-only; explicitly negotiated v2 may carry a
+bounded, scanned completed Agent output. Both formats are defined in the
 [Runtime Evidence contract](runtime-evidence.md).
 
 ## Error fields

--- a/docs/api-reference.zh-CN.md
+++ b/docs/api-reference.zh-CN.md
@@ -14,13 +14,21 @@ credential_path = configure(api_key="dfx_your_key_here")
 
 <!-- api-parameters:configure:start -->
 
-| 参数 | 类型 | 必填/默认值 | 用法 |
+| 参数 | 类型 | 必填/默认值 | 它控制什么、什么时候填写 |
 | --- | --- | --- | --- |
-| `api_key` | `str` | 必填 | 以 `dfx_` 开头的可打印 ASCII KUMA 凭证；编码后最多 512 字节，不允许空白或控制字符。 |
+| `api_key` | `str` | 必填 | 保存 KUMA 调用官方 Case/Judge 时使用的凭证。填写平台签发的 `dfx_...` 值；必须是可打印 ASCII，不能包含空白或控制字符，编码后最多 512 字节。完全本地运行不需要配置它。 |
 
 <!-- api-parameters:configure:end -->
 
-返回原子写入的用户凭证文件绝对 `Path`，不发送网络请求。`KUMA_CONFIG_HOME` 可改变凭证目录。非法 Key 抛出 `ConfigurationError`，文件系统失败保留为真实 `OSError`。该文件含 Key，禁止打印或提交。
+**返回值：** 原子写入的用户凭证文件绝对 `Path`。
+
+**前置条件：** 必须传平台签发的完整 `dfx_...`，不能传脱敏后的展示值。若设置 `KUMA_CONFIG_HOME`，它必须是当前进程被允许写入的凭证目录。
+
+**后置条件：** 成功后，返回路径存在且包含通过校验的 Key；最终文件采用原子替换，不会留下“写了一半”的正式文件。写入失败时会删除临时文件。
+
+**异常：** Key 或凭证位置无效时抛 `ConfigurationError`；真实文件系统失败抛 `OSError`。
+
+**副作用与安全：** 必要时创建凭证目录，但不发送网络请求。文件内是真实 Key，禁止打印、上传或提交到 Git。
 
 ## `create_run`
 
@@ -32,30 +40,38 @@ run = create_run(repo_path=".", requirement_path="requirement.md")
 
 <!-- api-parameters:create_run:start -->
 
-| 参数 | 类型 | 必填/默认值 | 用法 |
+| 参数 | 类型 | 必填/默认值 | 它控制什么、什么时候填写 |
 | --- | --- | --- | --- |
-| `repo_path` | `str \| os.PathLike[str]` | `"."` | Agent 可见的仓库根目录；会展开并解析成绝对路径。 |
-| `requirement_path` | `str \| os.PathLike[str] \| None` | `None` | UTF-8 Requirement 文件。官方 Case 必须提供；自定义 Provider 可明确不要求。 |
-| `case_provider` | `CaseProvider \| callable \| None` | `None` | 自定义 Case 来源；`None` 使用官方鉴权 Provider。 |
-| `judge_provider` | `JudgeProvider \| callable \| None` | `None` | 自定义 Judge；当 `judge=True` 时，`None` 使用官方 Provider。 |
-| `strategy` | `str` | `"auto"` | `"auto"` 让服务选择；其他非空值是显式策略 ID。未知策略不会被静默替换。 |
-| `max_inputs` | `int \| None` | `None` | 正整数 Case Input 上限。自定义 Case Provider 必须提供；官方模式省略时遵循公开服务策略。 |
-| `judge` | `bool` | `True` | 最后一次 Submission 后执行 Judge；`False` 时 `run.report` 保持 `None`。 |
-| `on_failure` | `str` | `"continue"` | `"continue"` 在 failed/timeout/aborted 后继续；`"stop"` 立即结束 Run。 |
-| `allow_local` | `bool` | `False` | 允许可信的非 Docker 开发运行；不会创建沙箱，也不会放松校验或隐私规则。 |
-| `track_files` | `bool` | `True` | 每个 Input 前后采集有界文件元数据。 |
-| `upload_diff` | `bool` | `False` | 加入有界文本 diff；要求 `track_files=True`，并可能把仓库文本交给所配置的 Judge。 |
-| `save_local` | `bool` | `False` | 原子保存 Submission JSON 到 `.kuma/runs/<run_id>/`；不替代官方提交。 |
-| `allow_sensitive` | `bool` | `False` | 允许普通 Evidence 中被扫描器命中的内容；绝不放宽 OTel allowlist。 |
-| `timeout` | `float` | `300.0` 秒 | 单次公网 HTTP 尝试的正有限超时，不是整个 operation 的等待时间。 |
-| `operation_wait_timeout` | `float` | `600.0` 秒 | 一次官方异步 Case/Judge operation 的正有限总等待上限；超时保留恢复元数据。 |
-| `max_retries` | `int` | `2` | 自动瞬态重试次数，范围 0–5；幂等 POST 重试复用同一个 Key。 |
-| `api_key` | `str \| None` | `None` | 本次调用的 `dfx_` Key；解析顺序为本参数、`KUMA_API_KEY`、用户凭证文件。 |
-| `trace_evidence` | `TraceEvidenceCapture \| None` | `None` | `configure_trace_evidence()` 返回的显式 capture；省略时安全尝试复用全局 Provider，否则仅记录非阻断 warning。 |
+| `repo_path` | `str \| os.PathLike[str]` | `"."` | 指定“这次要测试哪个仓库”。KUMA 会读取该目录下的有界元数据，并在启用文件追踪时观察其中的文件变化。如果 Python 正在仓库根目录运行，保留 `"."` 即可。 |
+| `requirement_path` | `str \| os.PathLike[str] \| None` | `None` | 指向描述“Agent 要做什么、KUMA 要测试哪些行为”的 UTF-8 文件。使用官方 Case 时必须填写；只有自定义 Case Provider 明确不需要 Requirement 时才可省略。 |
+| `case_provider` | `CaseProvider \| callable \| None` | `None` | 决定由谁生成测试步骤。保留 `None` 会向 KUMA 官方服务申请 Case；传入 callable 表示由你的程序在本地提供 Case。 |
+| `judge_provider` | `JudgeProvider \| callable \| None` | `None` | 决定由谁评估全部步骤并生成最终报告。保留 `None` 使用官方 Judge；传入 callable 使用你自己的本地评估逻辑。`judge=False` 时不会使用它。 |
+| `strategy` | `str` | `"auto"` | 控制官方服务用哪种方法生成 Case。通常保留 `"auto"`；只有服务明确提供了某个 strategy ID 时才填写该 ID。无效 ID 会直接失败，不会偷偷换成其他策略。 |
+| `max_steps` | `int \| None` | `None` | 限制本次 Run 最多包含多少个测试步骤。例如填 `3`，Case 可以有 1、2 或 3 个步骤，并不保证一定生成 3 个。`None` 采用官方服务上限；自定义 Case Provider 必须填写正整数。显式值超过服务端公开上限会在生成 Case 前报错，KUMA 不会截断已返回的 Case。 |
+| `judge` | `bool` | `True` | 控制最后一个 Input 提交后是否进行评估。保持 `True` 才会得到 `TestReport`；设为 `False` 只执行并记录 Case，`run.report` 会保持 `None`。 |
+| `on_failure` | `str` | `"continue"` | 决定某一步被提交为 `failed`、`timeout` 或 `aborted` 后怎么办。`"continue"` 会继续交付下一个 Input；`"stop"` 会立即结束整个 Run。 |
+| `allow_local` | `bool` | `False` | 允许在 Docker 外启动可信的本地开发 Run。它只绕过 Docker 要求，不会隔离 Agent、扩大文件权限，也不会关闭校验或隐私保护。 |
+| `track_files` | `bool` | `True` | 让 KUMA 在每个 Input 前后比较仓库文件，从而告诉 Judge 哪些文件被创建、修改、删除或重命名。文件变化与评估无关或无法观察时可设为 `False`。 |
+| `upload_diff` | `bool` | `False` | 除路径、哈希、大小和变化类型外，再把有界的实际文本改动加入 Evidence。只有 Judge 必须查看代码差异且仓库文本允许披露时才开启；要求 `track_files=True`。 |
+| `save_local` | `bool` | `False` | 把每个已成功提交的 Submission 额外保存为 `.kuma/runs/<run_id>/` 下的 JSON，便于调试和审计。它只是本地副本，不能替代提交给官方 Judge。 |
+| `allow_sensitive` | `bool` | `False` | 当普通 Evidence 被扫描器判断为可能敏感时，是否仍允许继续。默认应保持 `False`；只有人工确认内容可以披露时才开启，而且它永远不能让秘密进入 OTel Trace Evidence。 |
+| `timeout` | `float` | `300.0` 秒 | 限制一次连接 KUMA 公网服务的 HTTP 请求最多等待多久。调小后单次网络失败会更快返回；它不限制 Case 生成或 Judge 的总等待时间。 |
+| `operation_wait_timeout` | `float` | `600.0` 秒 | 限制一次官方 Case/Judge operation 连同轮询在内总共等待多久。超时后 KUMA 抛出可重试错误，并保留安全恢复信息，以便继续同一个 operation。 |
+| `max_retries` | `int` | `2` | 设置一次瞬态 HTTP 失败后最多再尝试几次，允许 0–5。重试会复用同一个幂等键，不会故意创建第二个 Case/Judge operation。 |
+| `api_key` | `str \| None` | `None` | 为“这一个 Run”提供官方服务凭证，用于临时覆盖环境变量或已保存凭证。`None` 时依次读取 `KUMA_API_KEY` 和用户凭证文件；Case/Judge 都是本地 Provider 时不需要 Key。 |
+| `trace_evidence` | `TraceEvidenceCapture \| None` | `None` | 为本次 Run 指定一份 OTel Trace 采集器及其资源上限。需要显式控制时传入 `configure_trace_evidence()` 的返回值；`None` 时 KUMA 会尝试复用兼容的全局 Provider，没有则继续运行并记录非阻断 warning。 |
 
 <!-- api-parameters:create_run:end -->
 
-返回处于 `ready` 状态的同步 `Run`。配置、凭证、隔离、Provider、Case 或公网服务失败会抛出具体 `KumaError` 子类，并提供稳定的 `code`、`retryable` 和可选 `request_id`。创建过程可能读取 Requirement 和有界仓库元数据、创建 `.kuma/`、获取单 active Run 锁，并在使用官方 Provider 时调用公开 Backend。
+**返回值：** 处于 `ready` 状态的同步 `Run`。
+
+**前置条件：** `repo_path` 必须是调用方明确允许 KUMA 检查的仓库。官方 Case 需要可读的 Requirement 和有效 Key。除非设置 `allow_local=True`，进程必须运行在支持的容器环境中；同一本地运行环境一次只能有一个 Run 持有 active-Run 锁。
+
+**后置条件：** 返回的 Run 已持有该锁，并装入一个通过校验的 Case。若 `max_steps=N`，Case 可以有 1 到 N 个 Input，而不是必须恰好 N 个。获取运行资源后若初始化失败，KUMA 会先关闭资源并释放锁，再把异常抛给调用方。
+
+**异常：** 配置、凭证、隔离、Provider、Case 或公网服务失败会抛出具体 `KumaError` 子类，并提供稳定的 `code`、`retryable` 和可选 `request_id`。
+
+**副作用与安全：** 读取 Requirement 和有界仓库元数据，可能创建 `.kuma/`，官方 Provider 只调用公开 Backend。SDK 不直连 MCP、模型或数据库；自定义 Provider 在调用方进程内运行并继承该进程权限。
 
 ## `Run`
 
@@ -63,56 +79,85 @@ run = create_run(repo_path=".", requirement_path="requirement.md")
 
 <!-- api-parameters:get_input:start -->
 
-| 参数 | 类型 | 必填/默认值 | 用法 |
+| 参数 | 类型 | 必填/默认值 | 它控制什么、什么时候填写 |
 | --- | --- | --- | --- |
-| `full` | `bool` | `False` | `False` 仅返回 JSON-compatible payload；`True` 返回不可变 `KumaInput` 元数据和 payload。 |
+| `full` | `bool` | `False` | 决定 Agent 能拿到多少信息。保持 `False` 只返回真正要执行的任务 payload；需要 run/case/input ID、序号、payload 类型、约束或扩展字段时设为 `True`，返回完整且不可变的 `KumaInput`。 |
 
 <!-- api-parameters:get_input:end -->
 
-返回当前 Input 且不推进状态；全部提交后返回 `None`。在 `submit()` 前重复调用返回同一个 Input。非法顺序抛出 `InputProtocolError`。
+**返回值：** 当前 payload 或不可变 `KumaInput`；全部 Input 已提交后返回 `None`。
+
+**前置条件：** Run 必须为 `ready` 或已经是 `input_delivered`；拿到当前 Input 后必须先提交，才能请求下一个。
+
+**后置条件：** 首次交付会把 `ready` 改为 `input_delivered` 并开始该步骤的 Evidence；重复调用返回同一个 Input，不推进状态和 history。
+
+**异常与副作用：** 顺序错误抛 `InputProtocolError`，Evidence 初始化失败抛 `EvidenceCaptureError`。该方法可能启动有界采集，但不会调用 Judge 或追加 history。
 
 ### `submit`
 
 <!-- api-parameters:submit:start -->
 
-| 参数 | 类型 | 必填/默认值 | 用法 |
+| 参数 | 类型 | 必填/默认值 | 它控制什么、什么时候填写 |
 | --- | --- | --- | --- |
-| `output` | 有限 JSON-compatible 值 | 省略 | Agent 结果。显式值优先；仅当受支持 OTel instrumentation 提供最终 Agent/Workflow 输出时，completed Submission 才能省略。显式 `None` 不是成功结果。 |
-| `status` | `str` | `"completed"` | 只能是 `"completed"`、`"failed"`、`"timeout"` 或 `"aborted"`。 |
-| `error` | `str \| None` | `None` | 非 completed Submission 的安全摘要；不得包含 secret 或原始 traceback。 |
-| `logs` | `list[str \| Path] \| None` | `None` | 采集有界新增内容的日志文件；必须启用 Evidence，且仍受目录与敏感数据校验。 |
-| `wait` | `bool` | `True` | 最后一次 Submission 触发 Judge 时必须保持 `True`；公共 API 不暴露后台轮询。 |
+| `output` | 有限 JSON-compatible 值 | 省略 | 提交当前 Input 的 Agent 结果，Judge 会评估这个值。普通接入应明确传入。只有受支持 OTel instrumentation 已捕获真实最终 Agent/Workflow 输出时才能省略；显式传 `None` 不算成功结果。 |
+| `status` | `str` | `"completed"` | 记录当前步骤实际如何结束：有可用结果用 `"completed"`，Agent 报错用 `"failed"`，超过执行期限用 `"timeout"`，主动终止用 `"aborted"`。该值也会触发 `on_failure` 的继续/停止策略。 |
+| `error` | `str \| None` | `None` | 当 `status` 不是 `"completed"` 时，提供一段用户可读的失败摘要。它会进入 Submission Evidence，因此只能写安全概述，不能放 secret、文件正文或原始 traceback。 |
+| `logs` | `list[str \| Path] \| None` | `None` | 指定哪些本地日志文件的“新增部分”要随本次 Submission 一起采集。KUMA 只读取有界增量，并继续做路径与敏感数据校验；不需要日志时保留 `None`。 |
+| `wait` | `bool` | `True` | 让最后一次 `submit()` 同步等待 Judge，直到拿到报告或错误才返回。当前公共 API 必须保持 `True`，不提供后台轮询模式。 |
 
 <!-- api-parameters:submit:end -->
 
-只有最后一次 Submission 完成 Judge 时返回 `TestReport`，其他情况返回 `None`。Submission、Evidence offset、本地记录和 Trace 字节预算按事务提交。非法输出/状态抛出 `ValidationError` 或 `InputProtocolError`；采集和 Judge 失败保留稳定 `KumaError`。
+**返回值：** 只有最后一次 Submission 完成 Judge 时返回 `TestReport`，其他情况返回 `None`。
+
+**前置条件：** 当前必须有一个已交付但未提交的 Input。`completed` 必须有显式非 `None` output，或有受支持 OTel 捕获的真实最终输出；`logs` 路径必须位于允许的 Evidence 范围内。
+
+**后置条件：** 成功时只追加一个不可变 history 项，Evidence offset、本地记录和 Trace 字节预算一起提交。校验或准备失败后 Input 仍保持已交付；最终 Judge 失败后已完成 history 可供 `judge()` 重试。
+
+**异常：** 协议、输出、序列化和采集错误分别使用 `InputProtocolError`、`ValidationError`、`EvidenceCaptureError`；Judge 错误保留稳定 `KumaError` 类型。
+
+**副作用与安全：** 可能读取有界文件/日志变化、原子保存本地 Submission，并同步调用 Judge。output、error、日志、diff 和 Evidence 可能进入公开 Judge 边界，禁止传入凭证、原始 traceback、Prompt 或未经批准的文件正文。
 
 ### `judge`
 
 <!-- api-parameters:judge:start -->
 
-| 参数 | 类型 | 必填/默认值 | 用法 |
+| 参数 | 类型 | 必填/默认值 | 它控制什么、什么时候填写 |
 | --- | --- | --- | --- |
-| `wait` | `bool` | `True` | 必须为 `True`；官方 operation 在内部同步、有界轮询。 |
+| `wait` | `bool` | `True` | 让 `judge()` 一直等到最终报告或错误。公共 Python API 是同步接口，所以必须保持 `True`；最长等待时间通过 `create_run(operation_wait_timeout=...)` 控制。 |
 
 <!-- api-parameters:judge:end -->
 
-返回验证后的 `TestReport`。失败时恢复 `completed`，重试会复用 History 和 pending operation。Run 未完成时抛出 `InputProtocolError`；`wait=False` 抛出 `ConfigurationError`。
+**返回值：** 通过校验的 `TestReport`；成功后重复调用返回同一报告。
+
+**前置条件：** 所有 Input 都已有已提交 Submission，Run 为 `completed`，已配置 Judge Provider，并且 `wait=True`。
+
+**后置条件：** 成功时保存报告并进入 `report_ready`；失败时恢复 `completed`，保留不可变 history、幂等 identity 和 pending operation 供重试。
+
+**异常与副作用：** Run 未完成抛 `InputProtocolError`，`wait=False` 抛 `ConfigurationError`，Provider/服务失败保留稳定 `KumaError`。该调用同步执行 Judge；不能仅因轮询失败就创建第二个 operation。
 
 ### `cancel`
 
-`cancel()` 没有参数并返回 `None`，会释放 Evidence 状态、临时运行文件和 active Run 锁。重复取消安全；不允许隐藏提交中/失败状态时抛出 `InputProtocolError`。
+`cancel()` 没有参数。
+
+**返回值：** `None`。
+
+**前置条件：** Run 必须处于允许取消的生命周期状态；不能用 cancel 隐藏 failed 或正在提交的状态。
+
+**后置条件：** 未完成 Run 进入 `cancelled`，活动 Evidence 被丢弃，运行资源和 active-Run 锁被释放；对 `cancelled` 或 `report_ready` 重复调用是幂等的。
+
+**异常与副作用：** 非法状态抛 `InputProtocolError`。该方法删除经过校验的临时运行文件，但不会提交结果或调用 Judge。
 
 ### 只读属性
 
-| 属性 | 类型 | 含义 |
+| 属性 | 类型 | 它告诉你什么 |
 | --- | --- | --- |
-| `run_id` | `str` | 当前 Run 的公开标识。 |
-| `case_id` | `str` | 公开 Case 标识，不包含 Private Rubric。 |
-| `state` | `RunState` | 当前生命周期状态。 |
-| `history` | `tuple[HistoryItem, ...]` | 已提交的不可变 Input/Submission 对。 |
-| `report` | `TestReport \| None` | `report_ready` 后的最终验证 Judgment。 |
-| `runtime_warnings` | `tuple[str, ...]` | 非致命 Evidence 降级稳定代码。 |
+| `run_id` | `str` | 标识这一次执行，可用于关联日志、本地产物和公开服务记录。 |
+| `case_id` | `str` | 标识本次正在执行的公开 Case，可安全用于关联，但不会暴露 Private Rubric。 |
+| `max_steps` | `int` | 表示最终生成的 Case 实际包含多少个步骤；至少为 1，且不会超过显式传入的 `create_run(max_steps=...)` 上限，参数为 `None` 时则不超过服务或本地默认上限。 |
+| `state` | `RunState` | 告诉你现在允许做什么，例如获取 Input、提交、等待 Judge、已经完成或已取消。 |
+| `history` | `tuple[HistoryItem, ...]` | 按执行顺序保存所有已成功提交的 Input 及对应 Submission；正在处理但尚未提交的步骤不在其中。 |
+| `report` | `TestReport \| None` | `state` 变为 `report_ready` 后保存最终 Judge 结果；Judge 尚未完成或 `judge=False` 时为 `None`。 |
+| `runtime_warnings` | `tuple[str, ...]` | 保存不会阻断 Run 的 Evidence 缺口代码，例如自动 Trace 不可用；可用它向用户提示采集不完整。 |
 
 ## `KumaClient`
 
@@ -120,16 +165,20 @@ run = create_run(repo_path=".", requirement_path="requirement.md")
 
 <!-- api-parameters:KumaClient:start -->
 
-| 参数 | 类型 | 必填/默认值 | 用法 |
+| 参数 | 类型 | 必填/默认值 | 它控制什么、什么时候填写 |
 | --- | --- | --- | --- |
-| `api_key` | `str \| None` | `None` | 可选 `dfx_` Key，沿用环境变量/凭证文件回退；读取方法必须最终取得 Key。 |
-| `base_url` | `str` | KUMA 公开 URL | 公开 Backend API base；远程地址必须 HTTPS，本地集成可用 loopback HTTP，拒绝 URL credentials。 |
-| `timeout` | `float` | `30.0` 秒 | 每次公开配置 GET 请求的正有限超时；不控制 Run operation 的总等待时间。 |
-| `transport` | 公共 transport callable \| `None` | `None` | 测试/集成 HTTP 边界；普通用户不要传。 |
+| `api_key` | `str \| None` | `None` | 用于读取账号权限、策略和 Judge 配置等公开信息。可以只给这个 client 传 Key；保留 `None` 时会读取 `KUMA_API_KEY`，再读取已保存凭证。 |
+| `base_url` | `str` | KUMA 公开 URL | 决定这些 GET 请求发往哪个公开 Backend。普通用户保持默认即可；远程地址必须 HTTPS，本地集成可用 loopback HTTP，含用户名或密码的 URL 会被拒绝。 |
+| `timeout` | `float` | `30.0` 秒 | 设置每次配置 GET 最多等待响应多久，超时就失败；它不控制 Case/Judge operation 的轮询总时长。 |
+| `transport` | 公共 transport callable \| `None` | `None` | 用显式 callable 替换真实 HTTP，供测试或受控集成使用。普通应用应保留 `None`。 |
 
 <!-- api-parameters:KumaClient:end -->
 
-`entitlements()`、`strategies()` 和 `judge_config()` 均无参数，返回验证后的公开 mapping。它们可能抛出 `KumaAuthenticationError`、`KumaPermissionError` 或 `KumaRateLimitError`，不会直连 MCP、模型或数据库。
+**前置条件：** 构造阶段会校验 URL、timeout 和发现的 Key，但不会发送请求；调用鉴权读取方法前必须有有效 Key。
+
+**后置条件：** client 可以复用；`entitlements()`、`strategies()` 和 `judge_config()` 返回校验后的公开 mapping，不创建 Run。
+
+**异常与副作用：** 构造配置错误抛 `ConfigurationError`；读取方法发送一次公开 Backend GET，可能抛 `KumaAuthenticationError`、`KumaPermissionError` 或 `KumaRateLimitError`。凭证发现可能读取环境变量或用户凭证文件；`repr(client)` 不含 Key，也不会直连 MCP、模型或数据库。
 
 ## OpenTelemetry
 
@@ -137,26 +186,39 @@ run = create_run(repo_path=".", requirement_path="requirement.md")
 
 <!-- api-parameters:configure_trace_evidence:start -->
 
-| 参数 | 类型 | 必填/默认值 | 用法 |
+| 参数 | 类型 | 必填/默认值 | 它控制什么、什么时候填写 |
 | --- | --- | --- | --- |
-| `tracer_provider` | OTel SDK Provider \| `None` | `None` | 现有且提供 `add_span_processor` 的 Provider；`None` 选择当前全局 Provider，KUMA 绝不替换它。 |
-| `limits` | `TraceEvidenceLimits \| None` | `None` | 有界采集配置；`None` 使用下列默认值。 |
+| `tracer_provider` | OTel SDK Provider \| `None` | `None` | 指定 KUMA 从哪个同进程 OTel Provider 接收已结束的 span。应用使用非全局 Provider 时明确传入；`None` 使用当前全局 Provider。KUMA 只添加 processor，绝不会替换或重置它。 |
+| `logger_provider` | OTel SDK Provider \| `None` | `None` | 指定现有同进程 OTel LoggerProvider，用于采集有界的原生日志元数据。需要显式日志采集时传入；`None` 在显式模式下不附加日志采集。KUMA 不会替换它。 |
+| `limits` | `TraceEvidenceLimits \| None` | `None` | 控制一个 Run 最多保留多少 Trace 数据。需要更严格的内存或隐私预算时传入自定义限制；`None` 使用下方有界默认值。 |
 
 <!-- api-parameters:configure_trace_evidence:end -->
 
-返回供 `create_run(trace_evidence=...)` 使用的 `TraceEvidenceCapture`；非法 Provider 或限制抛出 `ConfigurationError`。
+**返回值：** 供 `create_run(trace_evidence=...)` 使用的 `TraceEvidenceCapture`。
+
+**前置条件：** 已安装 `otel` extra，并配置了可添加 span processor 的同进程 OTel SDK Provider；非全局 Provider 必须显式传入。
+
+**后置条件：** 选定 Provider 上新增一个 KUMA processor，返回的 capture 可以把已结束 span 关联到 Run；原有 instrumentation 和 exporter 保持不变。
+
+**异常与副作用：** Provider 或限制无效时抛 `ConfigurationError`。注册操作会修改所选 Provider，显式管理的 Provider 应只调用一次。只保留有界 allowlist 数据；Prompt、completion、源码、原始日志、凭证和 Private Rubric 始终排除。
 
 <!-- api-parameters:TraceEvidenceLimits:start -->
 
-| 参数 | 类型 | 必填/默认值 | 用法 |
+| 参数 | 类型 | 必填/默认值 | 达到上限后会怎样 |
 | --- | --- | --- | --- |
-| `max_spans` | 正 `int` | `200` | 单 Run 最多保留的结束 span 数。 |
-| `max_attributes` | 正 `int` | `32` | 每个 span 最多保留的 allowlisted attributes 数。 |
-| `max_events_per_span` | 正 `int` | `20` | 每个 span 最多保留的 allowlisted events 数。 |
-| `max_text_length` | 正 `int` | `256` 字符 | 单个允许文本值最多保留的 Unicode 字符数。 |
-| `max_total_bytes` | 正 `int` | `512000` 字节 | 单 Run 已提交 Trace envelope 的紧凑 JSON 总字节上限；必须能容纳最小 envelope。 |
+| `max_spans` | 正 `int` | `200` | 一个 Run 保留到该数量后，后续已结束 span 会被丢弃，并在 Evidence 中记录 dropped，而不是让内存无限增长。 |
+| `max_attributes` | 正 `int` | `32` | 每个 span 最多保留这么多个安全 allowlist 属性；其余属性被丢弃并计数。无论数字多大，敏感属性仍会被拒绝。 |
+| `max_events_per_span` | 正 `int` | `20` | 每个 span 最多保留这么多个安全 OTel event；更晚的 event 会被丢弃并记录。 |
+| `max_text_length` | 正 `int` | `256` 字符 | 每个允许保留的文本值超过该 Unicode 字符数后会被截断，并记录 truncated 状态。 |
+| `max_total_bytes` | 正 `int` | `512000` 字节 | 一个 Run 的全部已提交 Trace envelope 紧凑 JSON 合计不能超过该值；KUMA 会丢弃或截断 Trace 数据来守住预算，但该值本身必须能容纳最小合法 envelope。 |
+| `max_log_records` | 正 `int` | `200` | 每个步骤最多保留的规范化 OTel 日志记录数；超出部分会丢弃并记录。 |
+| `max_log_bytes` | 正 `int` | `128000` 字节 | 一个 Run 中已提交的结构化 OTel 日志 artifact 总字节上限；不会保留原始日志正文。 |
 
 <!-- api-parameters:TraceEvidenceLimits:end -->
+
+**前置条件：** 每项都是正整数，且 `max_total_bytes` 足以容纳必需 envelope。
+
+**后置条件：** 生成不可变限制对象；超额 Trace 会按明确原因丢弃或截断，而不会越过预算。提高容量不会扩大隐私 allowlist。
 
 ## 公共结果契约
 
@@ -170,7 +232,7 @@ run = create_run(repo_path=".", requirement_path="requirement.md")
 | `TestReport` | `report_id`、`run_id`、`status`（`pass`、`issue` 或 `insufficient_evidence`）、confidence、stop reason、公开 issues/evidence gaps 和 extensions。 |
 | `CaptureStatus` | file snapshot/diff、logs、sensitive scan、traces 的完整性；每项为 `complete`、`partial`、`failed` 或 `skipped`。 |
 
-这些对象不包含 Private Rubric、Prompt、模型设置或 Core 记录。仅哈希上传格式见 [Runtime Evidence 合同](runtime-evidence.md)。
+这些对象不包含 Private Rubric、Prompt、模型设置或 Core 记录。Runtime Evidence v1 仅含哈希；服务端明确协商 v2 后，可携带经过大小与敏感检查的 completed Agent 最终输出。两种格式见 [Runtime Evidence 合同](runtime-evidence.md)。
 
 ## 错误字段
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # SDK v4 架构
 
-本文描述当前 `kuma` Python 包的模块边界、同步用户 API、内部 v2 operation 流程和关键不变量。公开 HTTP 字段与路径另见 [API Contract](api-contract.md)；使用方式见[简体中文 SDK 指南](sdk-guide.zh-CN.md)或[英文 SDK 指南](sdk-guide.md)。
+本文描述当前 `kuma` Python 包的模块边界、同步用户 API、内部 v2 operation 流程和关键不变量。公开 HTTP 字段与路径另见 [API Contract](api-contract.md)；使用方式见 [README](../README.md)。
 
 ## 系统边界与数据归属
 
@@ -88,17 +88,17 @@ flowchart TD
 - `Run` 暴露 `get_input()`、`submit(output?)`、`judge()`、`cancel()` 以及只读 state/history/report/warnings。省略 output 时只读取当前步骤标准 OTel Agent/Workflow 输出；显式 output 是无 OTel Agent 的兼容路径并始终优先。
 - `contracts.py` 中的 dataclass 是不可变、经 schema major 验证的 JSON 边界值。
 - `kuma.providers` 暴露自定义 Provider Protocol、context、adapters 和官方 Provider。
-- `kuma.otel` 只在安装 `[otel]` extra 后可导入，暴露显式 attach API 和 Trace limits。
+- `create_run()` 在安装 `[otel]` 且全局 OTel SDK Provider 可用时自动挂载；`kuma.otel` 继续暴露显式 attach API 和 Trace limits 供高级配置。
 
 ### Provider
 
-`CaseProvider.generate_case(CaseGenerationContext)` 接收本地 requirement、公开 Repo Meta、input 类型/schema、strategy 和数量上限。输出可使用灵活的本地形状，但必须经 `normalize_case()` 转成完整 `Case`，才能交付第一个 Input。
+`CaseProvider.generate_case(CaseGenerationContext)` 接收本地 requirement、公开 Repo Meta、input 类型/schema、strategy 和数量上限。输出只能是文档列出的 `Case`、带必需 `inputs` 的 Case mapping、单个文本/`KumaInput` 或 `list`/`tuple` Inputs；任意 mapping fallback 和任意 iterable 不再进入 Input。`normalize_case()` 在交付第一个 Input 前递归拒绝私有评测字段，再构造完整 `Case`。
 
 `JudgeProvider.judge(JudgeContext)` 接收已归一化 Case、不可变 History、Run status 和 Evidence summary。输出必须经 `normalize_report()` 转成 `TestReport`。Provider 抛出的 `KumaError` 保持类型；其他异常被包装成不泄漏内部异常文本的 `ProviderError`。
 
 官方 Provider 是这两个端口的 HTTP 实现：
 
-- `OfficialCaseProvider` 不把 strategy catalog 查询作为 CaseGen 前置条件。显式模式只指定 ID；`auto` 不在客户端选择或发送 version。两种模式都只上传最小 Repo Meta、纯 frontmatter `agent_description`，以及从 requirement 三个必填章节提取并受 UTF-8 字节边界和敏感扫描保护的 `behavior_spec`；不会上传原始 requirement、schema、路径或仓库正文。响应记录 Backend/Core 的实际 strategy/version，并校验 batch/case 一致、fingerprint、signature 和私有字段缺失。`KumaClient.strategies()` 仅供用户显式查询。
+- `OfficialCaseProvider` 不把 strategy catalog 查询作为 CaseGen 前置条件。显式模式只指定 ID；`auto` 不在客户端选择或发送 version。`CaseGenerationContext.max_steps` 是公共 Provider 协议的结果上限；直接构造 Provider 时，构造器中的显式值必须与 context 一致，否则在网络请求前拒绝。用户显式设置非默认上限时，新请求先从 entitlements 读取服务端上限；超限在 Case POST 前以带安全最大值的 `case_step_limit_exceeded` 拒绝。已有 pending operation 跳过该预检并恢复原 operation，避免配置漂移破坏幂等。两种模式都只上传最小 Repo Meta、纯 frontmatter `agent_description`，以及从 requirement 三个必填章节提取并受 UTF-8 字节边界和敏感扫描保护的 `behavior_spec`；不会上传原始 requirement、schema、路径或仓库正文。响应记录 Backend/Core 的实际 strategy/version，并校验 batch/case 一致、fingerprint、signature 和私有字段缺失。`KumaClient.strategies()` 仅供用户显式查询。
 - `OfficialJudgeProvider` 先读取动态上传限制，再构建 multipart evidence。单 Run 的幂等键在重试和手动 `run.judge()` 重试间保持稳定。
 - Run Evidence 超过服务端单文件预算时，SDK 只在 HTTP transport projection 中按稳定顺序截断 raw log content，再移除尾部 OTel spans；本地不可变 `Submission` 不变。投影保留日志哈希/offset、Trace envelope 和所有 Input/Submission，并通过 `transport_projection`、`complete/truncated`、`dropped_count`、`missing` 与 capture reasons 明确暴露缺口。若仅靠这两类冗余内容仍无法满足预算，上传失败而不会删除 output、file evidence 或其他结构。
 - `OfficialJudgeProvider.judge_batch()` 是同步 Provider 级 API；它验证 Backend 的动态 batch 上限，保持输入顺序，并把每项成功或安全错误归一化为 `JudgeBatchResult`。
@@ -114,9 +114,11 @@ flowchart TD
 - `timeout` 是每次公网请求尝试的正有限秒数；`operation_wait_timeout` 是官方单 Case/Judge 的独立总等待预算，默认 600 秒。重试仅限安全错误 envelope 标记的瞬态失败，使用指数退避且 `max_retries` 限制为 0–5。`ServiceBusyError` 不会自动重试。
 - 单次公网响应最多读取 8 MiB；超限响应在 JSON 解析前失败，HTTP 响应句柄始终释放。
 - 对所有响应验证 JSON mapping 和公开字段；畸形响应不会成为成功对象。
-- Backend `details` 不进入异常文本或 SDK error details，避免暴露内部上下文。
+- Backend 任意 `details` 不进入异常文本或 SDK error details；唯一例外是 `case_step_limit_exceeded.details.max_allowed_steps` 这一经过闭集、类型和范围验证的公开整数。
 
 ## `create_run()` 编排与调用流程
+
+`create_run()` 先完成纯配置校验，再适配 Case Provider 并验证、解析其 requirement。缺失或无效 requirement 会在 OTel 自动接入、凭据解析、entitlements 协商、仓库扫描和 Runtime 创建前失败；有效 requirement 才进入后续官方协商与 Case 生成。
 
 ```mermaid
 sequenceDiagram
@@ -128,9 +130,17 @@ sequenceDiagram
     participant B as Website Backend
 
     U->>S: create_run(repo, requirement, providers, config)
-    S->>S: validate config, runtime, requirement, schema, Repo Meta
+    S->>S: validate config and Provider requirement precondition
+    S->>S: parse requirement/schema, then resolve runtime and Repo Meta
     alt official Case
         S->>C: generate_case(context)
+        opt explicit max_steps and no pending operation
+            C->>B: GET /sdk/entitlements/
+            B-->>C: limits.casegen_max_steps
+            break requested max_steps exceeds service limit
+                C-->>S: LimitExceededError before Case POST
+            end
+        end
         C->>B: POST /sdk/v2/cases/generate/ (idempotent)
         B-->>C: 202 operation_id + poll_after_ms
         loop while queued/running within operation_wait_timeout
@@ -202,7 +212,7 @@ stateDiagram-v2
 
 1. 同一 Run 最多有一个已交付但未提交的 Input；重复 `get_input()` 不前进。
 2. History 中 `KumaInput` 与 `Submission` 的 run/case/input ID 必须一致。
-3. output 在记录前必须是无 NaN/Infinity 的 JSON 值；completed submission 必须有 output。
+3. Input payload 与 output 在记录前必须是无 NaN/Infinity、无循环且最多 256 层容器的 JSON 值；共享无环子对象合法。completed submission 必须有 output，结构错误必须在 Evidence/persistence/network 前以稳定安全错误返回。
 4. Evidence 先 prepare，History 成功记录后才 commit。Submission 构造或 History 记录失败会 abort，不推进日志 offset、Trace Run 预算或本地 final file。
 5. Judge 对 Python 调用者保持同步；Official Provider 内部 POST v2 operation 并轮询终态。Judge 失败只把状态恢复为 `completed`，不删除真实 History，也不伪造报告。超时保留仅含 operation 元数据的恢复文件。
 6. cancel/finish 释放 OS lock 和临时 workspace；cancel 同时丢弃 active Trace association，迟到 span 不得串入下一 Run。
@@ -230,27 +240,39 @@ flowchart LR
 
 `repository/metadata.py` 是 Case 请求的最小化边界：只允许 schema version、基于公开 tree 的 fingerprint、相对 path、file/directory type、file size，以及 bounded truncation metadata。它不读取文件内容，并排除 `.git`、`.kuma`、依赖/build/cache 目录和敏感文件名。
 
-`tracking` 在每个 Input 周围采集文件状态和显式日志增量。`upload_diff=False` 时文件 Evidence 不包含文本内容；开启 diff 或传入日志会增加敏感数据面。发送给官方 Judge 前，SDK 扫描 output、error、path、diff、log 和 custom Case。默认命中即抛出 `SensitiveDataError`，Run 保持当前 Input 可重试。
+`evidence/tracking` 在每个 Input 周围采集文件状态和显式日志增量。日志 tracker
+在构造时绑定该 Run 的 canonical repo root；相对路径不依赖进程 cwd，路径组件
+先做 lexical boundary 与 symlink/reparse 检查，内部绝对路径只作为未序列化的
+offset key。History、持久化 Evidence 和 Judge wire 仅保留 repo-relative path
+与稳定的 index reason。`upload_diff=False` 时文件 Evidence 不包含文本内容；
+开启 diff 或传入日志会增加敏感数据面。发送给官方 Judge 前，SDK 扫描 output、
+error、path、diff、log 和 custom Case。默认命中即抛出 `SensitiveDataError`，
+Run 保持当前 Input 可重试。
 
 Evidence 的完整性不由单个布尔值掩盖。`CaptureStatus` 分组件记录 complete/partial/failed/skipped，`missing` 给出缺失原因，`dropped_count` 给出丢弃数量，非致命运行问题进入 `runtime_warnings`。`save_local=True` 将同一结构写入 `.kuma/runs/<run_id>/submissions/`，先写 pending file，提交后 rename；本地保存失败只产生 warning，不伪造提交状态。
 
-每个已关联 Run/Case/Input 的 Submission 还会生成
+每个已关联 Run/Case/Input 的 Submission 还会生成并在本地保存
 [`defuzex.runtime_evidence.v1`](runtime-evidence.md) 公开 envelope。它使用闭合
-typed component union，只传关联 ID、顺序、路径/大小、结果枚举和 SHA-256，
-不传日志、输出或工具参数正文。Official Judge 通过公开 Judge config 的
-`evidence_types` 协商传输：新服务收到每步 typed EvidenceItem，未广告该 schema
-的旧服务仍收到 `defuzex.run_evidence.v1`。SDK 不从文本、OTel span name 或框架
-事件推断 tool/command/test/state 事实。
+typed component union，只传关联 ID、顺序、路径/大小、结果枚举和 SHA-256。
+Official Judge 通过公开 Judge config 的 `evidence_types` 协商传输：明确广告 v2
+时，SDK 从已提交的 frozen output 生成不修改本地历史的 v2 transport projection，
+只给 completed response claim 增加经强制敏感扫描和 32,768-byte 上限约束的
+`agent_output` JSON。仅广告 v1 时保持 hash-only v1；未广告 typed schema 的旧
+服务仍收到 `defuzex.run_evidence.v1`。SDK 不把日志、Trace、prompt、completion、
+diff 或 tool/model payload 混为 Agent output，也不从文本、OTel span name 或
+框架事件推断 tool/command/test/state 事实。
 
 ## OpenTelemetry 适配
 
-`otel.py` 通过 SDK `TracerProvider.add_span_processor()` 增加一个处理器。显式 capture 始终优先；未传 capture 时，`create_run()` 惰性复用已经配置的兼容全局 Provider，并按 Provider 身份幂等复用 capture。它不调用全局 `set_tracer_provider()`，因此可与已有 processor/exporter 和 instrumentation 共存。未安装 `[otel]` 或没有兼容 Provider 时，Run 正常继续并记录稳定的 `trace_auto_capture_unavailable`；真正的自动附着失败记录 `trace_auto_attach_failed`，两者都不阻断 Run。
+`create_run()` 在没有显式 capture 时按需导入 `otel.py`。若当前全局 Provider 暴露 SDK `TracerProvider.add_span_processor()`，适配器会自动增加一次 span 处理器并跨顺序 Run 复用；若全局 SDK `LoggerProvider` 可用，也增加一次原生 Logs 处理器。显式 `configure_trace_evidence()` capture 优先，可用于非全局 Provider 和自定义 limits。两种路径都不设置或替换任何全局 provider，因此可与已有 processor/exporter 和 instrumentation 共存。未安装 `[otel]`、Provider 未配置或不可自动安全复用时保持 no-op，并记录非阻断的 `trace_auto_capture_unavailable` runtime warning；意外 attach 失败只产生 `trace_auto_attach_failed` warning。两者都不影响 Run。
 
-span 在 start 时绑定到 capture 当前唯一 active step，因此同进程线程池不依赖 `ContextVar` 继承；在 end 时才映射和导出。父 span 可以先于或后于 child 结束，JSON 使用 ID 保留关系，并按开始时间稳定排序。step prepare 会 force flush，然后冻结本次 Evidence；commit 才累计整个 Run 的字节预算，abort 可恢复同一 association。
+span 在 start 时绑定到 capture 当前唯一 active step，因此同进程线程池不依赖 `ContextVar` 继承；在 end 时才映射和导出。capture window 从 `get_input()` 打开，到 `submit()` force-flush 后冻结 Evidence 时关闭。标准 processor 的 span 必须在窗口内开始并在关闭前结束；窗口前开始但窗口内结束、以及关闭时仍打开的 span 都按 `trace_span_outside_window` 计数并降低完整性。完全发生在窗口外的 span 没有安全 step 归属，因此不向前后 Run 追记。父 span 可以先于或后于 child 结束，JSON 使用 ID 保留关系，并按开始时间稳定排序。commit 才累计整个 Run 的字节预算，abort 可恢复同一 association。
 
-省略 `submit(output)` 的自动输出只读取 `invoke_agent`/`invoke_workflow` span 的 `gen_ai.output.messages` attribute 或 event。显式 output 优先；同一 span 的最后有效 event 覆盖 attribute，多 span 按结束时间选择、同时间 Workflow 优先并以 span ID 稳定打破平局。候选输出在内存中有界且不会复制进 Trace JSON，随后仍经过 Submission JSON 校验和敏感扫描。没有合法候选时保持当前 Input 并返回安全的 `output_invalid`，要求调用者显式提交。只要 instrumentation 明确给出最终输出，OTel 的 `error` span 状态不会被 SDK 当作业务失败依据；Trace status 仍原样保留。
+省略 `submit(output)` 的自动输出只读取 `invoke_agent`/`invoke_workflow` span 的 `gen_ai.output.messages` attribute 或 event。显式 output 优先；同一 span 的最后有效 event 覆盖 attribute；多 span 时 Workflow 结果始终优先于 Agent 结果，同类候选再按结束时间和 span ID 稳定选择。候选输出在内存中有界且不会复制进 Trace JSON，随后仍经过 Submission JSON 校验和敏感扫描。没有合法候选时保持当前 Input 并返回安全的 `output_invalid`，要求调用者显式提交。只要 instrumentation 明确给出最终输出，OTel 的 `error` span 状态不会被 SDK 当作业务失败依据；Trace status 仍原样保留。
 
-`_trace_mapping.py` 是纯映射边界。它保留标准 ID、时间、kind/status、events、resource 和 scope，并使用拒绝式 allowlist 过滤 attributes。仅允许受控 `gen_ai` 模型/usage/latency 字段及少量 service/OTel resource 字段；prompt、completion、源码、文件/日志正文、token/key 和 Private Rubric 永远不允许。限制覆盖 span、attribute、event、文本和整个 Run 的完整紧凑 JSON envelope；降级必须显式报告，Exporter/serialization/flush 异常不得破坏 Run。
+`evidence/trace_mapping.py` 是纯映射边界。它保留标准 ID、时间、kind/status、events、resource 和 scope，并使用拒绝式 allowlist 过滤 attributes。`max_attributes` 在 allowlist 后限制保留项；每个排除项都计入 dropped accounting，普通未允许键与明确敏感键分别使用稳定 reason，privacy 分类不再依靠含糊 substring 决定是否计数。仅允许受控 `gen_ai` 模型/usage/latency 字段及少量 service/OTel resource 字段；prompt、completion、源码、文件/日志正文、token/key 和 Private Rubric 永远不允许。限制覆盖 span、attribute、event、文本和整个 Run 的完整紧凑 JSON envelope；任何丢失或截断都不得报告 `complete`，Exporter/serialization/flush 异常不得破坏 Run。
+
+`_otel_log_mapping.py` 将同一 active step 内的原生 LogRecord 映射到一个版本化 JSON log segment。它只保留时间、severity、trace/span 关联、安全 resource/scope、正文/event hash 和 attribute 计数；原始 body、event name 与普通 attribute 值不会进入内存中的 Evidence payload。segment 复用既有 `Submission.logs` wire，并在 `runtime_evidence` 中投影为 hash-only `artifact_snapshot`，不新增 Core component 类型。record 数与每 Run 完整 JSON 字节均有独立硬上限；prepare/commit/abort 与 span Evidence 共用事务生命周期。
 
 成功的公共 wire extension 是：
 

--- a/docs/runtime-evidence.md
+++ b/docs/runtime-evidence.md
@@ -1,9 +1,10 @@
-# Runtime Evidence v1
+# Runtime Evidence v1 and v2
 
 `Submission.extensions["runtime_evidence"]` is the canonical, bounded record of
 runtime facts the SDK observed between one `get_input()` and its matching
 `submit()`. Its closed schema is `defuzex.runtime_evidence.v1`; it does not
-change the public Run method signatures.
+change the public Run method signatures. Local history and `save_local=True`
+persistence continue to store this v1 form.
 
 ## Envelope and association
 
@@ -59,7 +60,7 @@ fields are limited to:
 | `test_result` | `suite_id`, `outcome` (`passed`, `failed`, `partial`), `passed`, `failed`, `skipped` |
 | `state_transition` | `state_id`, `outcome` (`succeeded`, `failed`, `unknown`), optional `before_sha256`, `after_sha256` |
 | `artifact_snapshot` | `artifact_id`, optional `path`, `sha256`, `size_bytes`, `media_type` |
-| `agent_response_claim` | `claim_id`, `claim` (`completed`, `refused`, `blocked`), `text_sha256` |
+| `agent_response_claim` | v1: `claim_id`, `claim` (`completed`, `refused`, `blocked`), `text_sha256`; negotiated v2: a completed claim additionally requires `agent_output` |
 
 The current framework-neutral SDK implementation always emits an
 `agent_response_claim`. File tracking can emit `file_change`. Explicit log files
@@ -79,16 +80,45 @@ Official Judge revalidates every envelope against its actual Run/Input/step and
 stable Submission identity before upload. It sends one public `EvidenceItem`
 per history item with:
 
-- `source`: `defuzex.runtime_evidence.v1`
+- `source`: the negotiated `defuzex.runtime_evidence.v1` or
+  `defuzex.runtime_evidence.v2`
 - `media_type`: `application/vnd.defuzex.runtime-evidence+json`
 - `content`: the canonical UTF-8 JSON above
 - `name`: display-only filename
 
 Transport is negotiated through the Backend's public Judge config. The SDK only
-sends typed items when `evidence_types` explicitly contains
-`defuzex.runtime_evidence.v1`. Otherwise it sends the existing
+sends v2 when `evidence_types` explicitly contains
+`defuzex.runtime_evidence.v2`; v2 wins when both versions are advertised. A
+v1-only service receives the existing byte-compatible hash-only envelope. When
+neither typed version is advertised, the SDK sends the existing
 `defuzex.run_evidence.v1` item, so an older Backend never receives an unknown
-schema.
+schema. The SDK does not use legacy raw logs to emulate v2.
+
+For a completed Submission, v2 adds exactly one field to its existing
+`agent_response_claim`:
+
+```json
+{
+  "kind": "agent_response_claim",
+  "claim_id": "submission-response",
+  "claim": "completed",
+  "text_sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+  "agent_output": {"answer": "the final Agent result"}
+}
+```
+
+`agent_output` is the detached, finite JSON value accepted by `Run.submit()`.
+It is the Agent's final response claim—not a tool result, model event, log,
+trace span, prompt, completion, diff, or repository file. Failed, timed-out,
+aborted, refused, and blocked claims never include it. Explicit `submit(output)`
+still takes precedence over supported semantic OTel output extraction.
+
+The output's canonical JSON is limited to 32,768 UTF-8 bytes. JSON is never
+truncated because doing so could change its meaning or schema. Exceeding that
+limit, the complete 120,000-character envelope limit, or dynamic Judge file and
+total limits raises a stable `KumaError` before multipart POST. `text_sha256`
+keeps the v1 algorithm: strings hash raw UTF-8 with `surrogatepass`; other values
+hash key-sorted compact JSON with ASCII escapes and `allow_nan=false`.
 
 For Official Case generation, `create_run()` derives `evidence_capabilities`
 from the same configured capture boundaries. It only adds that optional public
@@ -100,12 +130,16 @@ the Run can actually produce. The SDK never declares framework-only kinds.
 
 ## Privacy and resource behavior
 
-The envelope contains hashes instead of Agent output, log bodies, trace bodies,
-stdout/stderr, tool arguments, prompts, or model responses. Paths must be safe,
-root-relative, and pass the existing sensitive-path scanner. Invalid, external,
-or sensitive observations are dropped before serialization and reflected in the
-Submission's existing `missing` and `dropped_count` fields. Component and total
-character limits are enforced while retaining the response claim.
+V1 contains hashes instead of Agent output. V2 contains only the bounded final
+Agent output described above; it does not add log bodies, trace bodies,
+stdout/stderr, tool arguments, prompts, model responses, or diff text. Before a
+v2 multipart POST, the SDK applies the existing canonical sensitive JSON scanner
+to `agent_output` with no `allow_sensitive` bypass. Credential findings therefore
+fail locally; the SDK stores neither the matched value nor raw diagnostic text.
+Paths must be safe, root-relative, and pass the existing sensitive-path scanner.
+Invalid, external, or sensitive observations are otherwise dropped before
+serialization and reflected in the Submission's existing `missing` and
+`dropped_count` fields.
 
 Preparation, `save_local=True` persistence, log offsets, and trace exporter
 state retain the existing transaction boundary: only an accepted Submission

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -154,7 +154,10 @@ print(report)
 | custom | custom | Fully local |
 | any | `judge=False` | Complete after the final submission without a Judge |
 
-Custom Case Providers require `max_inputs`. Provider outputs are normalized and validated before entering the Run.
+Custom Case Providers require `max_steps`, the maximum number of steps the Run
+will accept rather than an exact requested count. Official mode may omit it to
+use the public service limit. Provider outputs are normalized and validated;
+KUMA rejects an over-limit Case instead of truncating it.
 
 ### Run state machine
 
@@ -190,7 +193,7 @@ Each `get_input()` to `submit()` interval is one Evidence transaction. Evidence 
 - `save_local=True` writes structured records under `.kuma/runs/<run_id>/submissions/`; local persistence does not replace official submission.
 - `CaptureStatus`, `missing`, `dropped_count`, and `runtime_warnings` expose partial or degraded capture.
 
-Framework-neutral runtime metadata follows the canonical, hash-only [Runtime Evidence contract](runtime-evidence.md); that page is the authoritative schema and privacy reference.
+Framework-neutral runtime metadata follows the [Runtime Evidence contract](runtime-evidence.md). v1 remains hash-only; only an explicitly negotiated v2 official service receives a bounded, scanned completed Agent output. That page is the authoritative schema and privacy reference.
 
 Before official upload, KUMA scans output, errors, paths, diffs, explicit logs, and custom Cases for sensitive material. The API key is used for authorization and is not added to Evidence. `allow_sensitive=True` is an explicit ordinary-Evidence override, not a substitute for isolation or secret hygiene.
 

--- a/docs/sdk-guide.zh-CN.md
+++ b/docs/sdk-guide.zh-CN.md
@@ -154,7 +154,7 @@ print(report)
 | 自定义 | 自定义 | 完全本地 |
 | 任意 | `judge=False` | 最后一次提交后结束，不运行 Judge |
 
-自定义 Case Provider 必须设置 `max_inputs`。Provider 输出进入 Run 前会被归一化并验证。
+自定义 Case Provider 必须设置 `max_steps`；它是 Run 可接受的步骤数上限，不是要求生成的精确数量。官方模式可省略并采用公开服务上限。Provider 输出进入 Run 前会被归一化并验证；KUMA 会拒绝超限 Case，不会截断。
 
 ### Run 状态机
 
@@ -187,7 +187,7 @@ print(report)
 - `save_local=True` 将结构化记录写入 `.kuma/runs/<run_id>/submissions/`；本地记录不能替代官方提交。
 - `CaptureStatus`、`missing`、`dropped_count` 和 `runtime_warnings` 用于呈现采集不完整或降级。
 
-框架无关的运行时元数据遵循规范、仅含哈希的 [Runtime Evidence 合同](runtime-evidence.md)；其 schema 与隐私规则以该文档为准。
+框架无关的运行时元数据遵循 [Runtime Evidence 合同](runtime-evidence.md)。v1 仍仅含哈希；只有官方服务明确协商 v2 后，才会接收经过大小和敏感检查的 completed Agent 最终输出。该文档是 schema 与隐私规则的权威说明。
 
 上传到官方服务前，KUMA 会扫描 output、error、路径、diff、显式日志和自定义 Case 中的敏感内容。API Key 仅用于鉴权，不会加入 Evidence。`allow_sensitive=True` 只是普通 Evidence 的显式覆盖，不能替代隔离与 secret 管理。
 

--- a/examples/minimal_local.py
+++ b/examples/minimal_local.py
@@ -52,7 +52,7 @@ Do not access the network or paths outside the temporary repository.
             repo_path=repo,
             requirement_path=requirement,
             case_provider=local_case,
-            max_inputs=1,
+            max_steps=1,
             judge=False,
             allow_local=True,
             track_files=False,

--- a/examples/single_agent_template/app.py
+++ b/examples/single_agent_template/app.py
@@ -207,7 +207,7 @@ def main(argv: list[str] | None = None) -> int:
             repo_path=repo,
             requirement_path=requirement,
             case_provider=None if use_official else _local_case,
-            max_inputs=None if use_official else 1,
+            max_steps=None if use_official else 1,
             judge=use_official,
             on_failure="stop",
             allow_local=_environment_flag("KUMA_ALLOW_LOCAL", default=not use_official),

--- a/src/kuma/_json_values.py
+++ b/src/kuma/_json_values.py
@@ -1,0 +1,189 @@
+"""Bounded conversion for JSON values accepted by public SDK contracts."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any
+
+MAX_JSON_CONTAINER_DEPTH = 256
+
+
+class JsonStructureError(ValueError):
+    """Report an invalid JSON graph without retaining or displaying its values."""
+
+
+def _transform_json(
+    value: Any,
+    *,
+    freeze: bool,
+    depth: int,
+    active_containers: set[int],
+) -> Any:
+    """Copy one JSON graph while enforcing finite scalars, depth, and acyclicity.
+
+    Args:
+        value: Candidate scalar or container. Mappings and ``list``/``tuple``
+            containers are supported; other Sequence implementations retain
+            their existing unsupported-object behavior.
+        freeze: Return read-only mappings and tuples when ``True``; otherwise
+            return ordinary detached dictionaries and lists.
+        depth: Number of containers on the current ancestor path. The root
+            container therefore enters at depth one.
+        active_containers: Object identities on the current traversal path.
+            Identities are removed when their container finishes, so a shared
+            child used by two siblings is not mistaken for a cycle.
+
+    Returns:
+        A detached value containing only finite JSON scalar types and built-in
+        containers, optionally frozen.
+
+    Raises:
+        JsonStructureError: If a value is unsupported, non-finite, cyclic, or
+            deeper than :data:`MAX_JSON_CONTAINER_DEPTH`.
+        Exception: A custom Mapping may raise while exposing its items. Public
+            SDK boundaries catch and replace such failures with stable errors.
+
+    Preconditions:
+        ``active_containers`` belongs only to this traversal. Callers must not
+        reuse it across independent values.
+
+    Postconditions:
+        Success shares no mutable container with ``value``. Failure retains no
+        caller value or object representation in the raised message.
+
+    Side Effects:
+        Iterates custom Mapping objects and calls ``str`` on their keys, matching
+        the SDK's established mapping-to-JSON behavior. It performs no I/O.
+
+    Security/Privacy:
+        Error text contains only a stable structural reason, never a key,
+        scalar value, object representation, or host detail.
+    """
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return value
+        raise JsonStructureError("non-finite JSON number")
+    if not isinstance(value, (Mapping, list, tuple)):
+        raise JsonStructureError("unsupported JSON value")
+    if depth >= MAX_JSON_CONTAINER_DEPTH:
+        raise JsonStructureError("JSON container depth exceeded")
+
+    identity = id(value)
+    if identity in active_containers:
+        raise JsonStructureError("cyclic JSON value")
+    active_containers.add(identity)
+    try:
+        if isinstance(value, Mapping):
+            transformed = {
+                str(key): _transform_json(
+                    child,
+                    freeze=freeze,
+                    depth=depth + 1,
+                    active_containers=active_containers,
+                )
+                for key, child in value.items()
+            }
+            return MappingProxyType(transformed) if freeze else transformed
+        transformed_items = tuple(
+            _transform_json(
+                child,
+                freeze=freeze,
+                depth=depth + 1,
+                active_containers=active_containers,
+            )
+            for child in value
+        )
+        return transformed_items if freeze else list(transformed_items)
+    finally:
+        active_containers.remove(identity)
+
+
+def detach_json(value: Any) -> Any:
+    """Return a mutable JSON copy after bounded graph and encoder validation.
+
+    Args:
+        value: Candidate public payload. Mappings and ``list``/``tuple`` values
+            may contain at most 256 nested containers, counting a container at
+            the root as level one.
+
+    Returns:
+        A detached graph made only of dictionaries, lists, and finite JSON
+        scalars. Reused but acyclic child containers are copied independently.
+
+    Raises:
+        JsonStructureError: If the graph is cyclic, too deep, non-finite,
+            unsupported, or rejected by Python's JSON encoder.
+        Exception: A custom Mapping may fail while being inspected. SDK caller
+            boundaries convert this to their stable public error type.
+
+    Postconditions:
+        Successful output can be serialized with ``allow_nan=False`` and cannot
+        be mutated through a caller-owned container.
+
+    Side Effects:
+        Iterates custom Mapping values once; performs no persistence, Evidence,
+        network, model, or billing operation.
+
+    Security/Privacy:
+        Structural failure messages never include caller data.
+    """
+    try:
+        plain = _transform_json(
+            value,
+            freeze=False,
+            depth=0,
+            active_containers=set(),
+        )
+        json.dumps(plain, allow_nan=False)
+    except JsonStructureError:
+        raise
+    except (RecursionError, TypeError, ValueError) as exc:
+        raise JsonStructureError("invalid JSON value") from exc
+    return plain
+
+
+def freeze_json(value: Any) -> Any:
+    """Return a recursively immutable copy of one bounded JSON value.
+
+    Args:
+        value: Candidate public contract field following the same accepted
+            shapes and 256-container depth limit as :func:`detach_json`.
+
+    Returns:
+        Finite scalars unchanged, mappings as ``MappingProxyType``, and arrays
+        as tuples. Shared aliases remain valid but become detached copies.
+
+    Raises:
+        JsonStructureError: If ``value`` is cyclic, too deep, non-finite, or not
+            JSON compatible.
+        Exception: A custom Mapping may fail while being inspected. Contract
+            constructors replace this with a stable SDK validation error.
+
+    Postconditions:
+        Success cannot be changed through the source containers and is safe for
+        immutable Input, Submission, Evidence, and report contracts.
+
+    Side Effects:
+        Iterates a custom Mapping once during detachment. No external I/O or SDK
+        lifecycle state is touched.
+    """
+    plain = detach_json(value)
+    return _transform_json(
+        plain,
+        freeze=True,
+        depth=0,
+        active_containers=set(),
+    )
+
+
+__all__ = [
+    "MAX_JSON_CONTAINER_DEPTH",
+    "JsonStructureError",
+    "detach_json",
+    "freeze_json",
+]

--- a/src/kuma/_runtime_filesystem.py
+++ b/src/kuma/_runtime_filesystem.py
@@ -1,0 +1,152 @@
+"""Safe local paths and atomic repository runtime-directory setup."""
+
+from __future__ import annotations
+
+import os
+import stat
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+
+from .errors import ConfigurationError
+
+
+def default_lock_path() -> Path:
+    """Return the shared platform lock path for the single-Run invariant."""
+    runtime_root = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime_root:
+        return Path(runtime_root).expanduser() / "kuma" / "active-run.lock"
+    if os.name == "posix":
+        return Path("/tmp/kuma-active-run.lock")
+    return Path(tempfile.gettempdir()) / "kuma-active-run.lock"
+
+
+def default_runtime_root(mode: str) -> Path:
+    """Return the SDK-owned root used for temporary Run resources."""
+    if mode == "docker":
+        return Path("/tmp/kuma")
+    return Path(tempfile.gettempdir()) / "kuma"
+
+
+def _create_repo_runtime_directory(path: Path) -> bool:
+    """Create ``path`` or verify a concurrently/existing directory.
+
+    Returns ``True`` only when this call created the directory, allowing its
+    caller to remove an empty partial setup after a later atomic-write failure.
+    """
+    try:
+        path.mkdir()
+        return True
+    except FileExistsError:
+        if path.is_dir():
+            return False
+        raise
+
+
+def _write_runtime_ignore_rule(root: Path, gitignore: Path, existing: str) -> None:
+    """Atomically append the KUMA runtime ignore rule and clean failed temps.
+
+    Existing newline style and file mode are retained. The helper deliberately
+    re-raises filesystem and encoding errors for the owning public boundary to
+    translate into one safe :class:`ConfigurationError`.
+    """
+    separator = "\r\n" if "\r\n" in existing else "\n"
+    updated = existing
+    if updated and not updated.endswith(("\n", "\r")):
+        updated += separator
+    updated += f"/.kuma/{separator}"
+    descriptor: int | None = None
+    temporary: Path | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=".gitignore.kuma-",
+            suffix=".tmp",
+            dir=root,
+            text=True,
+        )
+        temporary = Path(temporary_name)
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
+            descriptor = None
+            handle.write(updated)
+        if gitignore.exists():
+            temporary.chmod(stat.S_IMODE(gitignore.stat().st_mode))
+        temporary.replace(gitignore)
+    except BaseException:
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+        if temporary is not None:
+            with suppress(OSError):
+                temporary.unlink(missing_ok=True)
+        raise
+
+
+def _remove_empty_runtime_directory(path: Path, *, created: bool) -> None:
+    """Remove only an empty runtime directory created by the failed operation."""
+    if created:
+        with suppress(OSError):
+            path.rmdir()
+
+
+def ensure_repo_runtime_directory(repo_path: Path) -> Path:
+    """Create the repository runtime directory and idempotent ignore rule.
+
+    Args:
+        repo_path: Existing authorized repository root.
+
+    Returns:
+        Absolute ``<repo>/.kuma`` directory path.
+
+    Raises:
+        ConfigurationError: If the repository is missing, its ``.gitignore`` is
+            not readable UTF-8 text, or atomic runtime setup cannot complete.
+
+    Postconditions:
+        ``.kuma`` exists and ``/.kuma/`` is represented once by an equivalent
+        ignore rule. A failed update removes its temporary file and any new empty
+        ``.kuma`` directory.
+
+    Side Effects:
+        May create ``.kuma`` and atomically replace ``.gitignore``. No repository
+        files are enumerated or uploaded.
+    """
+    created_runtime_directory = False
+    runtime_directory: Path | None = None
+    failure_message: str | None = None
+    try:
+        root = repo_path.expanduser().resolve()
+        if not root.is_dir():
+            raise ConfigurationError("repo_path must be an existing directory")
+        runtime_directory = root / ".kuma"
+        created_runtime_directory = _create_repo_runtime_directory(runtime_directory)
+
+        gitignore = root / ".gitignore"
+        existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
+        normalized_rules = {line.strip() for line in existing.splitlines()}
+        if ".kuma/" in normalized_rules or "/.kuma/" in normalized_rules:
+            return runtime_directory
+
+        _write_runtime_ignore_rule(root, gitignore, existing)
+        return runtime_directory
+    except UnicodeError:
+        assert runtime_directory is not None
+        _remove_empty_runtime_directory(
+            runtime_directory, created=created_runtime_directory
+        )
+        failure_message = "Repository .gitignore must be readable UTF-8 text"
+    except ConfigurationError:
+        raise
+    except (AttributeError, TypeError, ValueError, OSError):
+        if runtime_directory is not None:
+            _remove_empty_runtime_directory(
+                runtime_directory, created=created_runtime_directory
+            )
+        failure_message = "Repository runtime storage is unavailable"
+    raise ConfigurationError(failure_message) from None
+
+
+__all__ = [
+    "default_lock_path",
+    "default_runtime_root",
+    "ensure_repo_runtime_directory",
+]

--- a/src/kuma/api.py
+++ b/src/kuma/api.py
@@ -4,11 +4,16 @@ from __future__ import annotations
 
 import os
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from .config import CreateRunConfig, resolve_create_run_config, write_api_key
-from .contracts import Case
+from .config import (
+    DEFAULT_CASE_MAX_STEPS,
+    CreateRunConfig,
+    resolve_create_run_config,
+    write_api_key,
+)
 from .errors import ConfigurationError, KumaError, ProviderError, ValidationError
 from .evidence.runtime_contract import (
     casegen_framework_is_advertised,
@@ -44,21 +49,95 @@ def configure(*, api_key: str) -> Path:
         Absolute path of the atomically written ``credentials.json`` file.
 
     Raises:
-        ConfigurationError: The key format is invalid or a credential location
-            cannot be resolved.
-        OSError: The credential directory or file cannot be written.
+        ConfigurationError: If the key format or credential location is invalid,
+            or credential storage cannot be written atomically.
 
-    This function performs no network request. ``KUMA_CONFIG_HOME`` redirects
-    the user-level location for isolated development and tests. The file contains
-    the credential, so callers must not print or commit it.
+    Preconditions:
+        ``api_key`` is the complete credential to persist, not a redacted display
+        value. ``KUMA_CONFIG_HOME``, when set, points to the directory in which
+        the caller intends KUMA to store credentials.
+
+    Postconditions:
+        Success leaves one complete JSON credential file at the returned path.
+        A failed atomic replacement removes its temporary file instead of
+        reporting a partial credential as configured.
+
+    Side Effects:
+        Creates the credential directory when needed and atomically replaces the
+        KUMA user credential file. No network request is made.
+
+    Security/Privacy:
+        The file is restricted to the current user where supported. It contains
+        the real key and must not be printed, uploaded, or committed.
     """
 
     return write_api_key(api_key)
 
 
+def _resolve_repo_path(repo_path: str | os.PathLike[str]) -> Path:
+    """Resolve an authorized repository root and contain local path failures.
+
+    Args:
+        repo_path: String or path-like repository directory selected by the caller.
+
+    Returns:
+        Canonical absolute directory with symlink and filesystem-root inputs
+        rejected.
+
+    Raises:
+        ConfigurationError: If the value is not path-like, the path cannot be
+            inspected, or it violates the repository-root safety constraints.
+
+    Security/Privacy:
+        Operating-system errors are replaced with a fixed message so exception
+        text cannot expose a host path, errno, or platform-specific diagnostic.
+    """
+
+    try:
+        expanded = Path(repo_path).expanduser()
+        if expanded.is_symlink():
+            raise ConfigurationError("repo_path must not be a symbolic link")
+        resolved = expanded.resolve()
+        if not resolved.is_dir():
+            raise ConfigurationError("repo_path must be an existing directory")
+        if resolved == Path(resolved.anchor):
+            raise ConfigurationError("repo_path must not be a filesystem root")
+        return resolved
+    except ConfigurationError:
+        raise
+    except (TypeError, ValueError, OSError, RuntimeError):
+        pass
+    raise ConfigurationError(
+        "repo_path must be an accessible path-like directory"
+    ) from None
+
+
+def _repo_root_alias(repo_path: str | os.PathLike[str]) -> Path:
+    """Return the caller-spelled absolute root used for platform path aliases.
+
+    The canonical root is validated first by :func:`_resolve_repo_path`. This
+    second projection intentionally preserves aliases such as macOS ``/var`` so
+    Evidence tracking can correlate operating-system spellings without relaxing
+    containment. Any unexpected path conversion failure remains a safe SDK error.
+    """
+
+    try:
+        return Path(os.path.abspath(Path(repo_path).expanduser()))
+    except (TypeError, ValueError, OSError, RuntimeError):
+        pass
+    raise ConfigurationError(
+        "repo_path must be an accessible path-like directory"
+    ) from None
+
+
 def _resolve_trace_evidence(
     configured: TraceEvidenceCapture | None,
 ) -> tuple[TraceEvidenceCapture | None, str | None]:
+    """Prefer explicit Trace capture, otherwise attach to compatible global OTel.
+
+    Automatic discovery is optional and failure-isolated: inability to import or
+    attach OTel becomes a safe runtime warning instead of blocking Run creation.
+    """
     if configured is not None:
         if not isinstance(configured, TraceEvidenceCapture):
             raise ConfigurationError(
@@ -75,23 +154,131 @@ def _resolve_trace_evidence(
             return None, "trace_auto_capture_unavailable"
         return capture, None
     except Exception:
-        # Optional observability must never turn a valid Run into a failed Run.
+        # Automatic observability cannot turn a valid Run into a failed Run.
         return None, "trace_auto_attach_failed"
+
+
+def _prepare_case_requirement(
+    case_provider: CaseProvider | Callable[[CaseGenerationContext], Any] | None,
+    requirement_path: str | os.PathLike[str] | None,
+) -> tuple[CaseProvider | None, RequirementSpec | None]:
+    """Validate the Case Provider requirement precondition before side effects.
+
+    ``create_run`` invokes this local boundary immediately after pure option
+    validation. It adapts a custom Provider only far enough to read its declared
+    ``requirement_required`` policy, then delegates all requirement parsing to
+    :func:`parse_requirement`. Official mode is represented by a ``None``
+    Provider and always requires a requirement.
+
+    Args:
+        case_provider: User-supplied Case Provider/callable, or ``None`` to select
+            the official Provider.
+        requirement_path: Explicit requirement file to parse. ``None`` is valid
+            only when the adapted custom Provider declares
+            ``requirement_required=False``.
+
+    Returns:
+        The adapted custom Provider (or ``None`` for official mode) and the parsed
+        requirement (or ``None`` for an opted-out custom Provider).
+
+    Raises:
+        ConfigurationError: If a custom Provider cannot be adapted.
+        ValidationError: With ``requirement_required`` when a required path is
+            absent, or with the existing parser code when the selected file is
+            missing or invalid.
+
+    Preconditions:
+        General ``create_run`` options have passed pure configuration validation;
+        no credential, repository, Runtime, Evidence, or transport setup has run.
+
+    Postconditions:
+        Success proves the selected Provider's requirement precondition and, when
+        a path was supplied, returns the one canonical parsed representation.
+        Failure leaves Backend, Runtime, Evidence, and repository state untouched.
+
+    Side Effects:
+        May read only the explicitly selected requirement and its explicitly
+        referenced local schema through :func:`parse_requirement`. It performs no
+        credential lookup, repository scan, OTel attachment, or network request.
+
+    Security/Privacy:
+        Requirement content remains local at this stage and is never sent by this
+        helper. Later official-wire allowlisting and sensitive scanning still own
+        the upload boundary.
+    """
+    adapted = None if case_provider is None else adapt_case_provider(case_provider)
+    requirement_required = adapted is None or bool(
+        getattr(adapted, "requirement_required", True)
+    )
+    if requirement_required and requirement_path is None:
+        raise ValidationError(
+            "This Case Provider requires an explicit requirement_path",
+            code="requirement_required",
+        )
+    requirement = (
+        None if requirement_path is None else parse_requirement(requirement_path)
+    )
+    return adapted, requirement
 
 
 def _adapted_providers(
     *,
     config: CreateRunConfig,
-    case_provider: Any,
+    case_provider: CaseProvider | None,
     judge_provider: Any,
     api_key: str | None,
     repo_path: Path,
     trace_evidence: TraceEvidenceCapture | None,
 ) -> tuple[CaseProvider, JudgeProvider | None, bool, bool]:
+    """Resolve local or official Providers and negotiate safe Evidence capability.
+
+    Official Case plus Judge may read entitlements for Evidence negotiation. An
+    explicit official ``max_steps`` also requires that public read before a new
+    Case operation; the provider reuses the same response when both apply.
+    Private service configuration never enters the SDK.
+
+    Args:
+        config: Validated options controlling Judge, privacy, timeout, retry, and
+            current Evidence capture abilities.
+        case_provider: Provider already adapted by the requirement preflight, or
+            ``None`` for official Case.
+        judge_provider: User provider/callback, or ``None`` for official Judge.
+        api_key: Optional explicit public Backend credential.
+        repo_path: Canonical repository root used for safe pending-state paths.
+        trace_evidence: Active in-process OTel capture, or ``None``.
+
+    Returns:
+        Adapted Case provider, optional Judge provider, and booleans identifying
+        whether each side is official.
+
+    Raises:
+        ConfigurationError: If a custom Case lacks ``max_steps`` or a provider
+            configuration is invalid.
+        KumaError: If public capability negotiation fails.
+
+    Preconditions:
+        ``config`` and ``repo_path`` have passed local validation, and a custom
+        Case Provider has already passed requirement preflight adaptation.
+
+    Postconditions:
+        Returned providers implement SDK protocols. New CaseGen capability fields
+        are enabled only when the service advertises the exact framework and the
+        SDK can truthfully emit observable Evidence. When already fetched, the
+        entitlement response is attached to the official Case provider so its
+        step-limit preflight does not duplicate the GET.
+
+    Side Effects:
+        May resolve credentials and perform one public entitlements GET. It does
+        not generate a Case or run Judge.
+
+    Security/Privacy:
+        Negotiation sends no repository/requirement content and never reads or
+        stores private service configuration.
+    """
     official_case = case_provider is None
     official_judge = config.judge and judge_provider is None
-    if not official_case and config.max_inputs is None:
-        raise ConfigurationError("Custom Case Providers require max_inputs")
+    if not official_case and config.max_steps is None:
+        raise ConfigurationError("Custom Case Providers require max_steps")
 
     backend = None
     if official_case or official_judge:
@@ -106,10 +293,10 @@ def _adapted_providers(
         trace_evidence_configured=trace_evidence is not None,
     )
     can_negotiate = bool(official_case and official_judge and evidence_capabilities)
+    entitlements = None
     if can_negotiate and backend is not None:
-        can_negotiate = casegen_framework_is_advertised(
-            backend.json("GET", "/sdk/entitlements/")
-        )
+        entitlements = backend.json("GET", "/sdk/entitlements/")
+        can_negotiate = casegen_framework_is_advertised(entitlements)
     if not can_negotiate:
         evidence_capabilities = ()
     if official_case and backend is not None:
@@ -117,11 +304,14 @@ def _adapted_providers(
             backend,
             allow_sensitive=config.allow_sensitive,
             operation_wait_timeout=config.operation_wait_timeout,
+            max_steps=config.max_steps,
         )
+        if entitlements is not None:
+            official_case_provider._configure_entitlements(entitlements)
         official_case_provider._configure_evidence_capabilities(evidence_capabilities)
         adapted_case: CaseProvider = official_case_provider
     else:
-        adapted_case = adapt_case_provider(case_provider)
+        adapted_case = case_provider
     if not config.judge:
         adapted_judge = None
     elif official_judge and backend is not None:
@@ -136,239 +326,6 @@ def _adapted_providers(
     return adapted_case, adapted_judge, official_case, official_judge
 
 
-def _create_run_config(
-    *,
-    strategy: str,
-    max_inputs: int | None,
-    judge: bool,
-    on_failure: str,
-    allow_local: bool,
-    track_files: bool,
-    upload_diff: bool,
-    save_local: bool,
-    allow_sensitive: bool,
-    timeout: float,
-    operation_wait_timeout: float,
-    max_retries: int,
-) -> CreateRunConfig:
-    config = resolve_create_run_config(
-        {
-            "strategy": strategy,
-            "max_inputs": max_inputs,
-            "judge": judge,
-            "on_failure": on_failure,
-            "allow_local": allow_local,
-            "track_files": track_files,
-            "upload_diff": upload_diff,
-            "save_local": save_local,
-            "allow_sensitive": allow_sensitive,
-            "timeout": timeout,
-            "operation_wait_timeout": operation_wait_timeout,
-            "max_retries": max_retries,
-        }
-    )
-    if config.upload_diff and not config.track_files:
-        raise ConfigurationError("upload_diff requires track_files=True")
-    return config
-
-
-def _case_generation_context(
-    *,
-    resolved_repo: Path,
-    requirement_path: str | os.PathLike[str] | None,
-    config: CreateRunConfig,
-) -> tuple[RequirementSpec | None, CaseGenerationContext]:
-    requirement = (
-        None if requirement_path is None else parse_requirement(requirement_path)
-    )
-    repo_meta = collect_repo_meta(resolved_repo)
-    context = CaseGenerationContext(
-        repo_path=resolved_repo,
-        repo_meta=repo_meta.to_dict(),
-        requirement=None if requirement is None else requirement.content,
-        agent_description=None
-        if requirement is None
-        else requirement.agent_description,
-        requirement_sections={} if requirement is None else requirement.sections,
-        input_type="auto" if requirement is None else requirement.input_type,
-        input_schema=None if requirement is None else requirement.input_schema,
-        strategy=config.strategy,
-        max_inputs=config.max_inputs or 50,
-    )
-    return requirement, context
-
-
-def _generated_case(
-    *,
-    provider: CaseProvider,
-    context: CaseGenerationContext,
-    requirement: RequirementSpec | None,
-    run_id: str,
-    config: CreateRunConfig,
-) -> Case:
-    try:
-        raw_case = provider.generate_case(context)
-    except KumaError:
-        raise
-    except Exception as exc:
-        raise ProviderError("The custom Case Provider failed") from exc
-    return normalize_case(
-        raw_case,
-        run_id=run_id,
-        max_inputs=config.max_inputs or 50,
-        required_input_type=None if requirement is None else requirement.input_type,
-        required_input_schema=(
-            None if requirement is None else requirement.input_schema
-        ),
-    )
-
-
-def _validate_case_provenance_and_rubric(
-    *,
-    case: Case,
-    official_case: bool,
-    official_judge: bool,
-    config: CreateRunConfig,
-) -> None:
-    official_provenance = case.extensions.get("official_case")
-    if official_case:
-        validate_official_case_provenance(official_provenance)
-    elif "official_case" in case.extensions:
-        raise ProviderError(
-            "Custom Case Provider returned reserved official_case metadata",
-            code="invalid_case_provenance",
-        )
-    if (
-        not official_case
-        and config.judge
-        and not official_judge
-        and case.rubric is None
-    ):
-        raise ConfigurationError(
-            "Custom Case + custom Judge requires a fixed public rubric"
-        )
-
-
-def _evidence_collector(
-    *,
-    runtime: RuntimeSession,
-    resolved_repo: Path,
-    run_id: str,
-    case: Case,
-    config: CreateRunConfig,
-    official_judge: bool,
-    trace_evidence: TraceEvidenceCapture | None,
-) -> EvidenceCollector:
-    tracking_root = Path("/") if runtime.mode == "docker" else resolved_repo
-    return EvidenceCollector(
-        root=tracking_root,
-        scope="container" if runtime.mode == "docker" else "local",
-        excluded_roots=(runtime.workspace.runtime_root, resolved_repo / ".kuma"),
-        track_files=config.track_files,
-        upload_diff=config.upload_diff,
-        save_local=config.save_local,
-        allow_sensitive=config.allow_sensitive,
-        block_sensitive=official_judge or trace_evidence is not None,
-        persistent_path=runtime.workspace.persistent_path,
-        run_id=run_id,
-        case_id=case.case_id,
-        trace_evidence=trace_evidence,
-    )
-
-
-def _assemble_run(
-    *,
-    runtime: RuntimeSession,
-    resolved_repo: Path,
-    requirement_path: str | os.PathLike[str] | None,
-    run_id: str,
-    config: CreateRunConfig,
-    case_provider: CaseProvider,
-    judge_provider: JudgeProvider | None,
-    official_case: bool,
-    official_judge: bool,
-    trace_evidence: TraceEvidenceCapture | None,
-    trace_auto_warning: str | None,
-) -> Run:
-    requirement, context = _case_generation_context(
-        resolved_repo=resolved_repo,
-        requirement_path=requirement_path,
-        config=config,
-    )
-    case = _generated_case(
-        provider=case_provider,
-        context=context,
-        requirement=requirement,
-        run_id=run_id,
-        config=config,
-    )
-    _validate_case_provenance_and_rubric(
-        case=case,
-        official_case=official_case,
-        official_judge=official_judge,
-        config=config,
-    )
-    evidence = _evidence_collector(
-        runtime=runtime,
-        resolved_repo=resolved_repo,
-        run_id=run_id,
-        case=case,
-        config=config,
-        official_judge=official_judge,
-        trace_evidence=trace_evidence,
-    )
-    if trace_auto_warning is not None:
-        evidence.runtime_warnings.append(trace_auto_warning)
-    return Run(
-        run_id=run_id,
-        case=case,
-        runtime=runtime,
-        judge_provider=judge_provider,
-        judge_enabled=config.judge,
-        on_failure=config.on_failure,
-        strategy=config.strategy,
-        evidence=evidence,
-    )
-
-
-def _open_run(
-    *,
-    resolved_repo: Path,
-    requirement_path: str | os.PathLike[str] | None,
-    config: CreateRunConfig,
-    case_provider: CaseProvider,
-    judge_provider: JudgeProvider | None,
-    official_case: bool,
-    official_judge: bool,
-    trace_evidence: TraceEvidenceCapture | None,
-    trace_auto_warning: str | None,
-) -> Run:
-    run_id = f"run_{uuid.uuid4().hex}"
-    runtime = RuntimeSession.open(
-        run_id=run_id,
-        repo_path=resolved_repo,
-        allow_local=config.allow_local,
-        save_local=config.save_local,
-    )
-    try:
-        return _assemble_run(
-            runtime=runtime,
-            resolved_repo=resolved_repo,
-            requirement_path=requirement_path,
-            run_id=run_id,
-            config=config,
-            case_provider=case_provider,
-            judge_provider=judge_provider,
-            official_case=official_case,
-            official_judge=official_judge,
-            trace_evidence=trace_evidence,
-            trace_auto_warning=trace_auto_warning,
-        )
-    except BaseException:
-        runtime.close()
-        raise
-
-
 def create_run(
     *,
     repo_path: str | os.PathLike[str] = ".",
@@ -376,7 +333,7 @@ def create_run(
     case_provider: Any = None,
     judge_provider: Any = None,
     strategy: str = "auto",
-    max_inputs: int | None = None,
+    max_steps: int | None = None,
     judge: bool = True,
     on_failure: str = "continue",
     allow_local: bool = False,
@@ -394,71 +351,110 @@ def create_run(
 
     Args:
         repo_path: Repository root visible to the Agent. Defaults to the current
-            directory and is resolved to an absolute path.
+            directory. Symlink roots, filesystem roots, and missing directories
+            are rejected before runtime creation.
         requirement_path: UTF-8 requirement file used for Case generation.
             Official Case generation requires it; a custom Provider may opt out.
-        case_provider: ``CaseProvider`` or compatible callable. ``None`` selects
-            the official authenticated Provider.
-        judge_provider: ``JudgeProvider`` or compatible callable. ``None``
-            selects the official Provider when ``judge=True``.
-        strategy: ``"auto"`` or an explicit server strategy ID. The SDK never
+        case_provider: :class:`CaseProvider` or compatible callable. ``None``
+            selects the official authenticated provider.
+        judge_provider: :class:`JudgeProvider` or compatible callable. ``None``
+            selects the official provider when ``judge=True``.
+        strategy: ``"auto"`` or an explicit public strategy ID. The SDK never
             invents or silently substitutes an unknown strategy.
-        max_inputs: Positive upper bound for Case Inputs. Custom Case Providers
-            require an explicit value; ``None`` uses the official service policy.
+        max_steps: Maximum number of Case steps allowed. For example, ``3``
+            permits one, two, or three inputs; it does not require exactly three.
+            In official mode a value above the current service limit is rejected
+            before Case generation, with the allowed maximum available in the
+            stable error details; the SDK never truncates a returned Case. Custom
+            Case Providers require an explicit positive value. ``None`` uses the
+            official service policy.
         judge: Whether to request a final Judgment after the last Submission.
         on_failure: ``"continue"`` advances after a non-completed Submission;
             ``"stop"`` closes the Run immediately.
-        allow_local: Permit a trusted non-Docker development run. It does not
-            create a sandbox or relax privacy and protocol validation.
-        track_files: Capture bounded file metadata before and after each Input.
-        upload_diff: Include bounded text diffs; requires ``track_files=True``
-            and may expose repository text to the configured Judge.
-        save_local: Persist structured Submission records beneath
-            ``.kuma/runs/<run_id>/`` using atomic replacement.
-        allow_sensitive: Permit ordinary Evidence that triggers the sensitive
-            scanner. It never relaxes the OpenTelemetry allowlist.
-        timeout: Positive finite per-request HTTP timeout in seconds.
-        operation_wait_timeout: Positive finite total wait in seconds for one
-            official asynchronous Case or Judge operation.
-        max_retries: Automatic transient HTTP retries, inclusive range 0 through
-            5. Idempotent POST retries reuse the same request key.
-        api_key: Per-call ``dfx_`` credential. ``None`` falls back to
-            ``KUMA_API_KEY`` and then the user credential file.
-        trace_evidence: Capture returned by
+        allow_local: Permit a trusted non-Docker development run. This does not
+            create a sandbox or relax path, privacy, and protocol validation.
+        track_files: Capture bounded repository file metadata before and after
+            each input.
+        upload_diff: Include bounded safe text diffs. Requires
+            ``track_files=True`` and may expose selected repository text to the
+            configured Judge after sensitive scanning.
+        save_local: Persist committed Submission records under the SDK-owned
+            ``.kuma/runs/<run_id>/`` directory using atomic replacement.
+        allow_sensitive: Permit ordinary Evidence that triggers the scanner in
+            contracts where this opt-in is supported. It never permits secrets,
+            private rubrics, or non-allowlisted OTel values.
+        timeout: Positive finite timeout in seconds for each HTTP request.
+        operation_wait_timeout: Positive finite total seconds allowed for one
+            official asynchronous Case or Judge operation, across all polls.
+        max_retries: Transient HTTP retries after the first attempt, from ``0``
+            through ``5``. Retried idempotent requests reuse the same key.
+        api_key: Per-call opaque ``dfx_`` credential. ``None`` resolves
+            ``KUMA_API_KEY`` and then the local credential file when an official
+            provider needs authentication.
+        trace_evidence: Capture created by
             :func:`kuma.otel.configure_trace_evidence`. ``None`` attempts to
-            reuse a compatible configured global OTel Provider and otherwise
-            records a non-blocking runtime warning.
+            reuse a compatible configured global OTel provider; unavailable OTel
+            becomes a non-blocking ``runtime_warnings`` entry.
 
     Returns:
-        A synchronous :class:`kuma.run.Run` in ``ready`` state.
+        A synchronous :class:`Run` in ``ready`` state. Use ``get_input`` and
+        ``submit`` alternately, then inspect ``report`` after judging.
 
     Raises:
-        KumaError: Configuration, authentication, Provider, runtime isolation,
-            Case validation, or public service validation fails. The concrete
-            subclass exposes stable ``code`` and ``retryable`` fields.
+        KumaError: If configuration, authentication, runtime isolation, Case
+            generation/validation, Evidence setup, or a public service response
+            fails. Concrete subclasses expose stable ``code`` and ``retryable``.
 
-    Official Providers use only the public Backend. Custom Providers remain
-    local unless paired with an official Provider. The caller owns Agent
-    execution and must alternate :meth:`Run.get_input` with one
-    :meth:`Run.submit`, or call :meth:`Run.cancel` when abandoning the Run.
+    Preconditions:
+        ``repo_path`` is the repository the caller authorizes KUMA to inspect.
+        Official generation needs a readable requirement and valid credential.
+        Unless ``allow_local=True``, the process runs in the supported container.
+        Only one Run may own the process/container active-Run lease at a time.
+
+    Postconditions:
+        Success returns one validated Case with a non-empty input sequence no
+        larger than ``max_steps`` when supplied, and retains the active lease
+        until completion/cancellation. If setup fails after lease acquisition,
+        runtime resources are closed before the exception escapes.
+
+    Side Effects:
+        Reads the requirement and bounded repository metadata; may create the
+        repository ``.kuma`` runtime area; may call the public Backend for
+        official Case generation. The caller must call ``cancel`` when abandoning
+        an unfinished Run so resources are released promptly.
+
+    Security/Privacy:
+        Official providers communicate only with the public Backend. The SDK
+        never contacts MCP, a model provider, or a database directly. Repository,
+        Evidence, and OTel capture are bounded and sensitive-data checked. Custom
+        providers execute in-process and therefore inherit caller permissions.
     """
 
-    config = _create_run_config(
-        strategy=strategy,
-        max_inputs=max_inputs,
-        judge=judge,
-        on_failure=on_failure,
-        allow_local=allow_local,
-        track_files=track_files,
-        upload_diff=upload_diff,
-        save_local=save_local,
-        allow_sensitive=allow_sensitive,
-        timeout=timeout,
-        operation_wait_timeout=operation_wait_timeout,
-        max_retries=max_retries,
+    config = resolve_create_run_config(
+        {
+            "strategy": strategy,
+            "max_steps": max_steps,
+            "judge": judge,
+            "on_failure": on_failure,
+            "allow_local": allow_local,
+            "track_files": track_files,
+            "upload_diff": upload_diff,
+            "save_local": save_local,
+            "allow_sensitive": allow_sensitive,
+            "timeout": timeout,
+            "operation_wait_timeout": operation_wait_timeout,
+            "max_retries": max_retries,
+        }
     )
+    if config.upload_diff and not config.track_files:
+        raise ConfigurationError("upload_diff requires track_files=True")
+    adapted_case_input, requirement = _prepare_case_requirement(
+        case_provider,
+        requirement_path,
+    )
+    resolved_repo = _resolve_repo_path(repo_path)
+    repo_root_alias = _repo_root_alias(repo_path)
     trace_evidence, trace_auto_warning = _resolve_trace_evidence(trace_evidence)
-    resolved_repo = Path(repo_path).expanduser().resolve()
     (
         adapted_case_provider,
         adapted_judge_provider,
@@ -466,31 +462,105 @@ def create_run(
         official_judge,
     ) = _adapted_providers(
         config=config,
-        case_provider=case_provider,
+        case_provider=adapted_case_input,
         judge_provider=judge_provider,
         api_key=api_key,
         repo_path=resolved_repo,
         trace_evidence=trace_evidence,
     )
-    requirement_required = bool(
-        getattr(adapted_case_provider, "requirement_required", True)
+
+    run_id = f"run_{uuid.uuid4().hex}"
+    runtime = RuntimeSession.open(
+        run_id=run_id,
+        repo_path=resolved_repo,
+        allow_local=config.allow_local,
+        save_local=config.save_local,
     )
-    if requirement_required and requirement_path is None:
-        raise ValidationError(
-            "This Case Provider requires an explicit requirement_path",
-            code="requirement_required",
+    try:
+        effective_max_steps = config.max_steps or (
+            DEFAULT_CASE_MAX_STEPS if official_case else 50
         )
-    return _open_run(
-        resolved_repo=resolved_repo,
-        requirement_path=requirement_path,
-        config=config,
-        case_provider=adapted_case_provider,
-        judge_provider=adapted_judge_provider,
-        official_case=official_case,
-        official_judge=official_judge,
-        trace_evidence=trace_evidence,
-        trace_auto_warning=trace_auto_warning,
-    )
+        repo_meta = collect_repo_meta(resolved_repo)
+        context = CaseGenerationContext(
+            repo_path=resolved_repo,
+            repo_meta=repo_meta.to_dict(),
+            requirement=None if requirement is None else requirement.content,
+            agent_description=(
+                None if requirement is None else requirement.agent_description
+            ),
+            requirement_sections=({} if requirement is None else requirement.sections),
+            input_type="auto" if requirement is None else requirement.input_type,
+            input_schema=None if requirement is None else requirement.input_schema,
+            strategy=config.strategy,
+            max_steps=effective_max_steps,
+        )
+        try:
+            raw_case = adapted_case_provider.generate_case(context)
+        except KumaError:
+            raise
+        except Exception as exc:
+            raise ProviderError("The custom Case Provider failed") from exc
+        case = normalize_case(
+            raw_case,
+            run_id=run_id,
+            max_steps=effective_max_steps,
+            required_input_type=(
+                None if requirement is None else requirement.input_type
+            ),
+            required_input_schema=(
+                None if requirement is None else requirement.input_schema
+            ),
+        )
+        official_provenance = case.extensions.get("official_case")
+        if official_case:
+            validate_official_case_provenance(official_provenance)
+        elif "official_case" in case.extensions:
+            raise ProviderError(
+                "Custom Case Provider returned reserved official_case metadata",
+                code="invalid_case_provenance",
+            )
+        if (
+            not official_case
+            and config.judge
+            and not official_judge
+            and case.rubric is None
+        ):
+            raise ConfigurationError(
+                "Custom Case + custom Judge requires a fixed public rubric"
+            )
+        evidence = EvidenceCollector(
+            root=resolved_repo,
+            root_alias=repo_root_alias,
+            scope="container" if runtime.mode == "docker" else "local",
+            excluded_roots=(
+                runtime.workspace.runtime_root,
+                resolved_repo / ".kuma",
+            ),
+            track_files=config.track_files,
+            upload_diff=config.upload_diff,
+            save_local=config.save_local,
+            allow_sensitive=config.allow_sensitive,
+            block_sensitive=official_judge or trace_evidence is not None,
+            persistent_path=runtime.workspace.persistent_path,
+            run_id=run_id,
+            case_id=case.case_id,
+            trace_evidence=trace_evidence,
+        )
+        if trace_auto_warning is not None:
+            evidence.runtime_warnings.append(trace_auto_warning)
+        return Run(
+            run_id=run_id,
+            case=case,
+            runtime=runtime,
+            judge_provider=adapted_judge_provider,
+            judge_enabled=config.judge,
+            on_failure=config.on_failure,
+            strategy=config.strategy,
+            evidence=evidence,
+        )
+    except BaseException:
+        runtime.close()
+        raise
 
 
 __all__ = ["configure", "create_run"]

--- a/src/kuma/cli.py
+++ b/src/kuma/cli.py
@@ -12,10 +12,12 @@ from .local_quickstart import run_local_quickstart
 
 
 def _emit(data: Any) -> None:
+    """Write one JSON value to standard output for CLI callers."""
     print(json.dumps(data, ensure_ascii=False, indent=2))
 
 
 def cmd_whoami(args: argparse.Namespace) -> int:
+    """Fetch and print public entitlements for the configured API key."""
     base_url = args.base_url or os.environ.get("KUMA_BASE_URL", DEFAULT_BASE_URL)
     client = KumaClient(base_url=base_url, timeout=args.timeout)
     _emit(client.entitlements())
@@ -23,6 +25,7 @@ def cmd_whoami(args: argparse.Namespace) -> int:
 
 
 def cmd_quickstart(args: argparse.Namespace) -> int:
+    """Run the deterministic credential-free local quickstart command."""
     try:
         result = run_local_quickstart(demonstrate_failure=args.fail_demo)
     except Exception:
@@ -40,6 +43,7 @@ def cmd_quickstart(args: argparse.Namespace) -> int:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the public CLI parser without performing I/O."""
     parser = argparse.ArgumentParser(prog="kuma")
     subparsers = parser.add_subparsers(dest="command", required=True)
     whoami = subparsers.add_parser(
@@ -62,6 +66,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Parse CLI arguments, invoke the selected command, and return its exit code."""
     args = build_parser().parse_args(argv)
     try:
         return args.func(args)

--- a/src/kuma/client.py
+++ b/src/kuma/client.py
@@ -1,4 +1,4 @@
-"""Public account and service-configuration client for the v4 HTTP boundary."""
+"""Backward-compatible public client backed by the v4 HTTP boundary."""
 
 from __future__ import annotations
 
@@ -31,20 +31,34 @@ class KumaClient:
     """Read account and public service configuration without creating a Run.
 
     Args:
-        api_key: Optional ``dfx_`` credential. ``None`` resolves
-            ``KUMA_API_KEY`` and then the user credential file. Construction may
-            remain unauthenticated, but read methods then raise
-            ``KumaAuthenticationError``.
+        api_key: Optional opaque ``dfx_`` credential. ``None`` resolves
+            ``KUMA_API_KEY`` and then the local credential file. Construction may
+            remain unauthenticated, but read methods then raise an authentication
+            error.
         base_url: Public Backend API base URL. Remote URLs require HTTPS;
-            loopback HTTP is accepted for local integration.
+            loopback HTTP is accepted for local integration testing.
         timeout: Positive finite timeout in seconds for each GET request.
-        transport: Optional test/integration transport implementing the public
-            wire callable contract. Ordinary users should leave it as ``None``.
+        transport: Optional boundary callable used by deterministic integration
+            tests. Ordinary users should leave it as ``None``.
 
     Raises:
-        ConfigurationError: The URL, timeout, or resolved credential is invalid.
+        ConfigurationError: If URL, timeout, or a discovered credential is invalid.
 
-    The client never contacts MCP, model providers, or databases directly.
+    Preconditions:
+        A remote ``base_url`` uses HTTPS. A supplied/discovered key satisfies the
+        KUMA format; omitting a key is allowed only until an authenticated read.
+
+    Postconditions:
+        The reusable client holds validated URL, timeout, and credential state.
+        Construction makes no request and does not prove server acceptance.
+
+    Side Effects:
+        May read ``KUMA_API_KEY`` or the user credential file. Public read
+        methods each perform one Backend GET request without retry.
+
+    Security/Privacy:
+        ``repr`` exposes only URL and whether a key exists, never its value. This
+        client does not contact MCP, model providers, or databases directly.
     """
 
     def __init__(
@@ -55,6 +69,21 @@ class KumaClient:
         timeout: float = 30.0,
         transport: Transport | None = None,
     ) -> None:
+        """Validate configuration and prepare credential-optional public reads.
+
+        Args:
+            api_key: Optional explicit opaque credential; see the class contract.
+            base_url: Public Backend base URL.
+            timeout: Per-request deadline in seconds.
+            transport: Optional HTTP boundary replacement for tests.
+
+        Raises:
+            ConfigurationError: If any configuration value is invalid.
+
+        Postconditions:
+            An authenticated internal Backend client exists only when a key was
+            resolved. No HTTP request has occurred.
+        """
         self.base_url = _validate_base_url(base_url)
         self.timeout = _validate_timeout(timeout)
         resolved_key = resolve_api_key(api_key, required=False)
@@ -72,51 +101,110 @@ class KumaClient:
         )
 
     def __repr__(self) -> str:
+        """Return a credential-safe diagnostic representation.
+
+        Returns:
+            Text containing the public base URL and authentication-presence flag.
+
+        Security/Privacy:
+            The API key and credential path are never included.
+        """
         return (
             f"KumaClient(base_url={self.base_url!r}, "
             f"authenticated={self._authenticated})"
         )
 
     def _read(self, path: str) -> Mapping[str, Any]:
+        """Perform one public configuration GET and map legacy client errors.
+
+        Args:
+            path: Absolute SDK API route relative to ``base_url``.
+
+        Returns:
+            Decoded JSON object returned by the public Backend.
+
+        Raises:
+            KumaAuthenticationError: If no key is configured or authentication
+                is rejected.
+            KumaPermissionError: If the key lacks the required scope.
+            KumaRateLimitError: If the account quota is exhausted.
+            KumaError: For other validated public transport failures.
+
+        Preconditions:
+            ``path`` is a fixed SDK route chosen by a public method, not an
+            arbitrary caller URL.
+
+        Side Effects:
+            Performs one authenticated HTTPS/allowed-loopback GET request.
+
+        Security/Privacy:
+            Stable public errors are exposed without returning raw remote bodies.
+        """
         if self._backend is None:
             raise KumaAuthenticationError(
                 401, "Set KUMA_API_KEY or pass api_key to KumaClient."
             )
         try:
             return self._backend.json("GET", path)
-        except AuthenticationError:
-            raise KumaAuthenticationError(
-                401, "The KUMA API key is invalid, expired, or revoked."
-            ) from None
-        except PermissionDeniedError:
-            raise KumaPermissionError(
-                403, "The KUMA API key lacks permission for this operation."
-            ) from None
+        except AuthenticationError as exc:
+            raise KumaAuthenticationError(401, str(exc)) from None
+        except PermissionDeniedError as exc:
+            raise KumaPermissionError(403, str(exc)) from None
         except LimitExceededError:
             raise KumaRateLimitError(
                 429, "The KUMA account quota has been exhausted."
             ) from None
 
     def entitlements(self) -> Mapping[str, Any]:
-        """Return public user, key-scope, subscription, and quota information.
+        """Fetch public user, key-scope, subscription, and quota information.
 
-        Raises ``KumaAuthenticationError``, ``KumaPermissionError``, or
-        ``KumaRateLimitError`` for the corresponding public HTTP boundary.
+        Returns:
+            Validated JSON mapping from ``/sdk/entitlements/``. Callers should
+            treat unknown forward-compatible fields as data.
+
+        Raises:
+            KumaAuthenticationError: No usable key or rejected authentication.
+            KumaPermissionError: Key cannot read entitlements.
+            KumaRateLimitError: Account quota prevents the read.
+
+        Side Effects:
+            Performs one public Backend GET request.
         """
 
         return self._read("/sdk/entitlements/")
 
     def strategies(self) -> Mapping[str, Any]:
-        """Return the Backend-managed public active Case strategy catalog.
+        """Fetch the public active Case strategy catalog for explicit discovery.
 
-        This is an explicit discovery read; Case generation does not use it as a
-        client-side availability precheck.
+        Returns:
+            Backend-managed strategy mapping available to this credential.
+
+        Raises:
+            KumaAuthenticationError: No usable key or rejected authentication.
+            KumaPermissionError: Key cannot read strategy configuration.
+            KumaRateLimitError: Account quota prevents the read.
+
+        Side Effects:
+            Performs one public Backend GET. Case generation does not use this
+            method as a client-side availability precheck.
         """
 
         return self._read("/sdk/strategies/")
 
     def judge_config(self) -> Mapping[str, Any]:
-        """Return current public Judge upload limits and accepted Evidence types."""
+        """Fetch current public Judge upload limits and Evidence types.
+
+        Returns:
+            Backend configuration mapping used to bound official Evidence upload.
+
+        Raises:
+            KumaAuthenticationError: No usable key or rejected authentication.
+            KumaPermissionError: Key cannot read Judge configuration.
+            KumaRateLimitError: Account quota prevents the read.
+
+        Side Effects:
+            Performs one public Backend GET request.
+        """
 
         return self._read("/sdk/judge/config/")
 

--- a/src/kuma/config.py
+++ b/src/kuma/config.py
@@ -19,10 +19,25 @@ from .errors import AuthenticationError, ConfigurationError
 
 MAX_RETRIES = 5
 DEFAULT_OPERATION_WAIT_TIMEOUT = 600.0
+DEFAULT_CASE_MAX_STEPS = 10
 _MAX_API_KEY_BYTES = 512
 
 
 def validate_max_retries(value: int) -> int:
+    """Validate the number of HTTP retries allowed after the first attempt.
+
+    Args:
+        value: Integer from ``0`` through :data:`MAX_RETRIES`. ``0`` disables
+            retries; it does not disable the initial request. Booleans are not
+            accepted as integers.
+
+    Returns:
+        The unchanged validated retry count.
+
+    Raises:
+        ConfigurationError: If ``value`` is outside the closed range or is not
+            an integer.
+    """
     if (
         isinstance(value, bool)
         or not isinstance(value, int)
@@ -34,6 +49,19 @@ def validate_max_retries(value: int) -> int:
 
 
 def validate_operation_wait_timeout(value: float) -> float:
+    """Validate the total wait deadline for an asynchronous Case or Judge operation.
+
+    Args:
+        value: Positive finite seconds covering all polling attempts. This is
+            separate from the timeout of each individual HTTP request.
+
+    Returns:
+        The validated deadline converted to ``float`` seconds.
+
+    Raises:
+        ConfigurationError: If the value is boolean, non-numeric, non-finite,
+            zero, or negative.
+    """
     if (
         isinstance(value, bool)
         or not isinstance(value, int | float)
@@ -48,8 +76,48 @@ def validate_operation_wait_timeout(value: float) -> float:
 
 @dataclass(frozen=True, slots=True)
 class CreateRunConfig:
+    """Validated configuration used to assemble one :class:`kuma.run.Run`.
+
+    Callers normally pass these options to :func:`kuma.create_run` rather than
+    constructing this internal value directly. ``resolve_create_run_config``
+    merges defaults and process configuration before this dataclass validates
+    them, so later lifecycle code can rely on the invariants below.
+
+    Attributes:
+        strategy: Public Case strategy identifier. ``"auto"`` lets the official
+            service choose; a non-empty explicit identifier requests that exact
+            strategy.
+        max_steps: Positive upper bound on Case steps, or ``None`` to use the
+            selected provider/service default. It is not an exact requested
+            count. Custom Case Providers require an explicit value.
+        judge: Whether the Run automatically requests a final report after its
+            last submission.
+        on_failure: ``"continue"`` delivers the next input after a failed,
+            timed-out, or aborted submission; ``"stop"`` ends the Run early.
+        allow_local: Explicit opt-in to run against a local repository when no
+            supported container boundary is detected. It does not weaken path
+            or sensitive-data checks.
+        track_files: Capture bounded file snapshots and changes for each step.
+        upload_diff: Include bounded textual diffs in Evidence when safe. File
+            metadata can still be captured when this is ``False``.
+        save_local: Persist committed Run Evidence under the SDK-owned runtime
+            directory. Prepared but uncommitted Evidence is not finalized.
+        allow_sensitive: Permit sensitive values only where the relevant public
+            Evidence contract explicitly allows them. It never permits secrets,
+            private rubrics, or credentials in official transport.
+        timeout: Positive finite timeout in seconds for one HTTP request.
+        operation_wait_timeout: Positive finite total seconds spent polling one
+            accepted asynchronous Case or Judge operation.
+        max_retries: Number of bounded transient HTTP retries after the first
+            attempt, from ``0`` through :data:`MAX_RETRIES`.
+
+    Raises:
+        ConfigurationError: During construction when any field violates its
+            documented type, range, or closed-value constraint.
+    """
+
     strategy: str = "auto"
-    max_inputs: int | None = None
+    max_steps: int | None = None
     judge: bool = True
     on_failure: str = "continue"
     allow_local: bool = False
@@ -62,14 +130,32 @@ class CreateRunConfig:
     max_retries: int = 2
 
     def __post_init__(self) -> None:
+        """Reject invalid Run options before filesystem or network effects.
+
+        Preconditions:
+            Configuration sources have been merged; values are still untrusted
+            Python objects and may have incorrect runtime types.
+
+        Postconditions:
+            Success guarantees all booleans are actual ``bool`` values, timeouts
+            are positive and finite, retry count is bounded, and ``max_steps``
+            is either ``None`` or a positive integer.
+
+        Raises:
+            ConfigurationError: On the first invalid option.
+
+        Side Effects:
+            None. Validation does not read credentials, inspect repositories,
+            create runtime directories, or perform network requests.
+        """
         if not isinstance(self.strategy, str) or not self.strategy.strip():
             raise ConfigurationError("strategy must be a non-empty string")
-        if self.max_inputs is not None and (
-            isinstance(self.max_inputs, bool)
-            or not isinstance(self.max_inputs, int)
-            or self.max_inputs <= 0
+        if self.max_steps is not None and (
+            isinstance(self.max_steps, bool)
+            or not isinstance(self.max_steps, int)
+            or self.max_steps <= 0
         ):
-            raise ConfigurationError("max_inputs must be a positive integer")
+            raise ConfigurationError("max_steps must be a positive integer")
         if not isinstance(self.on_failure, str) or self.on_failure not in {
             "continue",
             "stop",
@@ -103,10 +189,27 @@ def resolve_create_run_config(
     explicit: Mapping[str, object] | None = None,
     process: Mapping[str, object] | None = None,
 ) -> CreateRunConfig:
-    """Merge defaults, process configuration, and per-call values.
+    """Merge process-wide and per-call Run options into one validated config.
 
     Only keys present in each mapping participate, preserving the v4 precedence
     rule: explicit call values > process configuration > SDK defaults.
+
+    Args:
+        explicit: Options supplied directly to ``create_run``. Present keys,
+            including values equal to defaults, override ``process``.
+        process: Options previously registered by ``kuma.configure``. ``None``
+            behaves as an empty mapping.
+
+    Returns:
+        Immutable :class:`CreateRunConfig` with defaults filled and all values
+        validated.
+
+    Raises:
+        ConfigurationError: If either mapping contains an unknown key or the
+            merged value violates a configuration constraint.
+
+    Postconditions:
+        Neither input mapping is mutated, and no external I/O has occurred.
     """
 
     merged: dict[str, object] = {}
@@ -120,28 +223,63 @@ def resolve_create_run_config(
 
 
 def credential_path(environ: Mapping[str, str] | None = None) -> Path:
-    """Return the user-level credential path without creating it."""
+    """Resolve the user-level credential file location without creating it.
+
+    Args:
+        environ: Environment mapping used for resolution, or ``None`` to use
+            ``os.environ``. Tests and embedded callers can pass an isolated map.
+
+    Returns:
+        Platform-appropriate ``credentials.json`` path. ``KUMA_CONFIG_HOME``
+        takes precedence, followed by Windows ``APPDATA`` or the XDG config
+        directory and home-directory fallback.
+
+    Raises:
+        ConfigurationError: If no home/config location can be resolved.
+
+    Security/Privacy:
+        The function reads path-setting environment variables only. It neither
+        reads nor creates the credential file and never returns a credential.
+    """
 
     env = os.environ if environ is None else environ
     override = env.get("KUMA_CONFIG_HOME")
-    if override:
-        return Path(override).expanduser() / "credentials.json"
-    if os.name == "nt" and env.get("APPDATA"):
-        return Path(env["APPDATA"]) / "KUMA" / "credentials.json"
-    configured_home = env.get("XDG_CONFIG_HOME")
-    if configured_home:
-        base = Path(configured_home)
-    else:
-        try:
-            base = Path.home() / ".config"
-        except RuntimeError as exc:
-            raise ConfigurationError(
-                "Credential location unavailable; set KUMA_API_KEY explicitly"
-            ) from exc
+    location_failed = False
+    try:
+        if override:
+            return Path(override).expanduser() / "credentials.json"
+        if os.name == "nt" and env.get("APPDATA"):
+            return Path(env["APPDATA"]) / "KUMA" / "credentials.json"
+        configured_home = env.get("XDG_CONFIG_HOME")
+        base = Path(configured_home) if configured_home else Path.home() / ".config"
+    except (TypeError, ValueError, OSError, RuntimeError):
+        location_failed = True
+    if location_failed:
+        raise ConfigurationError(
+            "Credential location unavailable; set KUMA_API_KEY explicitly"
+        ) from None
     return base / "kuma" / "credentials.json"
 
 
 def validate_api_key(api_key: str) -> str:
+    """Validate an opaque KUMA key before it can enter an HTTP header.
+
+    Args:
+        api_key: Printable ASCII token beginning with ``dfx_`` and occupying at
+            most 512 bytes. Spaces, tabs, line breaks, NUL, and non-ASCII text
+            are rejected to prevent header injection and backend disagreement.
+
+    Returns:
+        The unchanged opaque key. The SDK never parses scopes or account data
+        from the token itself.
+
+    Raises:
+        ConfigurationError: If the value has an invalid prefix, type, byte
+            length, or header-unsafe character.
+
+    Security/Privacy:
+        The key is not logged, normalized, truncated, or included in an error.
+    """
     if not isinstance(api_key, str) or not api_key.startswith("dfx_"):
         raise ConfigurationError("KUMA API keys must begin with 'dfx_'")
     try:
@@ -158,20 +296,54 @@ def validate_api_key(api_key: str) -> str:
 
 
 def write_api_key(api_key: str, *, path: Path | None = None) -> Path:
-    """Atomically store a validated API key in the user credential file."""
+    """Atomically store one validated API key in a user-selected credential file.
+
+    Args:
+        api_key: Opaque ``dfx_`` key accepted by :func:`validate_api_key`.
+        path: Destination file. ``None`` uses :func:`credential_path`; parent
+            directories are created when missing.
+
+    Returns:
+        Absolute path of the committed credential file.
+
+    Raises:
+        ConfigurationError: If the key is invalid or the default location is
+            unavailable, or the atomic credential write cannot complete.
+
+    Preconditions:
+        The caller intentionally requested persistent credential storage and has
+        permission to write the destination directory.
+
+    Postconditions:
+        On success the destination contains exactly one JSON ``api_key`` value.
+        On failure the temporary file is removed and no partial replacement is
+        reported as success.
+
+    Side Effects:
+        Creates directories and a temporary file, atomically replaces the
+        destination, and requests owner-only permissions where supported.
+
+    Security/Privacy:
+        The key is written only to the selected file and is never returned in
+        diagnostic text. Filesystem permission guarantees remain platform-owned.
+    """
 
     key = validate_api_key(api_key)
-    destination = (path or credential_path()).expanduser().resolve()
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=".credentials-",
-        suffix=".tmp",
-        dir=destination.parent,
-        text=True,
-    )
-    temporary = Path(temporary_name)
+    descriptor: int | None = None
+    temporary: Path | None = None
+    storage_failed = False
     try:
+        destination = (path or credential_path()).expanduser().resolve()
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=".credentials-",
+            suffix=".tmp",
+            dir=destination.parent,
+            text=True,
+        )
+        temporary = Path(temporary_name)
         with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            descriptor = None
             json.dump({"api_key": key}, handle)
             handle.write("\n")
         with suppress(OSError):
@@ -179,22 +351,54 @@ def write_api_key(api_key: str, *, path: Path | None = None) -> Path:
         temporary.replace(destination)
         with suppress(OSError):
             destination.chmod(0o600)
-    except BaseException:
-        temporary.unlink(missing_ok=True)
-        raise
+    except BaseException as exc:
+        if descriptor is not None:
+            with suppress(OSError):
+                os.close(descriptor)
+        if temporary is not None:
+            with suppress(OSError):
+                temporary.unlink(missing_ok=True)
+        if isinstance(exc, AttributeError | TypeError | ValueError | OSError):
+            storage_failed = True
+        else:
+            raise
+    if storage_failed:
+        raise ConfigurationError("KUMA credential storage is unavailable") from None
     return destination
 
 
 def read_stored_api_key(*, path: Path | None = None) -> str | None:
-    source = path or credential_path()
-    if not source.is_file():
-        return None
+    """Read a stored credential only when its complete file is valid.
+
+    Args:
+        path: Credential file to read, or ``None`` for the platform default.
+
+    Returns:
+        Validated opaque key, or ``None`` when the file does not exist.
+
+    Raises:
+        ConfigurationError: If the file cannot be decoded as the expected JSON
+            object or contains an invalid key.
+
+    Side Effects:
+        Reads one local file; performs no network request and writes nothing.
+
+    Security/Privacy:
+        Parse and validation failures use fixed messages and never echo file
+        content or the candidate credential.
+    """
+    read_failed = False
     try:
+        source = (path or credential_path()).expanduser()
+        if not source.is_file():
+            return None
         payload = json.loads(source.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (AttributeError, TypeError, ValueError, OSError, json.JSONDecodeError):
+        read_failed = True
+    if read_failed:
         raise ConfigurationError(
             "The KUMA credential file is unreadable or invalid"
-        ) from exc
+        ) from None
     if not isinstance(payload, dict) or not isinstance(payload.get("api_key"), str):
         raise ConfigurationError("The KUMA credential file is invalid")
     return validate_api_key(payload["api_key"])
@@ -207,7 +411,33 @@ def resolve_api_key(
     stored_path: Path | None = None,
     required: bool = True,
 ) -> str | None:
-    """Resolve explicit, environment, then user-stored credentials."""
+    """Resolve one API key using the documented precedence order.
+
+    Args:
+        explicit: Key passed by the caller. A truthy value has highest priority.
+        environ: Environment mapping, or ``None`` for ``os.environ``. The
+            resolver reads only ``KUMA_API_KEY`` from this mapping.
+        stored_path: Optional credential file override used only when neither an
+            explicit nor environment key is available.
+        required: When ``True``, absence is an authentication error; when
+            ``False``, absence returns ``None`` for credential-optional clients.
+
+    Returns:
+        Validated opaque key, or ``None`` only when ``required`` is ``False`` and
+        all sources are absent.
+
+    Raises:
+        AuthenticationError: If a key is required but no source provides one.
+        ConfigurationError: If the selected key or stored credential file is
+            malformed.
+
+    Side Effects:
+        May read the environment and one credential file. It performs no network
+        request and does not modify any source.
+
+    Security/Privacy:
+        Resolution never logs, embeds, or returns the key in an error message.
+    """
 
     env = os.environ if environ is None else environ
     candidate = (
@@ -223,6 +453,7 @@ def resolve_api_key(
 
 
 __all__ = [
+    "DEFAULT_CASE_MAX_STEPS",
     "CreateRunConfig",
     "credential_path",
     "read_stored_api_key",

--- a/src/kuma/contracts.py
+++ b/src/kuma/contracts.py
@@ -5,29 +5,47 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from types import MappingProxyType
 from typing import Any, Literal
 
+from ._json_values import freeze_json
 from .errors import KumaError, ValidationError
 
 
 def _freeze_json(value: Any, name: str) -> Any:
-    if isinstance(value, Mapping):
-        return MappingProxyType(
-            {str(key): _freeze_json(item, name) for key, item in value.items()}
-        )
-    if isinstance(value, list | tuple):
-        return tuple(_freeze_json(item, name) for item in value)
-    if value is None or isinstance(value, str | bool | int):
-        return value
-    if isinstance(value, float) and math.isfinite(value):
-        return value
-    raise ValidationError(f"{name} must contain only finite JSON-compatible values")
+    """Freeze a bounded public JSON field and map traversal failure safely.
+
+    Args:
+        value: Candidate contract field to detach and freeze.
+        name: Constant public field label used in the safe error message.
+
+    Returns:
+        An immutable JSON graph with read-only mappings and tuple arrays.
+
+    Raises:
+        ValidationError: If the field is cyclic, exceeds the 256-container depth
+            limit, contains non-finite/unsupported data, or a custom Mapping
+            fails. Input payload and Submission output errors use stable code
+            ``output_invalid``; other contract fields retain their prior code.
+
+    Postconditions:
+        Success shares no mutable JSON container with the caller. Failure does
+        not include a key, value, object representation, or original exception.
+
+    Side Effects:
+        Iterates custom Mapping values locally and performs no external I/O.
+    """
+    try:
+        return freeze_json(value)
+    except Exception:
+        code = "output_invalid" if name in {"payload", "output"} else None
+        raise ValidationError(
+            f"{name} must contain only finite JSON-compatible values",
+            code=code,
+        ) from None
 
 
 def _require_schema_version(value: str, family: str) -> None:
-    # Schema identifiers are a deployed cross-repository wire contract; the
-    # Python package rename must not change their namespace.
+    """Require the exact schema version for an immutable public contract."""
     prefix = f"defuzex.{family}.v"
     if not value.startswith(prefix) or not value[len(prefix) :].isdigit():
         raise ValidationError(f"Invalid {family} schema version: {value!r}")
@@ -39,16 +57,19 @@ def _require_schema_version(value: str, family: str) -> None:
 
 
 def _require_identifier(name: str, value: str) -> None:
+    """Require a non-empty bounded identifier without coercing external values."""
     if not isinstance(value, str) or not value.strip() or "\0" in value:
         raise ValidationError(f"{name} must be a non-empty string")
 
 
 def _require_optional_text(name: str, value: str | None) -> None:
+    """Accept ``None`` or bounded text without coercing external values."""
     if value is not None and not isinstance(value, str):
         raise ValidationError(f"{name} must be text or None")
 
 
 def _require_non_negative_integer(name: str, value: int | None) -> None:
+    """Require a non-negative integer while rejecting booleans."""
     if value is not None and (
         isinstance(value, bool) or not isinstance(value, int) or value < 0
     ):
@@ -61,6 +82,25 @@ class KumaInput:
 
     ``payload`` and both mapping fields are recursively frozen after local
     JSON/schema validation so Provider-owned objects cannot mutate Run history.
+
+    Attributes:
+        run_id: Public identifier of the Run that owns this input.
+        case_id: Public identifier of the Case that contains this input.
+        input_id: Stable identifier used to correlate delivery, Submission, and
+            Evidence for this one step.
+        index: Zero-based position in the Case execution order.
+        payload_type: ``"text"`` for a string payload or ``"structured"`` for
+            a JSON object/array payload.
+        payload: Agent-facing task value returned by ``Run.get_input``. It is a
+            recursively immutable JSON-compatible value, may contain at most
+            256 container levels, and cannot contain reference cycles. Shared
+            acyclic children are detached and accepted.
+        public_constraints: Public, non-secret constraints the Agent may use
+            while handling this input.
+        schema_version: Versioned wire family; currently
+            ``"defuzex.input.v1"``.
+        extensions: Forward-compatible public metadata. Unknown private grading
+            fields are not accepted into official Cases.
     """
 
     run_id: str
@@ -74,6 +114,7 @@ class KumaInput:
     extensions: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        """Validate Input identity/type and freeze its payload and constraints."""
         _require_schema_version(self.schema_version, "input")
         for name in ("run_id", "case_id", "input_id"):
             _require_identifier(name, getattr(self, name))
@@ -86,12 +127,15 @@ class KumaInput:
         if self.payload_type not in {"text", "structured"}:
             raise ValidationError("payload_type must be 'text' or 'structured'")
         if self.payload_type == "text" and not isinstance(self.payload, str):
-            raise ValidationError("text input payload must be a string")
+            raise ValidationError(
+                "text input payload must be a string", code="output_invalid"
+            )
         if self.payload_type == "structured" and not isinstance(
             self.payload, (Mapping, list, tuple)
         ):
             raise ValidationError(
-                "structured input payload must be a mapping or sequence"
+                "structured input payload must be a mapping or sequence",
+                code="output_invalid",
             )
         object.__setattr__(self, "payload", _freeze_json(self.payload, "payload"))
         object.__setattr__(
@@ -106,7 +150,32 @@ class KumaInput:
 
 @dataclass(frozen=True, slots=True)
 class FileChange:
-    """Public metadata for one created, modified, deleted, or renamed path."""
+    """Describe one bounded repository path change captured around a step.
+
+    Attributes:
+        path: Repository-relative POSIX-style path after boundary validation.
+        change_type: One of ``created``, ``modified``, ``deleted``, or
+            ``renamed``.
+        file_type: Optional observed type: ``file``, ``directory``, ``symlink``,
+            or ``special``.
+        before_hash: SHA-256 hex digest before the step, when hashing completed.
+        after_hash: SHA-256 hex digest after the step, when hashing completed.
+        before_size: Non-negative byte size before the step, when available.
+        after_size: Non-negative byte size after the step, when available.
+        before_mode: Platform mode bits observed before the step.
+        after_mode: Platform mode bits observed after the step.
+        old_path: Previous repository-relative path for a detected rename.
+        complete: ``False`` when limits or filesystem errors make the record
+            incomplete; callers must inspect ``reason``.
+        reason: Stable degradation reason, or ``None`` for complete capture.
+        diff: Optional bounded text diff when ``upload_diff=True`` and the file
+            is safe text. Binary and oversized content is never forced here.
+
+    Security/Privacy:
+        Paths are repository-relative. Hashes and metadata may be retained even
+        when raw file text is excluded; ``diff`` remains subject to sensitive
+        scanning and configured size limits.
+    """
 
     path: str
     change_type: str
@@ -123,6 +192,7 @@ class FileChange:
     diff: str | None = None
 
     def __post_init__(self) -> None:
+        """Validate one file change and freeze its optional metadata."""
         _require_identifier("path", self.path)
         if self.change_type not in {"created", "modified", "deleted", "renamed"}:
             raise ValidationError("Unsupported file change type")
@@ -143,7 +213,19 @@ class FileChange:
 
 @dataclass(frozen=True, slots=True)
 class FileEvidence:
-    """Bounded file-change evidence for either container or local scope."""
+    """Group ordered file changes captured for one Submission.
+
+    Attributes:
+        complete: Whether the snapshot/diff process observed its entire bounded
+            scope without omissions. ``False`` is never presented as success.
+        scope: ``"container"`` for the supported isolated runtime or ``"local"``
+            for an explicitly allowed local run.
+        changes: Ordered immutable :class:`FileChange` records.
+        errors: Stable non-sensitive capture reason codes; never raw tracebacks.
+        schema_version: Versioned contract, currently
+            ``"defuzex.file_evidence.v1"``.
+        extensions: Bounded public extension metadata.
+    """
 
     complete: bool
     scope: str
@@ -153,6 +235,7 @@ class FileEvidence:
     extensions: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        """Freeze ordered file changes and enforce bounded snapshot metadata."""
         _require_schema_version(self.schema_version, "file_evidence")
         if not isinstance(self.complete, bool):
             raise ValidationError("complete must be a boolean")
@@ -171,12 +254,21 @@ class FileEvidence:
 
 @dataclass(frozen=True, slots=True)
 class CaptureComponent:
-    """Completeness and stable degradation reasons for one capture component."""
+    """State whether one Evidence source was usable for a Submission.
+
+    Attributes:
+        status: ``complete``, ``partial``, ``failed``, or ``skipped``. ``partial``
+            means some usable data exists; ``failed`` means capture attempted but
+            produced no trustworthy component.
+        reasons: Ordered stable reason codes explaining omissions or degradation.
+            They are safe diagnostics, not raw provider/filesystem error text.
+    """
 
     status: str = "skipped"
     reasons: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
+        """Validate one capture status and freeze its reason codes."""
         if self.status not in {"complete", "partial", "failed", "skipped"}:
             raise ValidationError("Invalid capture component status")
         if any(not isinstance(item, str) for item in self.reasons):
@@ -186,7 +278,19 @@ class CaptureComponent:
 
 @dataclass(frozen=True, slots=True)
 class CaptureStatus:
-    """Per-component Evidence status; partial capture is never hidden as success."""
+    """Expose completeness independently for every SDK Evidence source.
+
+    Attributes:
+        file_snapshot: Baseline/final repository snapshot status.
+        file_diff: Derived file-change comparison status.
+        logs: Explicit file logs and mapped OTel log-record status.
+        sensitive_scan: Privacy scanner status for uploadable Evidence.
+        traces: In-process OpenTelemetry span capture status.
+
+    A caller should use these fields together with ``Submission.missing`` and
+    ``Submission.dropped_count``; an overall Submission status does not imply
+    every Evidence component is complete.
+    """
 
     file_snapshot: CaptureComponent = field(default_factory=CaptureComponent)
     file_diff: CaptureComponent = field(default_factory=CaptureComponent)
@@ -195,6 +299,7 @@ class CaptureStatus:
     traces: CaptureComponent = field(default_factory=CaptureComponent)
 
     def __post_init__(self) -> None:
+        """Require typed file, log, and Trace component statuses."""
         if any(
             not isinstance(component, CaptureComponent)
             for component in (
@@ -212,7 +317,33 @@ class CaptureStatus:
 
 @dataclass(frozen=True, slots=True)
 class Submission:
-    """One validated Agent result and its transactionally committed Evidence."""
+    """Represent one committed Agent response and its correlated Evidence.
+
+    Attributes:
+        run_id: Run that owns this Submission.
+        case_id: Case being executed by that Run.
+        input_id: Exact delivered input answered by this Submission.
+        status: ``completed``, ``failed``, ``timeout``, or ``aborted``.
+        output: Finite JSON-compatible Agent result. Required for ``completed``;
+            it may be passed explicitly or obtained from supported OTel output
+            conventions before construction.
+        error: Caller-supplied safe error summary for non-completed outcomes, or
+            ``None``. Raw secrets and tracebacks must not be placed here.
+        capture_status: Per-source completeness information.
+        logs: Ordered bounded structured log segments retained for this step.
+        file_evidence: Bounded file metadata/diff Evidence, or ``None`` when file
+            tracking is disabled or unavailable.
+        dropped_count: Number of Evidence records omitted because of limits,
+            privacy rules, or capture failures.
+        missing: Stable names/reasons for Evidence that could not be captured.
+        schema_version: Versioned contract, currently
+            ``"defuzex.submission.v1"``.
+        extensions: Public typed Evidence and compatible extension payloads.
+
+    Postconditions:
+        Construction recursively freezes all JSON containers, so committed Run
+        history cannot be changed through caller-owned objects.
+    """
 
     run_id: str
     case_id: str
@@ -229,6 +360,7 @@ class Submission:
     extensions: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        """Validate Submission correlation/status and freeze all Evidence fields."""
         _require_schema_version(self.schema_version, "submission")
         for name in ("run_id", "case_id", "input_id"):
             _require_identifier(name, getattr(self, name))
@@ -271,6 +403,24 @@ class Case:
 
     Official Cases carry integrity references in ``extensions`` and never expose
     a private server-side rubric through this contract.
+
+    Attributes:
+        inputs: Non-empty ordered immutable sequence delivered by the Run.
+        case_id: Public Case identifier, or ``None`` only before normalization of
+            a custom provider result.
+        input_type: Shared payload kind for every input: ``text`` or
+            ``structured``.
+        input_schema: Read-only JSON Schema for structured inputs, otherwise
+            usually ``None``.
+        rubric: Transparent public rules for a local custom Judge, or ``None``.
+            It may describe criteria but must not contain expected outputs,
+            answer keys, hidden answers, or official private-rubric content.
+        extensions: Public metadata and, for official Cases, validated opaque
+            provenance needed to submit the correct ``case_id`` for judging.
+
+    Security/Privacy:
+        ``extensions`` is validated at official boundaries and must not contain
+        private rubric criteria, hidden answers, prompts, or provider keys.
     """
 
     inputs: tuple[KumaInput, ...]
@@ -281,6 +431,7 @@ class Case:
     extensions: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        """Validate Case identity and Input schema while freezing public extensions."""
         if not self.inputs:
             raise ValidationError("A Case must contain at least one input")
         if any(not isinstance(item, KumaInput) for item in self.inputs):
@@ -307,12 +458,21 @@ class Case:
 
 @dataclass(frozen=True, slots=True)
 class HistoryItem:
-    """An Input/Submission pair whose Run, Case, and Input IDs must agree."""
+    """Pair one delivered input with the only Submission committed for it.
+
+    Attributes:
+        test_input: Immutable input previously returned by ``Run.get_input``.
+        submission: Immutable response committed by ``Run.submit``.
+
+    The constructor rejects mismatched Run, Case, or Input identifiers so a
+    Judge never receives cross-run Evidence through normal SDK history.
+    """
 
     test_input: KumaInput
     submission: Submission
 
     def __post_init__(self) -> None:
+        """Require a Submission associated with the paired Run Input."""
         if not isinstance(self.test_input, KumaInput) or not isinstance(
             self.submission, Submission
         ):
@@ -327,7 +487,28 @@ class HistoryItem:
 
 @dataclass(frozen=True, slots=True)
 class TestReport:
-    """Normalized final Judgment for one Run."""
+    """Expose the normalized public Judgment returned for one completed Run.
+
+    Attributes:
+        report_id: Public identifier of this Judgment.
+        run_id: Run whose committed history was judged.
+        status: ``pass``, ``issue``, or ``insufficient_evidence``. The last value
+            means the Judge could not safely reach a behavior conclusion.
+        confidence: Optional ``low``/``medium``/``high`` label or finite numeric
+            confidence from ``0`` through ``1``.
+        stop_reason: Stable public reason the judging lifecycle ended, such as
+            ``case_completed``.
+        issues: Ordered immutable public issue objects. Their exact fields are
+            service-versioned and must be treated as JSON data.
+        evidence_gaps: Ordered public explanations of missing Evidence.
+        schema_version: Versioned report family, currently
+            ``"defuzex.report.v1"``.
+        extensions: Additional validated public report metadata.
+
+    Security/Privacy:
+        The report does not expose the private rubric, prompt, hidden answer,
+        model configuration, or raw provider response.
+    """
 
     report_id: str
     run_id: str
@@ -340,6 +521,7 @@ class TestReport:
     extensions: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        """Validate Judgment score/status and freeze issues, steps, and extensions."""
         _require_schema_version(self.schema_version, "report")
         _require_identifier("report_id", self.report_id)
         _require_identifier("run_id", self.run_id)
@@ -384,7 +566,18 @@ class TestReport:
 
 @dataclass(frozen=True, slots=True)
 class JudgeBatchResult:
-    """One ordered result from the synchronous public batch Judge endpoint."""
+    """Represent one item in an ordered batch Judge response.
+
+    Attributes:
+        client_item_id: Caller-visible correlation identifier from the matching
+            batch request item.
+        run_id: Run associated with this result.
+        report: Normalized public report on success, otherwise ``None``.
+        error: Stable public SDK error on failure, otherwise ``None``.
+
+    Exactly one of ``report`` and ``error`` is present, allowing callers to
+    handle partial batch failure without treating failed items as successes.
+    """
 
     client_item_id: str
     run_id: str
@@ -392,6 +585,7 @@ class JudgeBatchResult:
     error: KumaError | None = None
 
     def __post_init__(self) -> None:
+        """Require exactly one normalized report or public error for a batch item."""
         _require_identifier("client_item_id", self.client_item_id)
         _require_identifier("run_id", self.run_id)
         if (self.report is None) == (self.error is None):

--- a/src/kuma/errors.py
+++ b/src/kuma/errors.py
@@ -25,6 +25,7 @@ class KumaError(Exception):
         retryable: bool = False,
         details: Mapping[str, Any] | None = None,
     ) -> None:
+        """Store stable public code, retryability, request ID, and detached safe details."""
         self.code = code or self.default_code
         self.request_id = request_id
         self.retryable = retryable
@@ -33,66 +34,98 @@ class KumaError(Exception):
 
 
 class ConfigurationError(KumaError):
+    """Report invalid local SDK configuration before unsafe side effects occur."""
+
     default_code = "config_invalid"
 
 
 class AuthenticationError(KumaError):
+    """Report a missing, invalid, expired, or revoked public API credential."""
+
     default_code = "auth_invalid"
 
 
 class PermissionDeniedError(KumaError):
+    """Report that a valid credential lacks permission for an operation."""
+
     default_code = "forbidden"
 
 
 class ValidationError(KumaError):
+    """Report invalid caller input or malformed data at a public boundary."""
+
     default_code = "validation_error"
 
 
 class SensitiveDataError(ValidationError):
+    """Report Evidence rejected by the SDK sensitive-data policy."""
+
     default_code = "sensitive_data_blocked"
 
 
 class DockerRequiredError(ConfigurationError):
+    """Report that the requested Run requires the supported container boundary."""
+
     default_code = "docker_required"
 
 
 class RunAlreadyActiveError(KumaError):
+    """Report that another Run already owns the process/container runtime lease."""
+
     default_code = "run_already_active"
 
 
 class ProviderError(KumaError):
+    """Report a safe Case or Judge Provider failure without leaking internals."""
+
     default_code = "provider_failed"
 
 
 class InputProtocolError(KumaError):
+    """Report an invalid call for the Run's current lifecycle state."""
+
     default_code = "invalid_run_state"
 
 
 class EvidenceCaptureError(KumaError):
+    """Report Evidence capture that could not satisfy its safety contract."""
+
     default_code = "evidence_capture_failed"
 
 
 class LimitExceededError(ValidationError):
+    """Report a caller value or payload that exceeds a documented public limit."""
+
     default_code = "limit_exceeded"
 
 
 class CaseIntegrityError(ValidationError):
+    """Report official Case provenance or correlation that fails closed."""
+
     default_code = "invalid_case_integrity"
 
 
 class RepoStateMismatchError(ValidationError):
+    """Report repository state that no longer matches the validated Case context."""
+
     default_code = "repo_state_mismatch"
 
 
 class ServiceBusyError(KumaError):
+    """Report explicit upstream capacity exhaustion that callers should not retry blindly."""
+
     default_code = "service_busy"
 
 
 class KumaTimeoutError(KumaError):
+    """Report a bounded request or operation wait deadline being reached."""
+
     default_code = "timeout"
 
 
 class ServiceError(KumaError):
+    """Report a safe public service or transport failure not covered more specifically."""
+
     default_code = "service_error"
 
 

--- a/src/kuma/evidence/otel_log_mapping.py
+++ b/src/kuma/evidence/otel_log_mapping.py
@@ -1,0 +1,397 @@
+"""Pure, bounded conversion from OTel LogRecords to safe log Evidence."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from itertools import islice
+from typing import TYPE_CHECKING, Any
+
+from ..repository.privacy import scan_sensitive_text
+from .trace_mapping import _safe_attributes, _safe_text
+
+if TYPE_CHECKING:
+    from .trace import TraceEvidenceLimits
+
+OTEL_LOG_SCHEMA = "defuzex.otel_logs.v1"
+OTEL_LOG_MEDIA_TYPE = "application/vnd.defuzex.otel-logs+json"
+
+_LOG_REASONS = frozenset(
+    {
+        "otel_log_attribute_filtered",
+        "otel_log_byte_limit",
+        "otel_log_capture_failed",
+        "otel_log_export_failed",
+        "otel_log_invalid",
+        "otel_log_limit",
+        "otel_log_sensitive_filtered",
+        "otel_log_value_truncated",
+    }
+)
+
+
+class LogRecordMappingError(ValueError):
+    """A stable, value-free reason why an OTel LogRecord was unusable."""
+
+    def __init__(self, reason: str = "otel_log_invalid") -> None:
+        """Retain an allowlisted reason code without rejected LogRecord content."""
+        super().__init__(reason)
+        self.reason = reason if reason in _LOG_REASONS else "otel_log_invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class BuiltOtelLogSegment:
+    """Return one safe OTel log artifact plus exact capture accounting.
+
+    Attributes:
+        segment: Structured hash-only log segment, or ``None`` when no record
+            fits safely in the remaining byte budget.
+        retained_count: Number of normalized records present in ``segment``.
+        dropped_count: Number of observed records omitted by mapping or limits.
+        reasons: Stable allowlisted degradation reasons; never raw log text or
+            exporter exceptions.
+        encoded_size: UTF-8 bytes consumed by the retained segment content.
+    """
+
+    segment: Mapping[str, Any] | None
+    retained_count: int
+    dropped_count: int
+    reasons: tuple[str, ...]
+    encoded_size: int
+
+
+def _optional_nano(value: Any) -> tuple[int | None, bool]:
+    """Normalize an optional non-negative OTel nanosecond timestamp."""
+    if value is None:
+        return None, False
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None, True
+    return value, False
+
+
+def _optional_identifier(value: Any, width: int) -> tuple[str | None, bool]:
+    """Normalize an optional trace or span identifier to fixed-width hex."""
+    if value in (None, 0):
+        return None, False
+    maximum = 1 << (width * 4)
+    if isinstance(value, bool) or not isinstance(value, int) or not 0 < value < maximum:
+        return None, True
+    return f"{value:0{width}x}", False
+
+
+def _severity(value: Any) -> tuple[int | None, str]:
+    """Map the standard numeric severity range to a stable public level."""
+    try:
+        number = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return None, "unset"
+    if not 0 <= number <= 24:
+        return None, "unset"
+    if number == 0:
+        return 0, "unset"
+    names = ("trace", "debug", "info", "warn", "error", "fatal")
+    return number, names[min((number - 1) // 4, len(names) - 1)]
+
+
+def _safe_hash(value: Any, limit: int) -> tuple[str | None, bool, bool, bool]:
+    """Hash bounded non-sensitive text without retaining the original log value."""
+    if value is None:
+        return None, False, False, False
+    if isinstance(value, str):
+        text = value[: limit + 1]
+    elif isinstance(value, bytes):
+        text = value[: limit + 1].decode("utf-8", "replace")
+    elif isinstance(value, bool | int) or (
+        isinstance(value, float) and math.isfinite(value)
+    ):
+        text = str(value)
+    else:
+        return None, False, False, True
+    bounded_text = (
+        text[:limit].encode("utf-8", "surrogatepass").decode("utf-8", "replace")
+    )
+    if scan_sensitive_text(bounded_text, location="otel_log"):
+        return None, False, True, False
+    truncated = len(text) > limit
+    bounded = bounded_text.encode("utf-8")
+    return hashlib.sha256(bounded).hexdigest(), truncated, False, False
+
+
+def _attribute_count(value: Any, limit: int) -> tuple[int, bool]:
+    """Count inspected attributes up to the configured privacy budget."""
+    if not isinstance(value, Mapping):
+        return 0, value is not None
+    try:
+        inspected = list(islice(value, limit + 1))
+    except Exception:
+        return 0, True
+    return min(len(inspected), limit), len(inspected) > limit
+
+
+def _record_core(record: Any) -> tuple[dict[str, Any], set[str]]:
+    """Normalize timing, correlation IDs, and severity for one LogRecord."""
+    timestamp, invalid_timestamp = _optional_nano(record.timestamp)
+    observed, invalid_observed = _optional_nano(record.observed_timestamp)
+    trace_id, invalid_trace = _optional_identifier(record.trace_id, 32)
+    span_id, invalid_span = _optional_identifier(record.span_id, 16)
+    reasons = set()
+    if invalid_timestamp or invalid_observed or invalid_trace or invalid_span:
+        reasons.add("otel_log_invalid")
+    severity_number, severity_name = _severity(getattr(record, "severity_number", None))
+    return (
+        {
+            "timestamp_unix_nano": timestamp,
+            "observed_timestamp_unix_nano": observed,
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "severity_number": severity_number,
+            "severity": severity_name,
+        },
+        reasons,
+    )
+
+
+def _record_content(
+    record: Any, limits: TraceEvidenceLimits
+) -> tuple[dict[str, Any], int, set[str]]:
+    """Hash body/event text and count rather than retain arbitrary attributes."""
+    body_hash, body_truncated, body_sensitive, body_invalid = _safe_hash(
+        getattr(record, "body", None), limits.max_text_length
+    )
+    event_hash, event_truncated, event_sensitive, event_invalid = _safe_hash(
+        getattr(record, "event_name", None), limits.max_text_length
+    )
+    attribute_count, attributes_truncated = _attribute_count(
+        getattr(record, "attributes", None), limits.max_attributes
+    )
+    reasons = set()
+    if body_sensitive or event_sensitive:
+        reasons.add("otel_log_sensitive_filtered")
+    if body_invalid or event_invalid:
+        reasons.add("otel_log_invalid")
+    if body_truncated or event_truncated or attributes_truncated:
+        reasons.add("otel_log_value_truncated")
+    if attribute_count or attributes_truncated:
+        reasons.add("otel_log_attribute_filtered")
+    return (
+        {
+            "body_sha256": body_hash,
+            "event_name_sha256": event_hash,
+            "attribute_count": attribute_count,
+        },
+        attribute_count + int(attributes_truncated),
+        reasons,
+    )
+
+
+def _resource_scope(
+    readable: Any, limits: TraceEvidenceLimits
+) -> tuple[dict[str, Any], int, set[str]]:
+    """Map allowlisted resource metadata and bounded instrumentation scope."""
+    reasons = set()
+    try:
+        attributes = getattr(getattr(readable, "resource", None), "attributes", None)
+        resource, dropped, truncated, _ = _safe_attributes(
+            attributes, limits, resource=True
+        )
+    except Exception:
+        resource, dropped, truncated = {}, 1, True
+    if dropped:
+        reasons.add("otel_log_attribute_filtered")
+    if truncated:
+        reasons.add("otel_log_value_truncated")
+    try:
+        scope = getattr(readable, "instrumentation_scope", None)
+        name, name_truncated = _safe_text(
+            getattr(scope, "name", ""), limits.max_text_length
+        )
+        version, version_truncated = _safe_text(
+            getattr(scope, "version", "") or "", limits.max_text_length
+        )
+    except Exception:
+        name, version = "", ""
+        name_truncated = version_truncated = True
+        reasons.add("otel_log_invalid")
+    if name_truncated or version_truncated:
+        reasons.add("otel_log_value_truncated")
+    return (
+        {"resource": resource, "scope": {"name": name, "version": version}},
+        dropped,
+        reasons,
+    )
+
+
+def map_log_record(
+    readable: Any, limits: TraceEvidenceLimits
+) -> tuple[dict[str, Any], int, bool, set[str]]:
+    """Map one SDK ReadableLogRecord without retaining raw body or attributes."""
+
+    try:
+        record = getattr(readable, "log_record", readable)
+    except Exception as exc:
+        raise LogRecordMappingError() from exc
+    try:
+        core, reasons = _record_core(record)
+    except Exception as exc:
+        raise LogRecordMappingError() from exc
+    content, dropped, content_reasons = _record_content(record, limits)
+    metadata, resource_dropped, metadata_reasons = _resource_scope(readable, limits)
+    reasons.update(content_reasons)
+    reasons.update(metadata_reasons)
+    return (
+        {**core, **content, **metadata},
+        dropped + resource_dropped,
+        bool(reasons),
+        reasons,
+    )
+
+
+def build_log_segment(
+    *,
+    run_id: str,
+    input_id: str,
+    submission_id: str,
+    records: list[Mapping[str, Any]],
+    observed_count: int,
+    dropped_count: int,
+    reasons: set[str],
+    max_bytes: int,
+) -> BuiltOtelLogSegment:
+    """Fit associated, hash-only OTel records into the remaining Run log budget.
+
+    ``TraceEvidenceCapture.prepare_step`` supplies already normalized records.
+    This pure projection removes a deterministic suffix until the complete JSON
+    envelope fits, recording every omission; it never retains raw bodies,
+    attributes, prompts, or secrets.
+
+    Args:
+        run_id: Owning Run identifier written into the closed envelope.
+        input_id: Owning input/step identifier.
+        submission_id: Deterministic Submission correlation identifier.
+        records: Normalized hash-only OTel records in stable order.
+        observed_count: Total associated records seen before filtering.
+        dropped_count: Records already omitted during mapping/capture.
+        reasons: Stable allowlisted degradation reasons accumulated so far.
+        max_bytes: Remaining UTF-8 byte budget for the complete content.
+
+    Returns:
+        Segment and exact retained/dropped/encoded accounting. ``segment`` is
+        ``None`` when no record fits safely.
+
+    Preconditions:
+        Records came from :func:`map_log_record`, identifiers match one active
+        Submission, and ``max_bytes`` is the remaining Run budget.
+
+    Postconditions:
+        Serialized content is at most ``max_bytes``. Omitted suffix records
+        increase ``dropped_count`` and add ``otel_log_byte_limit``.
+
+    Security/Privacy:
+        Only hashes, counts, and allowlisted metadata are serialized; raw body,
+        attributes, prompts, and exception text are never reintroduced.
+    """
+
+    retained = list(records)
+    bounded_reasons = set(reasons) & _LOG_REASONS
+    if not retained:
+        return BuiltOtelLogSegment(
+            segment=None,
+            retained_count=0,
+            dropped_count=max(dropped_count, observed_count),
+            reasons=tuple(sorted(bounded_reasons or {"otel_log_invalid"})),
+            encoded_size=0,
+        )
+    while retained:
+        content = _log_content(
+            run_id,
+            input_id,
+            submission_id,
+            retained,
+            observed_count,
+            dropped_count,
+            bounded_reasons,
+        )
+        encoded = content.encode("utf-8")
+        if len(encoded) <= max_bytes:
+            return BuiltOtelLogSegment(
+                segment={
+                    "path": "otel://in-process/logs",
+                    "segment_no": 0,
+                    "start_offset": 0,
+                    "end_offset": len(encoded),
+                    "encoding": "utf-8",
+                    "binary": False,
+                    "sha256": "sha256:" + hashlib.sha256(encoded).hexdigest(),
+                    "complete": not bounded_reasons,
+                    "media_type": OTEL_LOG_MEDIA_TYPE,
+                    "content": content,
+                },
+                retained_count=len(retained),
+                dropped_count=dropped_count,
+                reasons=tuple(sorted(bounded_reasons)),
+                encoded_size=len(encoded),
+            )
+        retained.pop()
+        dropped_count += 1
+        bounded_reasons.add("otel_log_byte_limit")
+    return BuiltOtelLogSegment(
+        segment=None,
+        retained_count=0,
+        dropped_count=max(dropped_count, observed_count),
+        reasons=tuple(sorted(bounded_reasons | {"otel_log_byte_limit"})),
+        encoded_size=0,
+    )
+
+
+def _log_content(
+    run_id: str,
+    input_id: str,
+    submission_id: str,
+    records: list[Mapping[str, Any]],
+    observed_count: int,
+    dropped_count: int,
+    reasons: set[str],
+) -> str:
+    """Serialize one associated OTel Logs envelope using canonical field order."""
+    payload = {
+        "schema_version": OTEL_LOG_SCHEMA,
+        "run_id": run_id,
+        "input_id": input_id,
+        "step_id": input_id,
+        "submission_id": submission_id,
+        "records": records,
+        "observed_count": observed_count,
+        "retained_count": len(records),
+        "dropped_count": dropped_count,
+        "truncated": bool(reasons),
+        "reasons": sorted(reasons),
+    }
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def log_record_sort_key(
+    item: tuple[int, Mapping[str, Any], int],
+) -> tuple[int, int, str, str, int]:
+    """Order records by timestamps, correlation IDs, then capture sequence."""
+    sequence, record, _ = item
+    return (
+        record["timestamp_unix_nano"] or 0,
+        record["observed_timestamp_unix_nano"] or 0,
+        record["trace_id"] or "",
+        record["span_id"] or "",
+        sequence,
+    )
+
+
+__all__ = [
+    "OTEL_LOG_MEDIA_TYPE",
+    "OTEL_LOG_SCHEMA",
+    "BuiltOtelLogSegment",
+    "LogRecordMappingError",
+    "build_log_segment",
+    "log_record_sort_key",
+    "map_log_record",
+]

--- a/src/kuma/evidence/runtime.py
+++ b/src/kuma/evidence/runtime.py
@@ -1,4 +1,4 @@
-"""Build and validate canonical, hash-only Runtime Evidence items."""
+"""Build local hash-only v1 Evidence and negotiated v2 transport views."""
 
 from __future__ import annotations
 
@@ -9,12 +9,20 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .._json_values import JsonStructureError, detach_json
 from ..contracts import FileChange, FileEvidence
+from ..errors import LimitExceededError
 from ..repository.privacy import scan_sensitive_path
+from .otel_log_mapping import OTEL_LOG_MEDIA_TYPE
 from .runtime_contract import (
+    RUNTIME_AGENT_OUTPUT_MAX_BYTES,
     RUNTIME_EVIDENCE_MAX_CHARS,
     RUNTIME_EVIDENCE_SCHEMA,
+    RUNTIME_EVIDENCE_SCHEMA_V1,
+    RUNTIME_EVIDENCE_SCHEMA_V2,
     normalize_sha256,
+    runtime_agent_output_bytes,
+    runtime_claim_sha256,
     runtime_evidence_json,
     validate_runtime_evidence,
 )
@@ -22,13 +30,23 @@ from .runtime_contract import (
 
 @dataclass(frozen=True, slots=True)
 class RuntimeEvidenceLimits:
-    """Internal resource limits bounded by the frozen Core contract."""
+    """Bound one canonical Runtime Evidence envelope before official upload.
+
+    Attributes:
+        max_components: Maximum typed facts retained in one step envelope; the
+            Core v1 contract permits at most 100.
+        max_text_length: Maximum characters accepted for a safe relative path or
+            other bounded identifier before that observation is dropped.
+        max_content_chars: Maximum characters in the complete canonical JSON
+            content, including identifiers and component envelope overhead.
+    """
 
     max_components: int = 100
     max_text_length: int = 1024
     max_content_chars: int = RUNTIME_EVIDENCE_MAX_CHARS
 
     def __post_init__(self) -> None:
+        """Enforce Core-compatible component, text, and envelope size limits."""
         values = (self.max_components, self.max_text_length, self.max_content_chars)
         if any(
             isinstance(value, bool) or not isinstance(value, int) for value in values
@@ -42,6 +60,16 @@ class RuntimeEvidenceLimits:
 
 @dataclass(frozen=True, slots=True)
 class BuiltRuntimeEvidence:
+    """Return a canonical envelope together with transparent loss accounting.
+
+    Attributes:
+        evidence: Closed ``defuzex.runtime_evidence.v1`` mapping ready for
+            serialization as one typed Evidence item.
+        missing: Stable reasons explaining unavailable or filtered observations.
+        dropped_count: Total observations/components omitted for privacy,
+            validity, component-count, or character-budget reasons.
+    """
+
     evidence: Mapping[str, Any]
     missing: tuple[str, ...] = ()
     dropped_count: int = 0
@@ -56,21 +84,8 @@ def runtime_submission_id(run_id: str, input_id: str) -> str:
     return f"submission-{digest[:32]}"
 
 
-def _sha256(value: Any) -> str:
-    if isinstance(value, str):
-        payload = value.encode("utf-8", "surrogatepass")
-    else:
-        payload = json.dumps(
-            value,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-    return hashlib.sha256(payload).hexdigest()
-
-
 def _relative_path(value: Any, root: Path, limit: int) -> str | None:
+    """Return a bounded non-sensitive path only when it remains under the Run root."""
     try:
         relative = Path(value).resolve().relative_to(root.resolve()).as_posix()
     except (OSError, TypeError, ValueError):
@@ -85,6 +100,7 @@ def _relative_path(value: Any, root: Path, limit: int) -> str | None:
 
 
 def _file_component(change: FileChange, *, path: str, operation: str) -> dict[str, Any]:
+    """Project one file observation to canonical hash-only wire fields."""
     result: dict[str, Any] = {
         "kind": "file_change",
         "path": path,
@@ -107,6 +123,7 @@ def _file_components(
     root: Path,
     limits: RuntimeEvidenceLimits,
 ) -> tuple[list[dict[str, Any]], int]:
+    """Order file changes, expand renames, and count unsafe paths as dropped."""
     if evidence is None:
         return [], 0
     result: list[dict[str, Any]] = []
@@ -139,6 +156,7 @@ def _log_components(
     root: Path,
     limits: RuntimeEvidenceLimits,
 ) -> tuple[list[dict[str, Any]], int]:
+    """Represent captured log segments as hashed artifact snapshots."""
     result: list[dict[str, Any]] = []
     dropped = 0
     for index, segment in enumerate(logs):
@@ -154,12 +172,17 @@ def _log_components(
         ):
             dropped += 1
             continue
+        media_type = segment.get("media_type")
         component: dict[str, Any] = {
             "kind": "artifact_snapshot",
             "artifact_id": f"log-segment-{index}",
             "sha256": digest,
             "size_bytes": end - start,
-            "media_type": "text/plain",
+            "media_type": (
+                OTEL_LOG_MEDIA_TYPE
+                if media_type == OTEL_LOG_MEDIA_TYPE
+                else "text/plain"
+            ),
         }
         path = _relative_path(segment.get("path"), root, limits.max_text_length)
         if path is not None:
@@ -169,6 +192,7 @@ def _log_components(
 
 
 def _trace_component(trace_evidence: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Represent canonical Trace Evidence as a hash-only artifact snapshot."""
     if trace_evidence is None:
         return None
     text = runtime_evidence_json(trace_evidence)
@@ -182,18 +206,134 @@ def _trace_component(trace_evidence: Mapping[str, Any] | None) -> dict[str, Any]
 
 
 def _claim_component(status: str, output: Any, error: str | None) -> dict[str, Any]:
+    """Hash the Agent response and label it explicitly as an unverified claim."""
     claim_text = output if output is not None else error or ""
     return {
         "kind": "agent_response_claim",
         "claim_id": "submission-response",
         "claim": "completed" if status == "completed" else "blocked",
-        "text_sha256": _sha256(claim_text),
+        "text_sha256": runtime_claim_sha256(claim_text),
     }
+
+
+def _bounded_plain_agent_output(output: Any) -> tuple[Any, str]:
+    """Detach one v2 output and return it with its frozen claim digest.
+
+    Structural failures become value-free ``ValueError`` instances. The
+    32,768-byte limit is measured against canonical JSON and raises a public
+    ``LimitExceededError`` instead of truncating the Agent result.
+    """
+
+    try:
+        plain_output = detach_json(output)
+        output_bytes = runtime_agent_output_bytes(plain_output)
+        digest = runtime_claim_sha256(plain_output)
+    except (JsonStructureError, RecursionError, TypeError, ValueError):
+        raise ValueError("runtime evidence Agent output is invalid") from None
+    if len(output_bytes) > RUNTIME_AGENT_OUTPUT_MAX_BYTES:
+        raise LimitExceededError(
+            "Agent output exceeds the Runtime Evidence upload limit",
+            code="agent_output_too_large",
+            details={"max_utf8_bytes": RUNTIME_AGENT_OUTPUT_MAX_BYTES},
+        )
+    return plain_output, digest
+
+
+def _project_v2_claim(
+    projected: Mapping[str, Any], *, status: str, output: Any
+) -> None:
+    """Mutate only the detached v2 claim after status/hash/size validation."""
+
+    claims = [
+        component
+        for component in projected["components"]
+        if component["kind"] == "agent_response_claim"
+    ]
+    if len(claims) != 1:
+        raise ValueError("runtime evidence must contain exactly one response claim")
+    claim = claims[0]
+    if status == "completed":
+        if claim["claim"] != "completed" or output is None:
+            raise ValueError("runtime evidence completed claim is invalid")
+        plain_output, digest = _bounded_plain_agent_output(output)
+        if digest != claim["text_sha256"]:
+            raise ValueError("runtime evidence Agent output hash is invalid")
+        claim["agent_output"] = plain_output
+    elif claim["claim"] == "completed":
+        raise ValueError("runtime evidence claim does not match Submission status")
+
+
+def project_runtime_evidence_v2(
+    value: Mapping[str, Any],
+    *,
+    run_id: str,
+    input_id: str,
+    step_id: str,
+    submission_id: str,
+    status: str,
+    output: Any,
+) -> dict[str, Any]:
+    """Create the negotiated v2 transport view of one stored v1 envelope.
+
+    Args:
+        value: Immutable v1 envelope captured transactionally with the
+            Submission. It remains unchanged in local history and persistence.
+        run_id: Expected Run association from the owning Submission.
+        input_id: Expected Input association from the owning Submission.
+        step_id: Expected public Case step identifier.
+        submission_id: Deterministic Submission identifier used by Core.
+        status: Owning Submission status. Only ``completed`` exposes output.
+        output: Frozen Submission output; it is detached into plain JSON before
+            inclusion and must match the existing v1 claim digest.
+
+    Returns:
+        A new closed ``defuzex.runtime_evidence.v2`` mapping. The original v1
+        extension and caller-owned values are never mutated.
+
+    Raises:
+        LimitExceededError: If canonical Agent output exceeds 32,768 UTF-8
+            bytes or adding it would exceed the 120,000-character envelope cap.
+        ValueError: If v1 association, claim cardinality/status/hash, output JSON,
+            or the resulting v2 envelope is invalid.
+
+    Security/Privacy:
+        This pure projection adds only the final Agent output. Sensitive-data
+        enforcement is deliberately performed by the official upload boundary
+        immediately before multipart construction.
+    """
+
+    identifiers = {
+        "run_id": run_id,
+        "input_id": input_id,
+        "step_id": step_id,
+        "submission_id": submission_id,
+    }
+    validate_runtime_evidence(
+        value,
+        **identifiers,
+        schema_version=RUNTIME_EVIDENCE_SCHEMA_V1,
+    )
+    projected = json.loads(runtime_evidence_json(value))
+    _project_v2_claim(projected, status=status, output=output)
+    projected["schema_version"] = RUNTIME_EVIDENCE_SCHEMA_V2
+    if len(runtime_evidence_json(projected)) > RUNTIME_EVIDENCE_MAX_CHARS:
+        raise LimitExceededError(
+            "Runtime Evidence exceeds the canonical envelope limit",
+            code="runtime_evidence_too_large",
+            details={"max_characters": RUNTIME_EVIDENCE_MAX_CHARS},
+        )
+    validate_runtime_evidence(
+        projected,
+        **identifiers,
+        schema_version=RUNTIME_EVIDENCE_SCHEMA_V2,
+    )
+    return projected
 
 
 def _with_component_ids(
     components: Sequence[Mapping[str, Any]],
 ) -> list[dict[str, Any]]:
+    """Assign deterministic unique component IDs and monotonic sequence numbers."""
     return [
         {
             "component_id": f"component-{sequence:04d}",
@@ -212,6 +352,7 @@ def _envelope(
     submission_id: str,
     components: Sequence[Mapping[str, Any]],
 ) -> dict[str, Any]:
+    """Build the closed association envelope consumed by Core Judge."""
     return {
         "schema_version": RUNTIME_EVIDENCE_SCHEMA,
         "run_id": run_id,
@@ -228,6 +369,7 @@ def _fit_components(
     identifiers: Mapping[str, str],
     limits: RuntimeEvidenceLimits,
 ) -> tuple[dict[str, Any], int, bool]:
+    """Retain ordered facts and the final claim within component and character caps."""
     dropped = max(0, len(components) - limits.max_components)
     retained = components[: limits.max_components]
     if dropped and limits.max_components > 1:
@@ -299,5 +441,6 @@ __all__ = [
     "BuiltRuntimeEvidence",
     "RuntimeEvidenceLimits",
     "build_runtime_evidence",
+    "project_runtime_evidence_v2",
     "runtime_submission_id",
 ]

--- a/src/kuma/evidence/runtime_contract.py
+++ b/src/kuma/evidence/runtime_contract.py
@@ -2,14 +2,21 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-RUNTIME_EVIDENCE_SCHEMA = "defuzex.runtime_evidence.v1"
+from .._json_values import JsonStructureError, detach_json
+
+RUNTIME_EVIDENCE_SCHEMA_V1 = "defuzex.runtime_evidence.v1"
+RUNTIME_EVIDENCE_SCHEMA_V2 = "defuzex.runtime_evidence.v2"
+# Preserve the original import as the v1 name used by existing integrations.
+RUNTIME_EVIDENCE_SCHEMA = RUNTIME_EVIDENCE_SCHEMA_V1
 RUNTIME_EVIDENCE_MEDIA_TYPE = "application/vnd.defuzex.runtime-evidence+json"
 RUNTIME_EVIDENCE_MAX_CHARS = 120_000
+RUNTIME_AGENT_OUTPUT_MAX_BYTES = 32_768
 CASEGEN_FRAMEWORK_SCHEMA = "defuzex.casegen.ita.v1"
 CASEGEN_EVIDENCE_CAPABILITY_ORDER = (
     "file_change",
@@ -76,6 +83,7 @@ def runtime_evidence_json(value: Mapping[str, Any]) -> str:
 
 
 def _json_value(value: Any) -> Any:
+    """Detach mappings and sequences into plain JSON containers for serialization."""
     if isinstance(value, Mapping):
         return {str(key): _json_value(child) for key, child in value.items()}
     if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
@@ -122,19 +130,23 @@ def casegen_framework_is_advertised(entitlements: Mapping[str, Any]) -> bool:
 
 
 def _text(value: Any, maximum: int) -> bool:
+    """Return whether text is non-empty and within its contract length."""
     return isinstance(value, str) and 1 <= len(value) <= maximum
 
 
 def _optional_hash(component: Mapping[str, Any], name: str) -> bool:
+    """Accept an omitted digest or require canonical lowercase SHA-256."""
     return name not in component or normalize_sha256(component[name]) == component[name]
 
 
 def _required_hash(component: Mapping[str, Any], name: str) -> bool:
+    """Require a present canonical lowercase SHA-256 field."""
     value = component.get(name)
     return isinstance(value, str) and normalize_sha256(value) == value
 
 
 def _relative_wire_path(value: Any) -> bool:
+    """Reject absolute, parent-traversing, or oversized public paths."""
     if not _text(value, 1024):
         return False
     normalized = value.replace("\\", "/")
@@ -146,19 +158,131 @@ def _relative_wire_path(value: Any) -> bool:
 
 
 def _non_negative(value: Any) -> bool:
+    """Accept non-negative integers while rejecting booleans."""
     return not isinstance(value, bool) and isinstance(value, int) and value >= 0
 
 
-def _valid_component_fields(component: Mapping[str, Any]) -> bool:
+def _valid_component_fields(
+    component: Mapping[str, Any], *, schema_version: str = RUNTIME_EVIDENCE_SCHEMA_V1
+) -> bool:
+    """Enforce the closed component fields for the selected wire version.
+
+    Runtime Evidence v2 changes only ``agent_response_claim``: a completed claim
+    carries ``agent_output`` while v1 remains hash-only. Required conditional
+    semantics are checked by :func:`_valid_component_value`.
+    """
     kind = component.get("kind")
     if kind not in _KINDS:
         return False
     allowed = _COMMON_FIELDS | _KIND_FIELDS[kind]
+    if schema_version == RUNTIME_EVIDENCE_SCHEMA_V2 and kind == "agent_response_claim":
+        allowed |= {"agent_output"}
     required = allowed - _KIND_OPTIONAL_FIELDS[kind]
+    if kind == "agent_response_claim":
+        required -= {"agent_output"}
     return required <= set(component) <= allowed
 
 
-def _valid_component_value(component: Mapping[str, Any]) -> bool:
+def runtime_claim_bytes(value: Any) -> bytes:
+    """Return bytes used by the frozen Runtime Evidence claim digest.
+
+    Strings retain the historical raw UTF-8 ``surrogatepass`` encoding. Every
+    other value uses finite, detached, key-sorted compact JSON with ASCII escapes.
+    This function performs no I/O and never embeds a rejected value in an error.
+    """
+
+    if isinstance(value, str):
+        return value.encode("utf-8", "surrogatepass")
+    plain = detach_json(value)
+    return json.dumps(
+        plain,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def runtime_agent_output_bytes(value: Any) -> bytes:
+    """Serialize one non-null finite Agent output using canonical JSON bytes.
+
+    Unlike :func:`runtime_claim_bytes`, strings include their JSON quotes because
+    this byte count governs the actual v2 ``agent_output`` value on the wire.
+    Invalid, cyclic, unsupported, or null values raise ``JsonStructureError``.
+    """
+
+    if value is None:
+        raise JsonStructureError("agent output must not be null")
+    plain = detach_json(value)
+    return json.dumps(
+        plain,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def runtime_claim_sha256(value: Any) -> str:
+    """Return the frozen lowercase digest for one Agent response claim."""
+
+    return hashlib.sha256(runtime_claim_bytes(value)).hexdigest()
+
+
+def _valid_claim_component(
+    component: Mapping[str, Any], *, schema_version: str
+) -> bool:
+    """Validate version-dependent Agent claim fields, hash, and output budget."""
+
+    valid_claim = (
+        _text(component["claim_id"], 128)
+        and component["claim"] in {"completed", "refused", "blocked"}
+        and normalize_sha256(component["text_sha256"]) == component["text_sha256"]
+    )
+    if not valid_claim:
+        return False
+    if schema_version == RUNTIME_EVIDENCE_SCHEMA_V1:
+        return "agent_output" not in component
+    if component["claim"] != "completed":
+        return "agent_output" not in component
+    if "agent_output" not in component:
+        return False
+    try:
+        encoded = runtime_agent_output_bytes(component["agent_output"])
+        digest = runtime_claim_sha256(component["agent_output"])
+    except (JsonStructureError, TypeError, ValueError):
+        return False
+    return (
+        len(encoded) <= RUNTIME_AGENT_OUTPUT_MAX_BYTES
+        and digest == component["text_sha256"]
+    )
+
+
+def _valid_component_value(
+    component: Mapping[str, Any], *, schema_version: str
+) -> bool:
+    """Validate values for exactly one kind in the frozen Core component union.
+
+    Args:
+        component: Closed-field mapping that already passed
+            :func:`_valid_component_fields`.
+
+    Returns:
+        ``True`` only when kind-specific enums, hashes, identifiers, paths,
+        counts, sizes, and required values satisfy the canonical v1 contract.
+
+    Preconditions:
+        ``kind`` and every required field exist; callers must run the closed-field
+        check first because this function indexes required keys directly.
+
+    Postconditions:
+        The mapping is not mutated. ``False`` identifies an invalid public
+        component before official upload/model use.
+
+    Security/Privacy:
+        Hash fields must be canonical SHA-256 and paths must be bounded relative
+        wire paths; raw tool arguments/stdout/log/prompt values are not accepted.
+    """
     kind = component["kind"]
     if kind == "file_change":
         return (
@@ -210,10 +334,9 @@ def _valid_component_value(component: Mapping[str, Any]) -> bool:
             and _non_negative(component["size_bytes"])
             and _text(component["media_type"], 128)
         )
-    return (
-        _text(component["claim_id"], 128)
-        and component["claim"] in {"completed", "refused", "blocked"}
-        and normalize_sha256(component["text_sha256"]) == component["text_sha256"]
+    return _valid_claim_component(
+        component,
+        schema_version=schema_version,
     )
 
 
@@ -224,7 +347,9 @@ def _validate_association(
     input_id: str,
     step_id: str,
     submission_id: str,
+    schema_version: str,
 ) -> None:
+    """Require exact Run, Input, step, and Submission correlation before upload."""
     actual = (
         value["run_id"],
         value["input_id"],
@@ -232,7 +357,7 @@ def _validate_association(
         value["submission_id"],
     )
     if (
-        value["schema_version"] != RUNTIME_EVIDENCE_SCHEMA
+        value["schema_version"] != schema_version
         or actual != (run_id, input_id, step_id, submission_id)
         or not _text(value["run_id"], 128)
         or not _text(value["input_id"], 128)
@@ -242,7 +367,10 @@ def _validate_association(
         raise ValueError("runtime evidence association is invalid")
 
 
-def _validate_components(components: Any) -> None:
+def _validate_components(
+    components: Any, *, schema_version: str = RUNTIME_EVIDENCE_SCHEMA_V1
+) -> None:
+    """Require versioned closed components in strictly increasing order."""
     if (
         not isinstance(components, Sequence)
         or isinstance(components, str | bytes | bytearray)
@@ -252,7 +380,9 @@ def _validate_components(components: Any) -> None:
     component_ids: set[str] = set()
     previous_sequence = -1
     for component in components:
-        if not isinstance(component, Mapping) or not _valid_component_fields(component):
+        if not isinstance(component, Mapping) or not _valid_component_fields(
+            component, schema_version=schema_version
+        ):
             raise ValueError("runtime evidence component is invalid")
         component_id, sequence = component["component_id"], component["sequence"]
         if (
@@ -260,7 +390,7 @@ def _validate_components(components: Any) -> None:
             or component_id in component_ids
             or not _non_negative(sequence)
             or sequence <= previous_sequence
-            or not _valid_component_value(component)
+            or not _valid_component_value(component, schema_version=schema_version)
         ):
             raise ValueError("runtime evidence component is invalid")
         component_ids.add(component_id)
@@ -274,8 +404,20 @@ def validate_runtime_evidence(
     input_id: str,
     step_id: str,
     submission_id: str,
+    schema_version: str = RUNTIME_EVIDENCE_SCHEMA_V1,
 ) -> None:
-    """Fail closed on malformed, duplicate, or mis-associated public evidence."""
+    """Fail closed on malformed, duplicate, or mis-associated public evidence.
+
+    ``schema_version`` is the exact version negotiated with the Backend. Omitting
+    it preserves v1 validation for existing callers; unknown versions are never
+    inferred from untrusted content.
+    """
+
+    if schema_version not in {
+        RUNTIME_EVIDENCE_SCHEMA_V1,
+        RUNTIME_EVIDENCE_SCHEMA_V2,
+    }:
+        raise ValueError("runtime evidence schema version is unsupported")
 
     fields = {
         "schema_version",
@@ -293,8 +435,9 @@ def validate_runtime_evidence(
         input_id=input_id,
         step_id=step_id,
         submission_id=submission_id,
+        schema_version=schema_version,
     )
-    _validate_components(value["components"])
+    _validate_components(value["components"], schema_version=schema_version)
     if len(runtime_evidence_json(value)) > RUNTIME_EVIDENCE_MAX_CHARS:
         raise ValueError("runtime evidence exceeds the character limit")
 
@@ -302,12 +445,18 @@ def validate_runtime_evidence(
 __all__ = [
     "CASEGEN_EVIDENCE_CAPABILITY_ORDER",
     "CASEGEN_FRAMEWORK_SCHEMA",
+    "RUNTIME_AGENT_OUTPUT_MAX_BYTES",
     "RUNTIME_EVIDENCE_MAX_CHARS",
     "RUNTIME_EVIDENCE_MEDIA_TYPE",
     "RUNTIME_EVIDENCE_SCHEMA",
+    "RUNTIME_EVIDENCE_SCHEMA_V1",
+    "RUNTIME_EVIDENCE_SCHEMA_V2",
     "casegen_framework_is_advertised",
     "derive_casegen_evidence_capabilities",
     "normalize_sha256",
+    "runtime_agent_output_bytes",
+    "runtime_claim_bytes",
+    "runtime_claim_sha256",
     "runtime_evidence_json",
     "validate_runtime_evidence",
 ]

--- a/src/kuma/evidence/trace.py
+++ b/src/kuma/evidence/trace.py
@@ -5,26 +5,45 @@ from __future__ import annotations
 import threading
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+from hashlib import sha256
 from typing import Any
 
 from ..contracts import CaptureComponent
 from ..errors import ConfigurationError
-from .trace_mapping import extract_agent_output, json_size, map_span
+from .otel_log_mapping import (
+    LogRecordMappingError,
+    build_log_segment,
+    log_record_sort_key,
+    map_log_record,
+)
+from .runtime import runtime_submission_id
+from .trace_mapping import SpanMappingError, extract_agent_output, json_size, map_span
 
 _CAPTURE_REASONS = frozenset(
     {
         "trace_attribute_filtered",
         "trace_attribute_invalid",
         "trace_attribute_limit",
+        "trace_attribute_not_allowlisted",
         "trace_budget_exhausted",
         "trace_byte_limit",
         "trace_capture_failed",
         "trace_drop_count_saturated",
         "trace_event_limit",
+        "trace_event_invalid",
         "trace_export_failed",
         "trace_flush_failed",
         "trace_serialization_failed",
+        "trace_span_duplicate",
+        "trace_parent_invalid",
+        "trace_scope_invalid",
+        "trace_span_context_invalid",
         "trace_span_limit",
+        "trace_span_outside_window",
+        "trace_span_sampled",
+        "trace_span_timing_invalid",
+        "trace_topology_partial",
+        "trace_value_invalid",
         "trace_value_truncated",
     }
 )
@@ -41,6 +60,7 @@ def _evidence_payload(
     truncated: bool = False,
     reasons: tuple[str, ...] = (),
 ) -> dict[str, Any]:
+    """Build one versioned Trace envelope with stable association and accounting."""
     return {
         "schema_version": "defuzex.trace_evidence.v1",
         "run_id": run_id,
@@ -58,21 +78,42 @@ _MIN_TRACE_EVIDENCE_BYTES = json_size(_evidence_payload("r", "c", "i"))
 
 @dataclass(frozen=True, slots=True)
 class TraceEvidenceLimits:
-    """Resource limits for bounded in-process Trace Evidence.
+    """Set hard in-memory and serialized limits for in-process OTel capture.
 
     Args:
-        max_spans: Maximum ended spans retained per Run; defaults to 200.
-        max_attributes: Maximum allowlisted attributes retained per span;
-            defaults to 32.
-        max_events_per_span: Maximum allowlisted events retained per span;
-            defaults to 20.
-        max_text_length: Maximum Unicode characters retained for one allowed text
-            value before truncation; defaults to 256.
-        max_total_bytes: Maximum compact JSON bytes across all Trace Evidence
-            envelopes committed by one Run; defaults to 512,000.
+        max_spans: Maximum retained ended spans for one active step before
+            deterministic topology-aware sampling drops records.
+        max_attributes: Maximum safe allowlisted attributes inspected/retained
+            per span or resource projection.
+        max_events_per_span: Maximum OTel events retained per span.
+        max_text_length: Maximum characters retained for each allowlisted name or
+            metadata value before truncation.
+        max_total_bytes: Maximum UTF-8 bytes of complete Trace Evidence envelopes
+            committed across one Run, including envelope and reason overhead.
+        max_log_records: Maximum normalized OTel log records retained per step.
+        max_log_bytes: Maximum UTF-8 bytes of structured OTel log artifacts
+            committed across one Run.
 
-    Every limit must be a positive integer. ``max_total_bytes`` must fit the
-    smallest valid envelope or construction raises ``ConfigurationError``.
+    Raises:
+        ConfigurationError: If any limit is a boolean, is not a positive
+            integer, or ``max_total_bytes`` cannot hold the smallest valid Trace
+            Evidence envelope.
+
+    Preconditions:
+        Choose limits according to the maximum local memory and Evidence size
+        the application is prepared to retain. Increasing a number does not
+        enable additional attribute or log-body fields.
+
+    Postconditions:
+        A valid instance provides immutable budgets used by
+        :class:`TraceEvidenceCapture` for every step in one Run. Excluded,
+        sampled, or truncated telemetry is reported through stable capture
+        status and reason fields instead of exceeding these budgets.
+
+    Security/Privacy:
+        These values only reduce or enlarge resource budgets. They never widen
+        the Trace/OTel-log allowlists, permit raw prompt or log bodies, or bypass
+        KUMA's sensitive-data policy.
     """
 
     max_spans: int = 200
@@ -80,14 +121,19 @@ class TraceEvidenceLimits:
     max_events_per_span: int = 20
     max_text_length: int = 256
     max_total_bytes: int = 512_000
+    max_log_records: int = 200
+    max_log_bytes: int = 128_000
 
     def __post_init__(self) -> None:
+        """Reject limits that cannot bound a minimally valid Trace envelope."""
         for name in (
             "max_spans",
             "max_attributes",
             "max_events_per_span",
             "max_text_length",
             "max_total_bytes",
+            "max_log_records",
+            "max_log_bytes",
         ):
             value = getattr(self, name)
             if isinstance(value, bool) or not isinstance(value, int) or value < 1:
@@ -101,6 +147,15 @@ class TraceEvidenceLimits:
 
 @dataclass(slots=True)
 class _Association:
+    """Correlate exported telemetry with the one currently active Run step.
+
+    Attributes:
+        run_id: Owning public Run identifier.
+        case_id: Owning public Case identifier.
+        input_id: Current step/input identifier.
+        active: Whether late exports may still enter this step bucket.
+    """
+
     run_id: str
     case_id: str
     input_id: str
@@ -109,6 +164,27 @@ class _Association:
 
 @dataclass(slots=True)
 class _Bucket:
+    """Hold bounded mutable telemetry awaiting one step transaction.
+
+    Attributes:
+        spans: Retained ``(sequence, mapped_span, encoded_size)`` records.
+        next_sequence: Monotonic capture sequence for deterministic ordering.
+        bytes_used: Approximate bytes currently held by mapped spans.
+        dropped_count: Span/event observations omitted from retained Evidence.
+        truncated: Whether any span-side limit or mapping loss occurred.
+        reasons: Stable span-side degradation reason codes.
+        agent_output: Best supported final Agent output with ordering priority.
+        observed_spans: Total associated spans seen before sampling.
+        dropped_attribute_events: Attribute/event fields removed by privacy or limits.
+        log_records: Retained normalized OTel log records with sequence and size.
+        next_log_sequence: Monotonic capture sequence for log ordering.
+        log_bytes_used: Bytes currently held by normalized log records.
+        observed_logs: Total associated OTel log records observed.
+        dropped_logs: Log records omitted by mapping or limits.
+        dropped_log_fields: Individual log fields filtered or truncated.
+        log_reasons: Stable log-side degradation reason codes.
+    """
+
     spans: list[tuple[int, Mapping[str, Any], int]] = field(default_factory=list)
     next_sequence: int = 0
     bytes_used: int = 0
@@ -116,14 +192,97 @@ class _Bucket:
     truncated: bool = False
     reasons: set[str] = field(default_factory=set)
     agent_output: tuple[tuple[int, int, int], Any] | None = None
+    observed_spans: int = 0
+    dropped_attribute_events: int = 0
+    log_records: list[tuple[int, Mapping[str, Any], int]] = field(default_factory=list)
+    next_log_sequence: int = 0
+    log_bytes_used: int = 0
+    observed_logs: int = 0
+    dropped_logs: int = 0
+    dropped_log_fields: int = 0
+    log_reasons: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True, slots=True)
+class _TraceSnapshot:
+    """Freeze one bucket view while building transactional Evidence.
+
+    Attributes:
+        sequence: Bucket sequence boundary included by this snapshot.
+        spans: Deterministically ordered retained span mappings.
+        reasons: Stable span degradation reasons.
+        dropped: Total omitted span observations.
+        truncated: Whether span Evidence is incomplete.
+        observed_spans: Total spans observed before sampling.
+        dropped_attribute_events: Filtered/truncated span fields count.
+        log_records: Deterministically ordered normalized log records.
+        observed_logs: Total OTel log records observed.
+        dropped_logs: Omitted log-record count.
+        dropped_log_fields: Filtered/truncated log-field count.
+        log_reasons: Stable log degradation reasons.
+    """
+
+    sequence: int
+    spans: list[Mapping[str, Any]]
+    reasons: tuple[str, ...]
+    dropped: int
+    truncated: bool
+    observed_spans: int
+    dropped_attribute_events: int
+    log_records: list[Mapping[str, Any]]
+    observed_logs: int
+    dropped_logs: int
+    dropped_log_fields: int
+    log_reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedOtelLogs:
+    """Stage safe OTel log segments in the owning Submission transaction.
+
+    Attributes:
+        segments: Structured bounded log artifacts ready for Submission logs.
+        component: Public completeness status for OTel log capture.
+        missing: Stable missing/degradation reason codes.
+        dropped_count: Omitted records and fields counted for the Submission.
+        observed_count: Associated OTel records seen before filtering.
+        retained_count: Records represented in ``segments``.
+        _encoded_size: Run byte budget reserved if the transaction commits.
+    """
+
+    segments: tuple[Mapping[str, Any], ...] = ()
+    component: CaptureComponent = field(default_factory=CaptureComponent)
+    missing: tuple[str, ...] = ()
+    dropped_count: int = 0
+    observed_count: int = 0
+    retained_count: int = 0
+    _encoded_size: int = 0
 
 
 @dataclass(slots=True)
 class PreparedTraceEvidence:
+    """Stage Trace/OTel Evidence until the enclosing Submission commits.
+
+    Attributes:
+        evidence: Versioned Trace Evidence mapping, or ``None`` when unavailable.
+        component: Public Trace capture completeness status.
+        missing: Stable reasons for absent or partial Trace Evidence.
+        dropped_count: Omitted telemetry observations charged to the Submission.
+        capture_summary: Safe aggregate counts/topology status for diagnostics.
+        otel_logs: OTel logs staged in the same step transaction.
+        _capture: Capture owner that commits/aborts the reservation.
+        _association: Step association, or ``None`` for a no-capture preparation.
+        _sequence: Snapshot boundary protected from late telemetry.
+        _encoded_size: Trace bytes reserved against the Run budget.
+        _finished: Whether commit or abort already finalized this preparation.
+    """
+
     evidence: Mapping[str, Any] | None
     component: CaptureComponent
     missing: tuple[str, ...]
     dropped_count: int
+    capture_summary: Mapping[str, Any] | None
+    otel_logs: PreparedOtelLogs
     _capture: TraceEvidenceCapture
     _association: _Association | None
     _sequence: int
@@ -131,13 +290,20 @@ class PreparedTraceEvidence:
     _finished: bool = False
 
     def commit(self) -> None:
+        """Commit prepared capture state only after the enclosing submission succeeds."""
         if self._finished:
             return
         if self._association is not None:
-            self._capture._commit(self._association, self._sequence, self._encoded_size)
+            self._capture._commit(
+                self._association,
+                self._sequence,
+                self._encoded_size,
+                self.otel_logs._encoded_size,
+            )
         self._finished = True
 
     def abort(self) -> None:
+        """Discard prepared capture state after a failed enclosing submission."""
         if self._finished:
             return
         if self._association is not None:
@@ -146,21 +312,76 @@ class PreparedTraceEvidence:
 
 
 class TraceEvidenceCapture:
-    """Receive mapped ended spans and expose one transaction per Run step."""
+    """Collect ended in-process OTel telemetry for one active Run step at a time.
+
+    The capture is normally returned by ``configure_trace_evidence`` or attached
+    automatically by ``create_run`` when a compatible global provider exists.
+    It is thread-safe and associates worker-thread spans at span start, but it
+    does not receive spans from another process or an OTLP network exporter.
+
+    Security/Privacy:
+        Mapping retains a strict allowlist of identifiers, timing, status, safe
+        resource/scope metadata, and approved ``gen_ai`` usage/model attributes.
+        Arbitrary attributes, prompt/completion text, raw logs, tool arguments,
+        source, and credentials are filtered or represented only by safe hashes.
+    """
 
     def __init__(self, limits: TraceEvidenceLimits | None = None) -> None:
+        """Initialize empty thread-safe capture with bounded Run budgets.
+
+        Args:
+            limits: Resource limits to enforce, or ``None`` for safe defaults.
+
+        Raises:
+            ConfigurationError: If the supplied limits cannot represent even a
+                minimal valid Trace Evidence envelope.
+
+        Postconditions:
+            No Run/step is active, no telemetry is retained, and byte accounting
+            starts at zero. No provider has been attached by this constructor.
+
+        Side Effects:
+            Allocates local locks/maps only; performs no network or filesystem I/O.
+        """
         self.limits = limits or TraceEvidenceLimits()
         self._lock = threading.RLock()
         self._buckets: dict[int, _Bucket] = {}
         self._run_bytes: dict[tuple[str, str], int] = {}
+        self._run_log_bytes: dict[tuple[str, str], int] = {}
         self._active: _Association | None = None
         self._registrations: dict[tuple[int, int], _Association] = {}
+        self._prewindow_registrations: set[tuple[int, int]] = set()
         self._force_flush: Callable[[], bool] | None = None
 
     def _set_force_flush(self, callback: Callable[[], bool]) -> None:
+        """Register the attached provider's flush callback for step finalization."""
         self._force_flush = callback
 
     def begin_step(self, run_id: str, case_id: str, input_id: str) -> None:
+        """Open the telemetry transaction for exactly one delivered Run input.
+
+        Args:
+            run_id: Non-empty owning Run identifier.
+            case_id: Non-empty owning Case identifier.
+            input_id: Non-empty current input/step identifier.
+
+        Raises:
+            ConfigurationError: If identifiers are invalid or their minimal
+                envelope alone exceeds the Run byte budget.
+            RuntimeError: If a prior step is still active. The conflicting prior
+                bucket is discarded to prevent cross-step leakage.
+
+        Preconditions:
+            The previous step was committed, aborted, cancelled, or the Run was
+            finished. ``Run.get_input`` owns this lifecycle call.
+
+        Postconditions:
+            Success installs one empty active bucket; subsequent same-process
+            span starts and log exports correlate to these identifiers.
+
+        Side Effects:
+            Changes only in-memory association state.
+        """
         if any(
             not isinstance(value, str) or not value
             for value in (run_id, case_id, input_id)
@@ -184,10 +405,22 @@ class TraceEvidenceCapture:
             self._active = association
 
     def register_span(self, span: Any) -> None:
+        """Associate a span that starts inside the current step capture window.
+
+        The window opens in :meth:`begin_step` and closes when
+        :meth:`prepare_step` snapshots the Submission. A valid span started
+        before or after that window is not registered; if it later ends while a
+        step is active, :meth:`export_registered_span` accounts for the loss.
+        This method performs no network or filesystem I/O.
+        """
         key = _span_key(span)
         with self._lock:
             association = self._active
-            if key is None or association is None or not association.active:
+            if key is None:
+                return
+            if association is None or not association.active:
+                if len(self._prewindow_registrations) < self.limits.max_spans * 4:
+                    self._prewindow_registrations.add(key)
                 return
             bucket = self._buckets.get(id(association))
             if bucket is None or key in self._registrations:
@@ -195,32 +428,64 @@ class TraceEvidenceCapture:
             registered = sum(
                 candidate is association for candidate in self._registrations.values()
             )
-            if len(bucket.spans) + registered >= self.limits.max_spans:
-                self._note_drop(bucket, 1, "trace_span_limit", truncated=True)
+            if registered >= self.limits.max_spans * 4:
+                bucket.observed_spans += 1
+                self._note_sampled_span(bucket)
                 return
             self._registrations[key] = association
 
     def export_registered_span(self, span: Any) -> None:
+        """Map an ended span or account for an end inside the wrong window.
+
+        Spans registered at start retain their original step association across
+        worker threads. An unregistered span that ends while a step is active is
+        counted as ``trace_span_outside_window`` rather than disappearing. A
+        span ending when no step is active cannot be safely attributed and is
+        ignored to prevent cross-step or cross-Run leakage.
+        """
         key = _span_key(span)
         if key is None:
             return
         with self._lock:
             association = self._registrations.pop(key, None)
-        if association is not None:
-            self.export_span(span, association=association)
+            if association is None:
+                started_before_window = key in self._prewindow_registrations
+                self._prewindow_registrations.discard(key)
+                active = self._active
+                if started_before_window and active is not None and active.active:
+                    bucket = self._buckets.get(id(active))
+                    if bucket is not None:
+                        bucket.observed_spans += 1
+                        self._note_drop(
+                            bucket,
+                            1,
+                            "trace_span_outside_window",
+                            truncated=True,
+                        )
+                return
+        self.export_span(span, association=association)
 
     def export_span(
         self, span: Any, *, association: _Association | None = None
     ) -> None:
+        """Map an ended span into the currently active same-process Run step."""
         if association is None:
             with self._lock:
                 association = self._active
         if association is None or not association.active:
             return
+        with self._lock:
+            bucket = self._buckets.get(id(association))
+            if bucket is None or not association.active:
+                return
+            bucket.observed_spans += 1
         try:
             mapped, dropped, truncated, reasons = map_span(span, self.limits)
             size = json_size(mapped)
             agent_output = extract_agent_output(span, self.limits.max_total_bytes)
+        except SpanMappingError as exc:
+            self.record_failure(exc.reason, association=association)
+            return
         except Exception:
             self.record_failure("trace_serialization_failed", association=association)
             return
@@ -233,26 +498,126 @@ class TraceEvidenceCapture:
                 if bucket.agent_output is None or rank >= bucket.agent_output[0]:
                     bucket.agent_output = (rank, output)
             self._increment_dropped(bucket, dropped)
+            bucket.dropped_attribute_events += dropped
             bucket.truncated = bucket.truncated or truncated
             bucket.reasons.update(
                 reason for reason in reasons if reason in _CAPTURE_REASONS
             )
-            if len(bucket.spans) >= self.limits.max_spans:
-                self._note_drop(bucket, 1, "trace_span_limit", truncated=True)
+            self._retain_sampled_span(bucket, association, mapped, size)
+
+    def export_log_record(self, record: Any) -> None:
+        """Capture one ended OTel LogRecord without retaining its raw values."""
+
+        with self._lock:
+            association = self._active
+            if association is None or not association.active:
                 return
-            run_bytes = self._run_bytes.get(
-                (association.run_id, association.case_id), 0
+            bucket = self._buckets.get(id(association))
+            if bucket is None:
+                return
+            bucket.observed_logs += 1
+        try:
+            mapped, dropped, _, reasons = map_log_record(record, self.limits)
+            size = json_size(mapped)
+        except LogRecordMappingError as exc:
+            self.record_log_failure(exc.reason, association=association)
+            return
+        except Exception:
+            self.record_log_failure("otel_log_invalid", association=association)
+            return
+        with self._lock:
+            bucket = self._buckets.get(id(association))
+            if bucket is None or not association.active:
+                return
+            bucket.dropped_log_fields = min(
+                bucket.dropped_log_fields + dropped, _MAX_DROPPED_COUNT
             )
-            if run_bytes + bucket.bytes_used + size > self.limits.max_total_bytes:
-                self._note_drop(bucket, 1, "trace_byte_limit", truncated=True)
+            bucket.log_reasons.update(reasons)
+            if len(bucket.log_records) >= self.limits.max_log_records:
+                self._drop_log(bucket, "otel_log_limit")
                 return
-            sequence = bucket.next_sequence
-            bucket.next_sequence += 1
-            bucket.spans.append((sequence, mapped, size))
-            bucket.bytes_used += size
+            if bucket.log_bytes_used + size > self.limits.max_log_bytes:
+                self._drop_log(bucket, "otel_log_byte_limit")
+                return
+            sequence = bucket.next_log_sequence
+            bucket.next_log_sequence += 1
+            bucket.log_records.append((sequence, mapped, size))
+            bucket.log_bytes_used += size
+
+    def _retain_sampled_span(
+        self,
+        bucket: _Bucket,
+        association: _Association,
+        mapped: Mapping[str, Any],
+        size: int,
+    ) -> None:
+        """Insert or replace a sampled span while maintaining topology and byte counts."""
+        identity = (mapped["trace_id"], mapped["span_id"])
+        if any(
+            (item[1]["trace_id"], item[1]["span_id"]) == identity
+            for item in bucket.spans
+        ):
+            self._note_drop(bucket, 1, "trace_span_duplicate", truncated=True)
+            return
+        replacement = self._sample_replacement(bucket, mapped)
+        if len(bucket.spans) >= self.limits.max_spans and replacement is None:
+            self._note_sampled_span(bucket)
+            return
+        replaced_size = 0 if replacement is None else bucket.spans[replacement][2]
+        run_bytes = self._run_bytes.get((association.run_id, association.case_id), 0)
+        projected = run_bytes + bucket.bytes_used - replaced_size + size
+        if projected > self.limits.max_total_bytes:
+            self._note_drop(bucket, 1, "trace_byte_limit", truncated=True)
+            return
+        sequence = bucket.next_sequence
+        bucket.next_sequence += 1
+        item = (sequence, mapped, size)
+        if replacement is None:
+            bucket.spans.append(item)
+        else:
+            bucket.spans[replacement] = item
+            self._note_sampled_span(bucket)
+        bucket.bytes_used += size - replaced_size
+
+    def _sample_replacement(
+        self, bucket: _Bucket, candidate: Mapping[str, Any]
+    ) -> int | None:
+        """Choose a deterministic lower-priority span eligible for replacement."""
+        if len(bucket.spans) < self.limits.max_spans:
+            return None
+        protected = {
+            span["parent_span_id"]
+            for _, span, _ in bucket.spans
+            if span["parent_span_id"] is not None
+        }
+        if candidate["parent_span_id"] is not None:
+            protected.add(candidate["parent_span_id"])
+        priorities = [
+            (_span_priority(span, protected), index)
+            for index, (_, span, _) in enumerate(bucket.spans)
+            if span["span_id"] not in protected
+        ]
+        if not priorities:
+            return None
+        worst_priority, worst_index = max(priorities)
+        if _span_priority(candidate, protected) >= worst_priority:
+            return None
+        return worst_index
+
+    def _note_sampled_span(self, bucket: _Bucket) -> None:
+        """Mark deterministic sampling and increment the dropped-span accounting."""
+        self._note_drop(bucket, 1, "trace_span_limit", truncated=True)
+        bucket.reasons.add("trace_span_sampled")
 
     def output_for_step(self, run_id: str, case_id: str, input_id: str) -> Any | None:
-        """Return the latest standard OTel Agent/Workflow output for this step."""
+        """Return the preferred standard OTel final output for this step.
+
+        A valid ``invoke_workflow`` result outranks every ``invoke_agent`` result
+        because it represents the orchestration's final answer. Within the same
+        operation class, the latest end time wins and span ID breaks exact ties.
+        The value is read only from bounded semantic-convention fields and is not
+        copied into Trace Evidence.
+        """
 
         association = self._matching_association(run_id, case_id, input_id)
         self._flush(association)
@@ -265,6 +630,7 @@ class TraceEvidenceCapture:
     def record_failure(
         self, reason: str, *, association: _Association | None = None
     ) -> None:
+        """Record a bounded stable span-capture reason without exception text."""
         with self._lock:
             target = association or self._active
             if target is None or not target.active:
@@ -276,31 +642,130 @@ class TraceEvidenceCapture:
                 )
                 self._note_drop(bucket, 1, bounded_reason)
 
+    def record_log_failure(
+        self, reason: str, *, association: _Association | None = None
+    ) -> None:
+        """Record a bounded stable OTel Logs reason without raw record content."""
+        with self._lock:
+            target = association or self._active
+            if target is None or not target.active:
+                return
+            bucket = self._buckets.get(id(target))
+            if bucket is not None:
+                self._drop_log(bucket, reason)
+
     def prepare_step(
         self, run_id: str, case_id: str, input_id: str
     ) -> PreparedTraceEvidence:
+        """Stage one associated step's flushed OTel Trace and Logs Evidence.
+
+        The active provider is flushed before a lock-protected snapshot is fit
+        to the remaining per-Run Trace and log budgets. The returned
+        ``PreparedTraceEvidence`` is coupled to the current association and
+        sequence: ``commit()`` charges retained bytes and seals the step only
+        after Submission success, while ``abort()`` discards it without charging
+        the Run so retry and late telemetry cannot leak into another step.
+
+        Args:
+            run_id: Expected active Run identifier.
+            case_id: Expected active Case identifier.
+            input_id: Expected active input/step identifier.
+
+        Returns:
+            Transactional :class:`PreparedTraceEvidence` containing bounded
+            Trace Evidence, mapped OTel logs, status, and accounting.
+
+        Raises:
+            RuntimeError: If identifiers do not match the active association.
+            ConfigurationError: If a minimal valid result cannot fit configured
+                limits.
+
+        Preconditions:
+            ``begin_step`` opened the exact association and the Agent has ended
+            all telemetry it expects this Submission to include.
+
+        Postconditions:
+            Success snapshots a fixed sequence but does not charge Run budgets or
+            close the association. ``commit`` seals/charges it; ``abort`` discards
+            it. Flush/mapping failures are represented as partial/missing status.
+
+        Side Effects:
+            Requests provider ``force_flush`` and reads in-memory telemetry only.
+
+        Security/Privacy:
+            Only allowlisted mapped values and hash-only log content are returned;
+            exporter exceptions and raw telemetry values are not exposed.
+        """
         association = self._matching_association(run_id, case_id, input_id)
         self._flush(association)
-        sequence, spans, reasons, dropped, truncated = self._snapshot(association)
+        snapshot = self._snapshot(association)
         evidence, reasons, dropped, encoded_size = self._fit_evidence(
             association,
-            spans,
-            reasons,
-            dropped,
-            truncated,
+            snapshot.spans,
+            snapshot.reasons,
+            snapshot.dropped,
+            snapshot.truncated,
         )
+        otel_logs = self._prepare_otel_logs(association, snapshot)
         status = "failed" if evidence is None else "complete"
-        if evidence is not None and reasons:
+        if evidence is not None and (
+            reasons or dropped > 0 or bool(evidence.get("truncated"))
+        ):
             status = "partial" if evidence["spans"] else "failed"
+        retained_spans = 0 if evidence is None else len(evidence["spans"])
         return PreparedTraceEvidence(
             evidence=evidence,
             component=CaptureComponent(status=status, reasons=reasons),
             missing=tuple(f"trace_evidence:{reason}" for reason in reasons),
             dropped_count=dropped,
+            capture_summary=_capture_summary(
+                observed_spans=snapshot.observed_spans,
+                retained_spans=retained_spans,
+                dropped_attribute_events=snapshot.dropped_attribute_events,
+                topology_complete="trace_topology_partial" not in reasons,
+                observed_logs=otel_logs.observed_count,
+                retained_logs=otel_logs.retained_count,
+                dropped_log_fields=snapshot.dropped_log_fields,
+            ),
+            otel_logs=otel_logs,
             _capture=self,
             _association=association,
-            _sequence=sequence,
+            _sequence=snapshot.sequence,
             _encoded_size=encoded_size,
+        )
+
+    def _prepare_otel_logs(
+        self, association: _Association, snapshot: _TraceSnapshot
+    ) -> PreparedOtelLogs:
+        """Build a bounded associated OTel Logs segment from captured records."""
+        if snapshot.observed_logs == 0 and not snapshot.log_reasons:
+            return PreparedOtelLogs()
+        run_key = (association.run_id, association.case_id)
+        with self._lock:
+            available = self.limits.max_log_bytes - self._run_log_bytes.get(run_key, 0)
+        built = build_log_segment(
+            run_id=association.run_id,
+            input_id=association.input_id,
+            submission_id=runtime_submission_id(
+                association.run_id, association.input_id
+            ),
+            records=snapshot.log_records,
+            observed_count=snapshot.observed_logs,
+            dropped_count=snapshot.dropped_logs,
+            reasons=set(snapshot.log_reasons),
+            max_bytes=max(0, available),
+        )
+        status = "complete"
+        if built.reasons:
+            status = "partial" if built.segment is not None else "failed"
+        return PreparedOtelLogs(
+            segments=() if built.segment is None else (built.segment,),
+            component=CaptureComponent(status=status, reasons=built.reasons),
+            missing=tuple(f"otel_logs:{reason}" for reason in built.reasons),
+            dropped_count=built.dropped_count + snapshot.dropped_log_fields,
+            observed_count=snapshot.observed_logs,
+            retained_count=built.retained_count,
+            _encoded_size=built.encoded_size,
         )
 
     def _fit_evidence(
@@ -311,6 +776,7 @@ class TraceEvidenceCapture:
         dropped: int,
         truncated: bool,
     ) -> tuple[Mapping[str, Any] | None, tuple[str, ...], int, int]:
+        """Prune sampled spans until the complete envelope fits remaining Run bytes."""
         ordered = sorted(
             spans,
             key=lambda item: (
@@ -354,6 +820,7 @@ class TraceEvidenceCapture:
         truncated: bool,
         reasons: set[str],
     ) -> dict[str, Any]:
+        """Build the ordered Trace envelope for the current immutable snapshot."""
         return _evidence_payload(
             association.run_id,
             association.case_id,
@@ -367,6 +834,7 @@ class TraceEvidenceCapture:
     def _matching_association(
         self, run_id: str, case_id: str, input_id: str
     ) -> _Association:
+        """Return the active association only when all supplied IDs match."""
         with self._lock:
             association = self._active
             expected = (run_id, case_id, input_id)
@@ -380,6 +848,7 @@ class TraceEvidenceCapture:
             return association
 
     def _flush(self, association: _Association) -> None:
+        """Flush provider processors and record failure without breaking Submission."""
         if self._force_flush is not None:
             try:
                 if not self._force_flush():
@@ -387,29 +856,76 @@ class TraceEvidenceCapture:
             except Exception:
                 self.record_failure("trace_flush_failed", association=association)
 
-    def _snapshot(
-        self, association: _Association
-    ) -> tuple[int, list[Mapping[str, Any]], tuple[str, ...], int, bool]:
+    def _snapshot(self, association: _Association) -> _TraceSnapshot:
+        """Close the step window and copy its telemetry/accounting under lock.
+
+        Registered spans still open at this boundary are observable omissions:
+        each is charged once as ``trace_span_outside_window`` before its
+        registration is removed. Spans wholly outside the window have no safe
+        step association and are never reassigned to another Run.
+        """
         with self._lock:
             association.active = False
             if self._active is association:
                 self._active = None
-            self._drop_registrations_locked(association)
             bucket = self._buckets[id(association)]
+            still_open = sum(
+                candidate is association for candidate in self._registrations.values()
+            ) + len(self._prewindow_registrations)
+            if still_open:
+                bucket.observed_spans += still_open
+                self._note_drop(
+                    bucket,
+                    still_open,
+                    "trace_span_outside_window",
+                    truncated=True,
+                )
+            self._drop_registrations_locked(association)
+            self._prewindow_registrations.clear()
             sequence = bucket.next_sequence - 1
             spans = [item[1] for item in bucket.spans if item[0] <= sequence]
             reasons = tuple(sorted(bucket.reasons))
             dropped = bucket.dropped_count
             truncated = bucket.truncated
-        return sequence, spans, reasons, dropped, truncated
+            observed_spans = bucket.observed_spans
+            dropped_attribute_events = bucket.dropped_attribute_events
+            ordered_logs = sorted(bucket.log_records, key=log_record_sort_key)
+            log_records = [item[1] for item in ordered_logs]
+            observed_logs = bucket.observed_logs
+            dropped_logs = bucket.dropped_logs
+            dropped_log_fields = bucket.dropped_log_fields
+            log_reasons = tuple(sorted(bucket.log_reasons))
+        spans, topology_dropped = _topology_closed(spans)
+        if topology_dropped:
+            reason_set = set(reasons)
+            reason_set.add("trace_topology_partial")
+            reasons = tuple(sorted(reason_set))
+            dropped = min(dropped + topology_dropped, _MAX_DROPPED_COUNT)
+            truncated = True
+        return _TraceSnapshot(
+            sequence=sequence,
+            spans=spans,
+            reasons=reasons,
+            dropped=dropped,
+            truncated=truncated,
+            observed_spans=observed_spans,
+            dropped_attribute_events=dropped_attribute_events,
+            log_records=log_records,
+            observed_logs=observed_logs,
+            dropped_logs=dropped_logs,
+            dropped_log_fields=dropped_log_fields,
+            log_reasons=log_reasons,
+        )
 
     def cancel_step(self) -> None:
+        """Abort the active step so late telemetry cannot enter another input."""
         with self._lock:
             association = self._active
             if association is not None:
                 self._discard_locked(association)
 
     def finish_run(self, run_id: str, case_id: str) -> None:
+        """Seal Run capture and discard registrations that could leak across Runs."""
         with self._lock:
             association = self._active
             if association is not None and (
@@ -418,16 +934,26 @@ class TraceEvidenceCapture:
             ) == (run_id, case_id):
                 self._discard_locked(association)
             self._run_bytes.pop((run_id, case_id), None)
+            self._run_log_bytes.pop((run_id, case_id), None)
+            self._prewindow_registrations.clear()
 
     def _commit(
-        self, association: _Association, sequence: int, encoded_size: int
+        self,
+        association: _Association,
+        sequence: int,
+        encoded_size: int,
+        encoded_log_size: int,
     ) -> None:
+        """Commit prepared byte usage and discard the active step transaction."""
         with self._lock:
             bucket = self._buckets.get(id(association))
             if bucket is None:
                 return
             run_key = (association.run_id, association.case_id)
             self._run_bytes[run_key] = self._run_bytes.get(run_key, 0) + encoded_size
+            self._run_log_bytes[run_key] = (
+                self._run_log_bytes.get(run_key, 0) + encoded_log_size
+            )
             retained = [item for item in bucket.spans if item[0] > sequence]
             if retained:
                 bucket.spans = retained
@@ -436,6 +962,7 @@ class TraceEvidenceCapture:
                 self._buckets.pop(id(association), None)
 
     def _abort(self, association: _Association) -> None:
+        """Abort prepared telemetry without advancing the committed Run budget."""
         with self._lock:
             if id(association) not in self._buckets:
                 return
@@ -445,13 +972,16 @@ class TraceEvidenceCapture:
             self._active = association
 
     def _discard_locked(self, association: _Association) -> None:
+        """Remove one association and all late-telemetry registrations under lock."""
         association.active = False
         if self._active is association:
             self._active = None
         self._drop_registrations_locked(association)
+        self._prewindow_registrations.clear()
         self._buckets.pop(id(association), None)
 
     def _drop_registrations_locked(self, association: _Association) -> None:
+        """Delete span registrations owned by the completed or cancelled step."""
         stale = [
             key
             for key, candidate in self._registrations.items()
@@ -462,6 +992,7 @@ class TraceEvidenceCapture:
 
     @staticmethod
     def _increment_dropped(bucket: _Bucket, count: int) -> None:
+        """Saturate the dropped counter at its public contract maximum."""
         if count <= 0:
             return
         total = bucket.dropped_count + count
@@ -472,14 +1003,31 @@ class TraceEvidenceCapture:
     def _note_drop(
         self, bucket: _Bucket, count: int, reason: str, *, truncated: bool = False
     ) -> None:
+        """Account for one dropped span and add its bounded reason code."""
         self._increment_dropped(bucket, count)
         bucket.reasons.add(
             reason if reason in _CAPTURE_REASONS else "trace_capture_failed"
         )
         bucket.truncated = bucket.truncated or truncated
 
+    @staticmethod
+    def _drop_log(bucket: _Bucket, reason: str) -> None:
+        """Account for one dropped LogRecord and its bounded reason code."""
+        bucket.dropped_logs = min(bucket.dropped_logs + 1, _MAX_DROPPED_COUNT)
+        allowed = {
+            "otel_log_byte_limit",
+            "otel_log_capture_failed",
+            "otel_log_export_failed",
+            "otel_log_invalid",
+            "otel_log_limit",
+        }
+        bucket.log_reasons.add(
+            reason if reason in allowed else "otel_log_capture_failed"
+        )
+
 
 def _span_key(span: Any) -> tuple[int, int] | None:
+    """Return a stable trace/span identifier pair or ``None`` for invalid spans."""
     context = getattr(span, "context", None)
     if context is None:
         get_context = getattr(span, "get_span_context", None)
@@ -496,4 +1044,80 @@ def _span_key(span: Any) -> tuple[int, int] | None:
     return trace_id, span_id
 
 
-__all__ = ["PreparedTraceEvidence", "TraceEvidenceCapture", "TraceEvidenceLimits"]
+def _span_priority(
+    span: Mapping[str, Any], protected_parent_ids: set[str]
+) -> tuple[int, int, str]:
+    """Rank spans deterministically to preserve boundaries and topology under limits."""
+    span_id = span["span_id"]
+    if span["parent_span_id"] is None:
+        category = 0
+    elif span["status"] == "error":
+        category = 1
+    elif span_id in protected_parent_ids:
+        category = 2
+    elif _is_boundary_span(span):
+        category = 3
+    else:
+        category = 4
+    duration_rank = -span["duration_nano"] if category >= 3 else 0
+    digest = sha256(f"{span['trace_id']}:{span_id}".encode("ascii")).hexdigest()
+    return category, duration_rank, digest
+
+
+def _is_boundary_span(span: Mapping[str, Any]) -> bool:
+    """Return whether a span represents a root, leaf, error, or Agent boundary."""
+    if span["kind"] in {"client", "server", "producer", "consumer"}:
+        return True
+    return span["attributes"].get("gen_ai.operation.name") == "execute_tool"
+
+
+def _topology_closed(
+    spans: list[Mapping[str, Any]],
+) -> tuple[list[Mapping[str, Any]], int]:
+    """Return whether retained parents are present whenever they were observed."""
+    retained = list(spans)
+    while True:
+        identities = {(span["trace_id"], span["span_id"]) for span in retained}
+        closed = [
+            span
+            for span in retained
+            if span["parent_span_id"] is None
+            or (span["trace_id"], span["parent_span_id"]) in identities
+        ]
+        if len(closed) == len(retained):
+            return closed, len(spans) - len(closed)
+        retained = closed
+
+
+def _capture_summary(
+    *,
+    observed_spans: int,
+    retained_spans: int,
+    dropped_attribute_events: int,
+    topology_complete: bool,
+    observed_logs: int,
+    retained_logs: int,
+    dropped_log_fields: int,
+) -> dict[str, Any]:
+    """Compute final capture status, missing reasons, and dropped accounting."""
+    return {
+        "schema_version": "defuzex.trace_capture_summary.v1",
+        "sampling_policy": "deterministic_topology_v1",
+        "observed_spans": observed_spans,
+        "retained_spans": retained_spans,
+        "dropped_spans": max(0, observed_spans - retained_spans),
+        "dropped_attributes_events": dropped_attribute_events,
+        "topology_complete": topology_complete,
+        "observed_log_records": observed_logs,
+        "retained_log_records": retained_logs,
+        "dropped_log_records": max(0, observed_logs - retained_logs),
+        "dropped_log_fields": dropped_log_fields,
+    }
+
+
+__all__ = [
+    "PreparedOtelLogs",
+    "PreparedTraceEvidence",
+    "TraceEvidenceCapture",
+    "TraceEvidenceLimits",
+]

--- a/src/kuma/evidence/trace_mapping.py
+++ b/src/kuma/evidence/trace_mapping.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import json
 import math
-from collections.abc import Mapping, Sequence
-from itertools import islice
+from collections.abc import Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 from ..repository.privacy import scan_sensitive_text
@@ -39,22 +38,41 @@ _ALLOWED_RESOURCE_ATTRIBUTES = frozenset(
 )
 _PRIVATE_ATTRIBUTE_TERMS = (
     "api_key",
+    "authorization",
     "completion",
     "content",
+    "cookie",
+    "credential",
     "file.body",
     "file.content",
     "log.body",
     "private_rubric",
     "prompt",
     "source",
+    "secret",
     "system_prompt",
     "token",
 )
+_PRIVATE_ATTRIBUTE_PATTERNS = tuple(
+    tuple(term.replace(".", "_").split("_")) for term in _PRIVATE_ATTRIBUTE_TERMS
+)
+_ATTRIBUTE_ITERATION_ERROR = object()
+_MAX_ATTRIBUTE_KEY_LENGTH = 256
 _AGENT_OUTPUT_OPERATIONS = frozenset({"invoke_agent", "invoke_workflow"})
 _GEN_AI_OUTPUT_MESSAGES = "gen_ai.output.messages"
 
 
+class SpanMappingError(ValueError):
+    """A stable, value-free reason why a required span field was unusable."""
+
+    def __init__(self, reason: str) -> None:
+        """Retain only a stable reason code, never the rejected span value."""
+        super().__init__(reason)
+        self.reason = reason
+
+
 def json_size(value: Any) -> int:
+    """Return the compact UTF-8 JSON size used for Evidence budgeting."""
     return len(
         json.dumps(
             value,
@@ -66,6 +84,7 @@ def json_size(value: Any) -> int:
 
 
 def _safe_text(value: Any, limit: int) -> tuple[str, bool]:
+    """Normalize Unicode, redact detected secrets, and truncate to the text limit."""
     text = str(value).encode("utf-8", "surrogatepass").decode("utf-8", "replace")
     if scan_sensitive_text(text, location="trace"):
         return "[redacted]", True
@@ -75,27 +94,77 @@ def _safe_text(value: Any, limit: int) -> tuple[str, bool]:
 
 
 def _safe_value(value: Any, limit: int) -> tuple[Any | None, bool]:
+    """Map one OTel scalar or short sequence into the bounded JSON subset."""
+    safe, truncated, _, _ = _safe_value_with_drops(value, limit)
+    return safe, truncated
+
+
+def _safe_value_with_drops(
+    value: Any, limit: int
+) -> tuple[Any | None, bool, int, set[str]]:
+    """Map one value while counting sequence members omitted by normalization.
+
+    This private mapper feeds the Trace attribute accounting boundary. It keeps
+    at most sixteen sequence members, counts every observed member it omits, and
+    never returns a rejected object's representation.
+
+    Args:
+        value: OTel attribute value to normalize.
+        limit: Maximum retained characters for each text value.
+
+    Returns:
+        The safe JSON value (or ``None``), whether text/sequence data was
+        truncated, the number of omitted values, and stable discard reasons.
+
+    Security/Privacy:
+        Unsupported values are counted and discarded without reading ``repr``.
+    """
     if value is None or isinstance(value, bool):
-        return value, False
+        return value, False, 0, set()
     if isinstance(value, int):
-        return (value, False) if -(2**63) <= value < 2**63 else (None, False)
+        return (
+            (value, False, 0, set())
+            if -(2**63) <= value < 2**63
+            else (None, False, 1, {"trace_attribute_invalid"})
+        )
     if isinstance(value, float):
-        return (value, False) if math.isfinite(value) else (None, False)
+        return (
+            (value, False, 0, set())
+            if math.isfinite(value)
+            else (None, False, 1, {"trace_attribute_invalid"})
+        )
     if isinstance(value, str):
-        return _safe_text(value, limit)
+        safe, truncated = _safe_text(value, limit)
+        filtered = truncated and safe == "[redacted]"
+        return (
+            safe,
+            truncated,
+            int(filtered),
+            {"trace_attribute_filtered"} if filtered else set(),
+        )
     if isinstance(value, Sequence) and not isinstance(value, bytes | bytearray):
         values: list[Any] = []
         truncated = len(value) > 16
+        dropped = max(0, len(value) - 16)
+        reasons = {"trace_attribute_limit"} if dropped else set()
         for child in value[:16]:
-            safe, child_truncated = _safe_value(child, limit)
+            safe, child_truncated, child_dropped, child_reasons = (
+                _safe_value_with_drops(child, limit)
+            )
             if safe is not None:
                 values.append(safe)
+            else:
+                child_dropped = max(1, child_dropped)
+                child_reasons.add("trace_attribute_invalid")
+            dropped += child_dropped
+            reasons.update(child_reasons)
             truncated = truncated or child_truncated
-        return values, truncated
-    return None, False
+        return values, truncated, dropped, reasons
+    return None, False, 1, {"trace_attribute_invalid"}
 
 
 def attribute_key_allowed(key: str, *, resource: bool = False) -> bool:
+    """Allow only public resource metadata and bounded ``gen_ai`` metrics."""
     if resource:
         return key in _ALLOWED_RESOURCE_ATTRIBUTES
     return key in _ALLOWED_GEN_AI_ATTRIBUTES or key.startswith(_ALLOWED_GEN_AI_PREFIXES)
@@ -107,143 +176,389 @@ def _safe_attributes(
     *,
     resource: bool = False,
 ) -> tuple[dict[str, Any], int, bool, set[str]]:
-    if not isinstance(attributes, Mapping):
+    """Filter all observed attributes before bounding retained allowlisted values.
+
+    ``max_attributes`` limits retained public values, not the first mapping
+    entries supplied by an instrumentation library. Every observed exclusion is
+    counted and receives either an allowlist, privacy-filter, limit, or invalid
+    reason without retaining its key or value.
+    """
+    if attributes is None:
         return {}, 0, False, set()
+    if not isinstance(attributes, Mapping):
+        return {}, 1, True, {"trace_attribute_invalid"}
     result: dict[str, Any] = {}
     dropped = 0
     truncated = False
     reasons: set[str] = set()
-    inspected = list(islice(attributes.items(), limits.max_attributes + 1))
-    if len(inspected) > limits.max_attributes:
-        inspected.pop()
-        dropped += 1
-        truncated = True
-        reasons.add("trace_attribute_limit")
-    for raw_key, raw_value in inspected:
-        key, key_truncated = _safe_text(raw_key, limits.max_text_length)
-        allowed = attribute_key_allowed(key, resource=resource)
-        if not allowed:
-            if any(term in key.casefold() for term in _PRIVATE_ATTRIBUTE_TERMS):
-                dropped += 1
-                reasons.add("trace_attribute_filtered")
-            continue
-        value, value_truncated = _safe_value(raw_value, limits.max_text_length)
-        if value is None:
+    for item in _attribute_items(attributes):
+        if item is _ATTRIBUTE_ITERATION_ERROR:
             dropped += 1
-            reasons.add("trace_attribute_invalid")
-            continue
-        result[key] = value
-        if key_truncated or value_truncated:
             truncated = True
-            reasons.add("trace_value_truncated")
+            reasons.add("trace_attribute_invalid")
+            break
+        raw_key, raw_value = item
+        key, value, item_truncated, item_dropped, item_reasons = _safe_attribute(
+            raw_key,
+            raw_value,
+            limits,
+            resource=resource,
+            retain=len(result) < limits.max_attributes,
+        )
+        dropped += item_dropped
+        reasons.update(item_reasons)
+        if key is not None:
+            result[key] = value
+        if item_truncated:
+            truncated = True
+            if not item_reasons:
+                reasons.add("trace_value_truncated")
     return result, dropped, truncated, reasons
+
+
+def _attribute_items(
+    attributes: Mapping[Any, Any],
+) -> Iterator[tuple[Any, Any] | object]:
+    """Yield mapping items and replace iterator failures with one safe sentinel.
+
+    The caller owns discard accounting. This generator never exposes exception
+    text or materializes an untrusted mapping, so memory remains bounded while
+    all successfully observed items are processed.
+    """
+    try:
+        iterator = iter(attributes.items())
+    except Exception:
+        yield _ATTRIBUTE_ITERATION_ERROR
+        return
+    while True:
+        try:
+            yield next(iterator)
+        except StopIteration:
+            return
+        except Exception:
+            yield _ATTRIBUTE_ITERATION_ERROR
+            return
+
+
+def _safe_attribute(
+    raw_key: Any,
+    raw_value: Any,
+    limits: TraceEvidenceLimits,
+    *,
+    resource: bool,
+    retain: bool,
+) -> tuple[str | None, Any | None, bool, int, set[str]]:
+    """Classify and optionally retain one attribute without exposing raw values."""
+    key = _normalized_attribute_key(raw_key)
+    if key is None:
+        return None, None, True, 1, {"trace_attribute_invalid"}
+    if not attribute_key_allowed(key, resource=resource):
+        reason = (
+            "trace_attribute_filtered"
+            if _private_attribute_key(key)
+            else "trace_attribute_not_allowlisted"
+        )
+        return None, None, False, 1, {reason}
+    if not retain:
+        return None, None, True, 1, {"trace_attribute_limit"}
+    try:
+        value, value_truncated, value_dropped, value_reasons = _safe_value_with_drops(
+            raw_value, limits.max_text_length
+        )
+    except Exception:
+        value, value_truncated, value_dropped, value_reasons = (
+            None,
+            False,
+            1,
+            {"trace_attribute_invalid"},
+        )
+    if value is None:
+        value_reasons.add("trace_attribute_invalid")
+        return None, None, False, max(1, value_dropped), value_reasons
+    return (
+        key,
+        value,
+        value_truncated,
+        value_dropped,
+        value_reasons,
+    )
+
+
+def _normalized_attribute_key(raw_key: Any) -> str | None:
+    """Return one bounded text key without truncating standard schema names.
+
+    ``max_text_length`` governs user-controlled values and display names, not
+    OTel schema keys. Keys use a fixed internal bound so a small value limit
+    cannot turn an allowlisted field into an apparent arbitrary key.
+    """
+    if not isinstance(raw_key, str):
+        return None
+    key = raw_key.encode("utf-8", "surrogatepass").decode("utf-8", "replace")
+    if not key or len(key) > _MAX_ATTRIBUTE_KEY_LENGTH:
+        return None
+    return key
+
+
+def _private_attribute_key(key: str) -> bool:
+    """Classify explicit sensitive key segments without substring false positives.
+
+    Attribute retention is still controlled solely by the strict allowlist. This
+    helper only chooses the public discard reason: complete key segments such as
+    ``token`` remain privacy-filtered, while benign names such as ``max_tokens``
+    are reported as ordinary allowlist exclusions.
+    """
+    segments = tuple(
+        segment
+        for segment in key.casefold().replace(".", "_").replace("-", "_").split("_")
+        if segment
+    )
+    return any(
+        segments[index : index + len(pattern)] == pattern
+        for pattern in _PRIVATE_ATTRIBUTE_PATTERNS
+        for index in range(len(segments) - len(pattern) + 1)
+    )
 
 
 def _map_events(
     events: Any, limits: TraceEvidenceLimits
 ) -> tuple[list[dict[str, Any]], int, bool, set[str]]:
-    source = list(islice(events or (), limits.max_events_per_span + 1))
-    dropped = int(len(source) > limits.max_events_per_span)
-    if dropped:
-        source.pop()
+    """Map at most the configured number of events and account for omissions."""
     mapped: list[dict[str, Any]] = []
-    truncated = bool(dropped)
-    reasons = {"trace_event_limit"} if dropped else set()
-    for event in source:
-        name, name_truncated = _safe_text(event.name, limits.max_text_length)
-        attributes, count, attr_truncated, attr_reasons = _safe_attributes(
-            getattr(event, "attributes", None), limits
-        )
-        mapped.append(
-            {
-                "name": name,
-                "time_unix_nano": _required_nano(event.timestamp, "event timestamp"),
-                "attributes": attributes,
-            }
-        )
+    dropped = 0
+    truncated = False
+    reasons: set[str] = set()
+    try:
+        iterator = iter(events or ())
+    except Exception:
+        return [], 1, True, {"trace_event_invalid"}
+    index = 0
+    # StopIteration or the explicit sentinel always terminates this bounded loop.
+    # Writing that invariant directly avoids a synthetic, unreachable ``for``
+    # exhaustion branch while preserving malformed-iterator failure isolation.
+    while True:
+        try:
+            event = next(iterator)
+        except StopIteration:
+            break
+        except Exception:
+            dropped += 1
+            truncated = True
+            reasons.add("trace_event_invalid")
+            break
+        if index == limits.max_events_per_span:
+            dropped += _event_limit_drop_count(events, index)
+            truncated = True
+            reasons.add("trace_event_limit")
+            break
+        try:
+            event_data, count, event_truncated, event_reasons = _map_event(
+                event, limits
+            )
+        except Exception:
+            dropped += 1
+            truncated = True
+            reasons.add("trace_event_invalid")
+            index += 1
+            continue
+        mapped.append(event_data)
         dropped += count
-        truncated = truncated or name_truncated or attr_truncated
-        reasons.update(attr_reasons)
-        if name_truncated:
-            reasons.add("trace_value_truncated")
+        truncated = truncated or event_truncated
+        reasons.update(event_reasons)
+        index += 1
     return mapped, dropped, truncated, reasons
 
 
+def _event_limit_drop_count(events: Any, retained_count: int) -> int:
+    """Count omitted events exactly when the OTel collection exposes its size.
+
+    Generic iterators remain bounded: once the first over-limit event is
+    observed, the function returns one rather than consuming an unknown or
+    potentially infinite source. Standard OTel event collections are sized and
+    therefore report their exact omitted count.
+    """
+    try:
+        total = len(events)
+    except (TypeError, ValueError, OverflowError):
+        return 1
+    return max(1, total - retained_count)
+
+
+def _map_event(
+    event: Any, limits: TraceEvidenceLimits
+) -> tuple[dict[str, Any], int, bool, set[str]]:
+    """Normalize one event name, timestamp, and allowlisted attributes."""
+    name, name_truncated = _safe_text(event.name, limits.max_text_length)
+    attributes, dropped, truncated, reasons = _safe_attributes(
+        getattr(event, "attributes", None), limits
+    )
+    if name_truncated:
+        reasons.add("trace_value_truncated")
+    return (
+        {
+            "name": name,
+            "time_unix_nano": _required_nano(event.timestamp, "event timestamp"),
+            "attributes": attributes,
+        },
+        dropped,
+        truncated or name_truncated,
+        reasons,
+    )
+
+
 def _required_nano(value: Any, label: str) -> int:
+    """Require a non-negative integer nanosecond timestamp."""
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         raise ValueError(f"invalid {label}")
     return value
 
 
 def _hex_identifier(value: Any, width: int, label: str) -> str:
+    """Validate an OTel numeric identifier and return fixed-width lowercase hex."""
     maximum = 1 << (width * 4)
     if isinstance(value, bool) or not isinstance(value, int) or not 0 < value < maximum:
         raise ValueError(f"invalid {label}")
     return f"{value:0{width}x}"
 
 
-def _span_core(span: Any, limits: TraceEvidenceLimits) -> tuple[dict[str, Any], bool]:
-    context = span.context
+def _span_core(
+    span: Any, limits: TraceEvidenceLimits
+) -> tuple[dict[str, Any], bool, set[str]]:
+    """Normalize required span identity, topology, timing, kind, and status.
+
+    Args:
+        span: Ended OTel-readable span object from the provider callback.
+        limits: Text/resource limits governing safe name projection.
+
+    Returns:
+        Core span mapping, whether a value was truncated, and stable degradation
+        reasons for optional parent/name/enum problems.
+
+    Raises:
+        SpanMappingError: If trace/span IDs or required start/end timing are
+            invalid. Optional malformed fields degrade instead of exposing text.
+
+    Preconditions:
+        The span has ended; mutable/live spans are outside exporter semantics.
+
+    Postconditions:
+        Success has fixed-width lowercase identifiers, non-negative duration,
+        closed kind/status values, and a bounded name.
+
+    Security/Privacy:
+        No attributes, events, output, prompt, or exception body are read here.
+    """
+    try:
+        context = span.context
+        trace_id = _hex_identifier(context.trace_id, 32, "trace ID")
+        span_id = _hex_identifier(context.span_id, 16, "span ID")
+    except Exception as exc:
+        raise SpanMappingError("trace_span_context_invalid") from exc
     parent = getattr(span, "parent", None)
-    start = _required_nano(span.start_time, "span start")
-    end = _required_nano(span.end_time, "span end")
-    if end < start:
-        raise ValueError("span end precedes start")
-    name, truncated = _safe_text(span.name, limits.max_text_length)
-    kind = getattr(getattr(span, "kind", None), "name", "UNSPECIFIED").lower()
-    status = getattr(
-        getattr(getattr(span, "status", None), "status_code", None),
-        "name",
-        "UNSET",
-    ).lower()
-    return {
-        "trace_id": _hex_identifier(context.trace_id, 32, "trace ID"),
-        "span_id": _hex_identifier(context.span_id, 16, "span ID"),
-        "parent_span_id": (
-            None
-            if parent is None
-            else _hex_identifier(parent.span_id, 16, "parent span ID")
-        ),
-        "name": name,
-        "kind": kind
-        if kind in {"internal", "server", "client", "producer", "consumer"}
-        else "unspecified",
-        "status": status if status in {"unset", "ok", "error"} else "unset",
-        "start_time_unix_nano": start,
-        "end_time_unix_nano": end,
-        "duration_nano": end - start,
-    }, truncated
+    try:
+        start = _required_nano(span.start_time, "span start")
+        end = _required_nano(span.end_time, "span end")
+        if end < start:
+            raise ValueError("span end precedes start")
+    except Exception as exc:
+        raise SpanMappingError("trace_span_timing_invalid") from exc
+    reasons: set[str] = set()
+    try:
+        name, truncated = _safe_text(span.name, limits.max_text_length)
+    except Exception:
+        name, truncated = "[invalid]", True
+        reasons.add("trace_value_invalid")
+    kind = _enum_name(getattr(span, "kind", None), "UNSPECIFIED").lower()
+    status_object = getattr(span, "status", None)
+    status = _enum_name(getattr(status_object, "status_code", None), "UNSET").lower()
+    parent_span_id = None
+    if parent is not None:
+        try:
+            raw_parent_id = parent.span_id
+            if raw_parent_id != 0:
+                parent_span_id = _hex_identifier(raw_parent_id, 16, "parent span ID")
+        except Exception:
+            reasons.add("trace_parent_invalid")
+    return (
+        {
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "parent_span_id": parent_span_id,
+            "name": name,
+            "kind": kind
+            if kind in {"internal", "server", "client", "producer", "consumer"}
+            else "unspecified",
+            "status": status if status in {"unset", "ok", "error"} else "unset",
+            "start_time_unix_nano": start,
+            "end_time_unix_nano": end,
+            "duration_nano": end - start,
+        },
+        truncated,
+        reasons,
+    )
 
 
-def _map_scope(span: Any, limits: TraceEvidenceLimits) -> tuple[dict[str, str], bool]:
-    scope = getattr(span, "instrumentation_scope", None)
-    name, name_truncated = _safe_text(
-        getattr(scope, "name", ""), limits.max_text_length
+def _enum_name(value: Any, default: str) -> str:
+    """Read an enum name defensively, falling back without leaking object text."""
+    try:
+        name = getattr(value, "name", default)
+        return name if isinstance(name, str) else default
+    except Exception:
+        return default
+
+
+def _map_scope(
+    span: Any, limits: TraceEvidenceLimits
+) -> tuple[dict[str, str], bool, set[str]]:
+    """Map bounded instrumentation scope name and version."""
+    try:
+        scope = getattr(span, "instrumentation_scope", None)
+        name, name_truncated = _safe_text(
+            getattr(scope, "name", ""), limits.max_text_length
+        )
+        version, version_truncated = _safe_text(
+            getattr(scope, "version", "") or "", limits.max_text_length
+        )
+    except Exception:
+        return {"name": "", "version": ""}, True, {"trace_scope_invalid"}
+    return (
+        {"name": name, "version": version},
+        name_truncated or version_truncated,
+        set(),
     )
-    version, version_truncated = _safe_text(
-        getattr(scope, "version", "") or "", limits.max_text_length
-    )
-    return {"name": name, "version": version}, name_truncated or version_truncated
 
 
 def map_span(
     span: Any, limits: TraceEvidenceLimits
 ) -> tuple[dict[str, Any], int, bool, set[str]]:
-    mapped, core_truncated = _span_core(span, limits)
-    attributes, dropped, truncated, reasons = _safe_attributes(
-        getattr(span, "attributes", None), limits
+    """Convert one ended OTel span to the public privacy-filtered Evidence shape."""
+    mapped, core_truncated, core_reasons = _span_core(span, limits)
+    span_attributes, attribute_field_reasons = _optional_span_field(
+        span, "attributes", "trace_attribute_invalid"
+    )
+    attributes, dropped, truncated, reasons = _safe_attributes(span_attributes, limits)
+    event_source, event_field_reasons = _optional_span_field(
+        span, "events", "trace_event_invalid"
     )
     events, event_dropped, event_truncated, event_reasons = _map_events(
-        getattr(span, "events", None), limits
+        event_source, limits
     )
+    try:
+        resource_attributes = getattr(
+            getattr(span, "resource", None), "attributes", None
+        )
+    except Exception:
+        resource_attributes = None
+        reasons.add("trace_attribute_invalid")
     resource, resource_dropped, resource_truncated, resource_reasons = _safe_attributes(
-        getattr(getattr(span, "resource", None), "attributes", None),
-        limits,
-        resource=True,
+        resource_attributes, limits, resource=True
     )
-    scope, scope_truncated = _map_scope(span, limits)
+    scope, scope_truncated, scope_reasons = _map_scope(span, limits)
+    reasons.update(core_reasons)
+    reasons.update(attribute_field_reasons)
+    reasons.update(event_field_reasons)
     reasons.update(event_reasons)
     reasons.update(resource_reasons)
+    reasons.update(scope_reasons)
     if core_truncated or scope_truncated:
         reasons.add("trace_value_truncated")
     mapped.update(
@@ -264,11 +579,29 @@ def map_span(
     )
 
 
+def _optional_span_field(span: Any, name: str, reason: str) -> tuple[Any, set[str]]:
+    """Read an optional span field and replace accessor failures with a reason code."""
+    try:
+        return getattr(span, name, None), set()
+    except Exception:
+        return None, {reason}
+
+
 def extract_agent_output(
     span: Any, max_bytes: int
 ) -> tuple[tuple[int, int, int], Any] | None:
     """Return a bounded final output only from Agent/Workflow semantic spans."""
 
+    try:
+        return _extract_agent_output(span, max_bytes)
+    except Exception:
+        return None
+
+
+def _extract_agent_output(
+    span: Any, max_bytes: int
+) -> tuple[tuple[int, int, int], Any] | None:
+    """Extract actual semantic-convention Agent output with deterministic priority."""
     attributes = getattr(span, "attributes", None)
     if not isinstance(attributes, Mapping):
         return None
@@ -297,10 +630,11 @@ def extract_agent_output(
     ):
         return None
     priority = 1 if operation == "invoke_workflow" else 0
-    return (end_time, priority, span_id), output
+    return (priority, end_time, span_id), output
 
 
 def _parse_output_messages(value: Any, max_bytes: int) -> list[dict[str, Any]] | None:
+    """Accept only a bounded JSON list of output-message objects."""
     if isinstance(value, str):
         if len(value.encode("utf-8", "surrogatepass")) > max_bytes:
             return None
@@ -329,4 +663,10 @@ def _parse_output_messages(value: Any, max_bytes: int) -> list[dict[str, Any]] |
     return normalized
 
 
-__all__ = ["attribute_key_allowed", "extract_agent_output", "json_size", "map_span"]
+__all__ = [
+    "SpanMappingError",
+    "attribute_key_allowed",
+    "extract_agent_output",
+    "json_size",
+    "map_span",
+]

--- a/src/kuma/evidence/tracking/_log_paths.py
+++ b/src/kuma/evidence/tracking/_log_paths.py
@@ -1,0 +1,210 @@
+"""Cross-platform repository boundary checks for explicit log paths."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path, PureWindowsPath
+from typing import BinaryIO
+
+
+def resolve_log_path(
+    root: Path,
+    supplied: str | os.PathLike[str],
+    *,
+    index: int,
+    root_alias: Path,
+) -> tuple[Path | None, Path | None, str | None]:
+    """Resolve one log path without following links or exposing host spelling.
+
+    Args:
+        root: Canonical repository root owned by the current Run.
+        supplied: Caller-selected text/path-like log path.
+        index: Zero-based request position used in public-safe reasons.
+        root_alias: Absolute spelling of ``root`` retained before
+            canonicalization, such as macOS ``/var`` for ``/private/var``.
+
+    Returns:
+        Absolute unresolved path, repository-relative path, and rejection
+        reason. Rejection returns ``None`` paths and an index-only reason.
+
+    Side Effects:
+        Performs bounded ``lstat`` calls only after the lexical path is proven
+        inside ``root``. It never opens a file or follows a link.
+
+    Security/Privacy:
+        Foreign drives/UNC paths, lexical escapes, symlink/reparse components,
+        caller spellings, and OS error text never enter the returned reason.
+    """
+    path, relative, rejected = _lexical_path(
+        root,
+        supplied,
+        index=index,
+        root_alias=root_alias,
+    )
+    if rejected is not None or path is None or relative is None:
+        return None, None, rejected
+    rejected = _component_rejection(root, relative, index=index)
+    if rejected is not None:
+        return None, None, rejected
+    return path, relative, None
+
+
+def _lexical_path(
+    root: Path,
+    supplied: str | os.PathLike[str],
+    *,
+    index: int,
+    root_alias: Path,
+) -> tuple[Path | None, Path | None, str | None]:
+    """Normalize one spelling and enforce the lexical repository boundary.
+
+    Windows drive/UNC forms are classified before ``Path`` resolution so a
+    foreign share cannot trigger an accidental host/network lookup. An
+    absolute path under the exact pre-canonical root spelling is translated
+    lexically to ``root``; no arbitrary symlink target is resolved. The
+    returned path remains unresolved for the link-component check.
+    """
+    try:
+        raw_path = os.fspath(supplied)
+        if not isinstance(raw_path, str) or "\0" in raw_path:
+            raise TypeError("path must resolve to text")
+        windows_path = PureWindowsPath(raw_path)
+        root_windows = PureWindowsPath(str(root))
+        foreign_drive = windows_path.drive and (
+            not windows_path.is_absolute()
+            or os.name != "nt"
+            or windows_path.drive.casefold() != root_windows.drive.casefold()
+        )
+        foreign_windows_root = os.name != "nt" and raw_path.startswith("\\")
+        if foreign_drive or foreign_windows_root:
+            return None, None, f"log_path_outside_root:{index}"
+        supplied_path = Path(raw_path).expanduser()
+        if not supplied_path.is_absolute():
+            relative = supplied_path
+        else:
+            absolute = Path(os.path.abspath(supplied_path))
+            try:
+                relative = absolute.relative_to(root)
+            except ValueError:
+                relative = absolute.relative_to(root_alias)
+        path = Path(os.path.abspath(root / relative))
+        return path, path.relative_to(root), None
+    except ValueError:
+        return None, None, f"log_path_outside_root:{index}"
+    except (KeyError, OSError, TypeError):
+        return None, None, f"invalid_log_path:{index}"
+
+
+def _component_rejection(root: Path, relative: Path, *, index: int) -> str | None:
+    """Return a safe reason for a link, mount boundary, or metadata failure.
+
+    Missing components are left for the ordinary bounded read-failure path.
+    Existing components are inspected without following their targets.
+    """
+    try:
+        root_device = root.stat().st_dev
+    except OSError:
+        return f"invalid_log_path:{index}"
+    current = root
+    for part in relative.parts:
+        current /= part
+        try:
+            metadata = current.lstat()
+        except FileNotFoundError:
+            return None
+        except OSError:
+            return f"invalid_log_path:{index}"
+        reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+        if stat.S_ISLNK(metadata.st_mode) or (
+            reparse_flag and getattr(metadata, "st_file_attributes", 0) & reparse_flag
+        ):
+            return f"log_path_symlink:{index}"
+        if metadata.st_dev != root_device:
+            return f"log_path_mount_boundary:{index}"
+    return None
+
+
+def open_verified_log(root: Path, path: Path) -> tuple[BinaryIO, os.stat_result]:
+    """Open one regular log and bind its handle to the canonical Run root.
+
+    Args:
+        root: Canonical repository root authorized for the current Run.
+        path: Canonical lexical path previously accepted under ``root``.
+
+    Returns:
+        A binary file handle positioned at byte zero and the immutable metadata
+        captured from that same handle. The caller owns and must close the handle.
+
+    Raises:
+        OSError: If opening fails, a link/reparse or mount boundary appears, the
+            path leaves ``root``, or its current identity differs from the open
+            handle.
+
+    Preconditions:
+        ``path`` came from :func:`resolve_log_path`; callers still must treat
+        that earlier result as stale because an attacker can replace components.
+
+    Postconditions:
+        On success, no bytes have been read and the returned handle refers to the
+        same regular file currently named by canonical ``path`` inside ``root``.
+        On failure, any opened descriptor is closed.
+
+    Side Effects:
+        Opens one read-only descriptor and performs bounded filesystem metadata
+        lookups. It does not write, follow an accepted link, or read file bytes.
+
+    Security/Privacy:
+        ``O_NOFOLLOW`` blocks a final-link swap where available. The post-open
+        identity check also protects platforms without that flag and detects
+        parent-component, mount, or check/open races before Evidence sees data.
+    """
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        frozen = os.fstat(descriptor)
+        _verify_open_descriptor(root, path, frozen)
+        return os.fdopen(descriptor, "rb"), frozen
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def _verify_open_descriptor(
+    root: Path,
+    path: Path,
+    frozen: os.stat_result,
+) -> None:
+    """Reject an opened descriptor unless its current path identity is stable.
+
+    The comparison deliberately happens after ``os.open`` and before any read.
+    It binds the descriptor identity to both ``lstat`` and the resolved target,
+    while requiring the target and descriptor to remain on the Run root device.
+    """
+    try:
+        canonical_target = path.resolve(strict=True)
+        canonical_target.relative_to(root)
+        named = path.lstat()
+        target = canonical_target.stat()
+        root_device = root.stat().st_dev
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise OSError("log path identity is not stable") from exc
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+    invalid = (
+        canonical_target != path
+        or not stat.S_ISREG(frozen.st_mode)
+        or not stat.S_ISREG(named.st_mode)
+        or (
+            bool(reparse_flag)
+            and bool(getattr(named, "st_file_attributes", 0) & reparse_flag)
+        )
+        or (frozen.st_dev, frozen.st_ino) != (named.st_dev, named.st_ino)
+        or (frozen.st_dev, frozen.st_ino) != (target.st_dev, target.st_ino)
+        or frozen.st_dev != root_device
+    )
+    if invalid:
+        raise OSError("log path identity changed during open")
+
+
+__all__ = ["open_verified_log", "resolve_log_path"]

--- a/src/kuma/evidence/tracking/diff.py
+++ b/src/kuma/evidence/tracking/diff.py
@@ -13,22 +13,34 @@ from .snapshot import Snapshot, SnapshotEntry
 
 @dataclass(frozen=True, slots=True)
 class DiffResult:
+    """Return uploadable file Evidence and local-only text diffs together.
+
+    Attributes:
+        evidence: Public bounded metadata and any explicitly enabled diffs.
+        local_diffs: Read-only mapping of every safe available text diff, kept
+            for local persistence even when ``upload_diff`` excluded it from the
+            public Evidence object.
+    """
+
     evidence: FileEvidence
     local_diffs: Mapping[str, str]
 
     def __post_init__(self) -> None:
+        """Freeze ordered file changes and bounded comparison reasons."""
         object.__setattr__(
             self, "local_diffs", MappingProxyType(dict(self.local_diffs))
         )
 
 
 def _rename_key(entry: SnapshotEntry) -> tuple[str, int, str] | None:
+    """Return hash, size, and kind used to pair deterministic renames."""
     if not entry.hash_complete or entry.sha256 is None:
         return None
     return entry.file_type, entry.size, entry.sha256
 
 
 def _changed(before: SnapshotEntry, after: SnapshotEntry) -> bool:
+    """Return whether kind, size, digest, link target, or mode changed."""
     return any(
         (
             before.file_type != after.file_type,
@@ -43,6 +55,7 @@ def _changed(before: SnapshotEntry, after: SnapshotEntry) -> bool:
 
 
 def _reason(before: SnapshotEntry | None, after: SnapshotEntry | None) -> str | None:
+    """Return why text diff content is unavailable for a file change."""
     reasons: list[str] = []
     for entry in (before, after):
         if entry is not None and entry.scan_error and entry.scan_error not in reasons:
@@ -59,6 +72,7 @@ def _unified_diff(
     old_path: str,
     new_path: str,
 ) -> str | None:
+    """Build a bounded unified text diff when both Snapshots retained content."""
     before_text = "" if before is None else before.text_content
     after_text = "" if after is None else after.text_content
     if before_text is None or after_text is None:
@@ -78,6 +92,7 @@ def _unified_diff(
 def _renamed_changes(
     removed: dict[str, SnapshotEntry], added: dict[str, SnapshotEntry]
 ) -> list[FileChange]:
+    """Pair identical deleted and created entries as deterministic renames."""
     removed_by_key: dict[tuple[str, int, str], list[str]] = {}
     added_by_key: dict[tuple[str, int, str], list[str]] = {}
     for path, entry in removed.items():
@@ -119,6 +134,7 @@ def _renamed_changes(
 def _deleted_changes(
     removed: Mapping[str, SnapshotEntry], *, upload_diff: bool
 ) -> tuple[list[FileChange], dict[str, str]]:
+    """Build ordered deletion Evidence for unpaired baseline paths."""
     changes: list[FileChange] = []
     local_diffs: dict[str, str] = {}
     for path in sorted(removed):
@@ -145,6 +161,7 @@ def _deleted_changes(
 def _created_changes(
     added: Mapping[str, SnapshotEntry], *, upload_diff: bool
 ) -> tuple[list[FileChange], dict[str, str]]:
+    """Build ordered creation Evidence for unpaired current paths."""
     changes: list[FileChange] = []
     local_diffs: dict[str, str] = {}
     for path in sorted(added):
@@ -175,6 +192,7 @@ def _modified_changes(
     *,
     upload_diff: bool,
 ) -> tuple[list[FileChange], dict[str, str]]:
+    """Build ordered modification Evidence for changed shared paths."""
     changes: list[FileChange] = []
     local_diffs: dict[str, str] = {}
     for path in sorted(common):
@@ -210,6 +228,7 @@ def compare_snapshots(
     scope: str,
     upload_diff: bool,
 ) -> DiffResult:
+    """Return deterministic file changes between two bounded snapshots."""
     removed = {
         path: before.entries[path]
         for path in before.entries.keys() - after.entries.keys()

--- a/src/kuma/evidence/tracking/evidence.py
+++ b/src/kuma/evidence/tracking/evidence.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
 from dataclasses import dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any
@@ -16,7 +17,7 @@ from ...contracts import (
     FileEvidence,
     Submission,
 )
-from ...errors import InputProtocolError
+from ...errors import ConfigurationError, EvidenceCaptureError, InputProtocolError
 from ...repository.privacy import (
     SensitiveFinding,
     enforce_sensitive_policy,
@@ -25,13 +26,18 @@ from ...repository.privacy import (
     scan_sensitive_text,
 )
 from ..runtime import build_runtime_evidence, runtime_submission_id
-from ..trace import PreparedTraceEvidence, TraceEvidenceCapture
+from ..trace import (
+    PreparedOtelLogs,
+    PreparedTraceEvidence,
+    TraceEvidenceCapture,
+)
 from .diff import DiffResult, compare_snapshots
 from .logs import LogTracker, PreparedLogs
 from .snapshot import Snapshot, Snapshotter
 
 
 def _plain(value: Any) -> Any:
+    """Return JSON-compatible Evidence data without retaining mutable aliases."""
     if is_dataclass(value) and not isinstance(value, type):
         return {
             field.name: _plain(getattr(value, field.name)) for field in fields(value)
@@ -46,23 +52,16 @@ def _plain(value: Any) -> Any:
 
 
 def _failed_snapshot(root: Path) -> Snapshot:
+    """Create an explicit failed Snapshot placeholder after filesystem capture errors."""
     return Snapshot(root=root, entries={}, errors=("snapshot_failed",), complete=False)
 
 
-def _metadata_capture_complete(snapshot: Snapshot) -> bool:
-    # Text retention only affects local diff availability; file metadata and
-    # hashes remain complete and keep their separate capture status.
-    return snapshot.complete or (
-        bool(snapshot.errors)
-        and all(error == "text_size_limit" for error in snapshot.errors)
-    )
-
-
 def _snapshot_component(*snapshots: Snapshot) -> CaptureComponent:
+    """Aggregate Snapshot statuses and bounded reason codes into one component."""
     errors = tuple(
         dict.fromkeys(error for snapshot in snapshots for error in snapshot.errors)
     )
-    if all(_metadata_capture_complete(snapshot) for snapshot in snapshots):
+    if not errors and all(snapshot.complete for snapshot in snapshots):
         return CaptureComponent(status="complete")
     if any(snapshot.entries for snapshot in snapshots):
         return CaptureComponent(status="partial", reasons=errors)
@@ -71,6 +70,15 @@ def _snapshot_component(*snapshots: Snapshot) -> CaptureComponent:
 
 @dataclass(frozen=True, slots=True)
 class _PreparedFiles:
+    """Stage file capture outputs before Submission validation completes.
+
+    Attributes:
+        snapshot: Aggregate baseline/final snapshot completeness.
+        diff: File comparison completeness.
+        evidence: Public file Evidence, or ``None`` when tracking is disabled.
+        result: Full comparison result including local-only diffs.
+    """
+
     snapshot: CaptureComponent
     diff: CaptureComponent
     evidence: FileEvidence | None
@@ -78,7 +86,41 @@ class _PreparedFiles:
 
 
 @dataclass(slots=True)
+class _CaptureSummary:
+    """Accumulate per-source status while preparing one Submission.
+
+    Attributes:
+        prepared_traces: Trace/OTel transaction staged for the same step.
+        status: Public per-component capture status.
+        missing: Mutable stable degradation reasons collected by the coordinator.
+        dropped_count: Total Evidence observations omitted so far.
+    """
+
+    prepared_traces: PreparedTraceEvidence | None
+    status: CaptureStatus
+    missing: list[str]
+    dropped_count: int
+
+
+@dataclass(slots=True)
 class PreparedEvidence:
+    """Stage every Evidence source for one atomic Submission commit.
+
+    Attributes:
+        capture_status: Public completeness state for file, log, privacy, and Trace.
+        file_evidence: Bounded file Evidence prepared for the Submission.
+        logs: Ordered explicit and OTel log artifacts.
+        missing: Stable reasons for unavailable or partial Evidence.
+        dropped_count: Total omitted observations across sources.
+        extensions: Versioned typed Evidence and safe capture summaries.
+        _collector: Owner whose active step is finalized on commit.
+        _prepared_logs: Incremental log offsets staged with this transaction.
+        _prepared_traces: Trace byte/association state staged with this transaction.
+        _pending_path: Temporary local Evidence record, when persistence is enabled.
+        _final_path: Final record path installed only on commit.
+        _finished: Whether commit or abort already finalized the transaction.
+    """
+
     capture_status: CaptureStatus
     file_evidence: FileEvidence | None
     logs: tuple[Mapping[str, Any], ...]
@@ -93,6 +135,7 @@ class PreparedEvidence:
     _finished: bool = False
 
     def commit(self, submission: Submission) -> None:
+        """Commit prepared capture state only after the enclosing submission succeeds."""
         del submission
         if self._finished:
             return
@@ -102,28 +145,45 @@ class PreparedEvidence:
                 self._pending_path.replace(self._final_path)
             except OSError:
                 self._collector.runtime_warnings.append("local_evidence_commit_failed")
-                self._pending_path.unlink(missing_ok=True)
+                with suppress(OSError):
+                    self._pending_path.unlink(missing_ok=True)
         if self._prepared_traces is not None:
             self._prepared_traces.commit()
         self._collector._finish_step()
         self._finished = True
 
     def abort(self) -> None:
+        """Discard prepared capture state after a failed enclosing submission."""
         if self._finished:
             return
         self._prepared_logs.abort()
         if self._prepared_traces is not None:
             self._prepared_traces.abort()
         if self._pending_path is not None:
-            self._pending_path.unlink(missing_ok=True)
+            with suppress(OSError):
+                self._pending_path.unlink(missing_ok=True)
         self._finished = True
 
 
 class EvidenceCollector:
+    """Coordinate bounded step Evidence as one commit-or-abort transaction.
+
+    ``Run.get_input`` starts a step, ``Run.submit`` calls :meth:`prepare`, and
+    :class:`PreparedEvidence` commits only after immutable history append. This
+    coupling prevents log offsets, Trace budgets, and local records from moving
+    forward when Submission validation fails.
+
+    Security/Privacy:
+        Reads are restricted to the configured root and explicit log paths.
+        Uploadable output passes size limits and sensitive scanning; private
+        rubric/model credentials are never inputs to this collector.
+    """
+
     def __init__(
         self,
         *,
         root: Path,
+        root_alias: Path | None = None,
         scope: str,
         excluded_roots: tuple[Path, ...],
         track_files: bool,
@@ -138,7 +198,54 @@ class EvidenceCollector:
         case_id: str | None = None,
         trace_evidence: TraceEvidenceCapture | None = None,
     ) -> None:
-        self.root = root.resolve()
+        """Configure all Evidence sources for one Run.
+
+        Args:
+            root: Canonical filesystem root allowed for snapshot and log reads.
+            root_alias: Optional caller-authorized absolute spelling retained
+                before canonicalization. It must resolve exactly to ``root`` and
+                is used only for platform aliases such as macOS ``/var``.
+            scope: Public ``container`` or explicitly allowed ``local`` label.
+            excluded_roots: Canonical subtrees never scanned, including KUMA
+                runtime/persistence directories.
+            track_files: Capture before/after snapshots when true.
+            upload_diff: Include bounded safe text diffs in public Evidence.
+            save_local: Stage atomic local Submission records when true.
+            allow_sensitive: Opt-in used by supported ordinary Evidence policy.
+            block_sensitive: Force rejection when official/trace boundaries make
+                sensitive content unsafe regardless of local preference.
+            persistent_path: Run-owned local output directory, or ``None``.
+            snapshotter: Optional preconfigured filesystem boundary for tests.
+            log_tracker: Optional incremental log tracker for tests/embedding.
+            run_id: Owning Run identifier required for Trace/runtime Evidence.
+            case_id: Owning Case identifier required for Trace correlation.
+            trace_evidence: Optional in-process OTel capture.
+
+        Preconditions:
+            ``root`` is the repository/runtime scope authorized by ``create_run``;
+            excluded roots and persistent path belong to that Run.
+
+        Postconditions:
+            Collector is idle with no active input or committed offsets changed.
+
+        Side Effects:
+            Resolves paths and allocates capture helpers; no snapshot/network/write
+            occurs until lifecycle methods are called.
+        """
+        root_failed = False
+        try:
+            self.root = root.resolve()
+            log_root = root if root_alias is None else root_alias
+            if log_root.resolve() != self.root:
+                raise ConfigurationError(
+                    "Evidence root alias must match the repository root"
+                )
+        except ConfigurationError:
+            raise
+        except (AttributeError, TypeError, ValueError, OSError, RuntimeError):
+            root_failed = True
+        if root_failed:
+            raise EvidenceCaptureError("Evidence storage is unavailable") from None
         self.scope = scope
         self.track_files = track_files
         self.upload_diff = upload_diff
@@ -146,11 +253,19 @@ class EvidenceCollector:
         self.allow_sensitive = allow_sensitive
         self.block_sensitive = block_sensitive
         self.persistent_path = persistent_path
-        self.snapshotter = snapshotter or Snapshotter(
-            self.root,
-            excluded_roots=excluded_roots,
-        )
-        self.log_tracker = log_tracker or LogTracker()
+        helper_failed = False
+        try:
+            self.snapshotter = snapshotter or Snapshotter(
+                self.root,
+                excluded_roots=excluded_roots,
+            )
+            self.log_tracker = log_tracker or LogTracker(root=log_root)
+        except (AttributeError, TypeError, ValueError, OSError, RuntimeError):
+            helper_failed = True
+        if helper_failed:
+            raise EvidenceCaptureError("Evidence storage is unavailable") from None
+        if self.log_tracker.root != self.root:
+            raise ConfigurationError("Evidence log root must match the repository root")
         self.run_id = run_id
         self.case_id = case_id
         self.trace_evidence = trace_evidence
@@ -160,6 +275,25 @@ class EvidenceCollector:
         self.runtime_warnings: list[str] = []
 
     def begin_step(self, input_id: str) -> None:
+        """Start baseline and Trace association for one delivered input.
+
+        Args:
+            input_id: Non-empty identifier of the current Run input.
+
+        Raises:
+            InputProtocolError: Another input already owns the active Evidence
+                transaction.
+
+        Preconditions:
+            No other input is active; ``Run.get_input`` owns this call.
+
+        Postconditions:
+            The input is active. File baseline is captured or marked failed;
+            Trace begin failure becomes a safe runtime warning and does not block.
+
+        Side Effects:
+            Reads a bounded repository snapshot and opens in-memory Trace capture.
+        """
         if self._input_id == input_id:
             return
         if self._input_id is not None:
@@ -189,52 +323,198 @@ class EvidenceCollector:
         output: Any,
         status: str,
         error: str | None,
-        logs: list[str | os.PathLike[str]] | None,
+        logs: Sequence[str] | None,
     ) -> PreparedEvidence:
-        if self._input_id != input_id:
-            raise InputProtocolError(
-                "Evidence capture does not match the current Input"
-            )
-        prepared_logs = self.log_tracker.prepare(logs)
-        prepared_files = self._prepare_files()
+        """Stage all Evidence owned by one Input for transactional Submission.
+
+        The coordinator combines ``Snapshotter`` file deltas, ``LogTracker``
+        segments, in-process ``TraceEvidenceCapture`` data, privacy enforcement,
+        canonical Runtime Evidence extensions, and an optional pending local
+        record. Returned ``PreparedEvidence`` owns every staged resource: only
+        ``commit(submission)`` advances offsets/budgets and atomically publishes
+        the local record, while ``abort()`` rolls back those staged side effects.
+
+        Args:
+            input_id: Exact active input identifier; mismatches fail closed.
+            output: Already validated JSON-compatible Agent output.
+            status: Stable Submission outcome.
+            error: Optional caller-safe error summary.
+            logs: Validated ordered log paths selected by the caller, or
+                ``None``. Relative values are resolved by ``LogTracker`` from
+                this collector's canonical ``root``.
+
+        Returns:
+            :class:`PreparedEvidence` owning all staged resources. The caller must
+            call exactly one of ``commit`` or ``abort``.
+
+        Raises:
+            InputProtocolError: If ``input_id`` is not the active step.
+            SensitiveDataError: If prepared uploadable content violates policy.
+            EvidenceCaptureError: If required canonical Evidence cannot be built.
+
+        Preconditions:
+            ``begin_step(input_id)`` succeeded and no prior preparation was
+            committed for this input.
+
+        Postconditions:
+            Success has not advanced log offsets, Trace byte budgets, step index,
+            or final local files. Those change only through ``commit``. Failure
+            aborts staged log/Trace/local resources before propagating.
+
+        Side Effects:
+            Reads bounded final file state and explicit logs, flushes in-process
+            OTel providers, and may write a temporary local JSON record.
+
+        Security/Privacy:
+            Output, error, diffs, logs, and trace projections are scanned/bounded;
+            raw private rubric/model/provider data is not an input.
+        """
+        self._require_active_input(input_id)
+        prepared_logs, prepared_files = self._prepare_sources(logs=logs)
+        prepared_traces = self._prepare_traces(input_id)
+        self._merge_otel_logs(
+            prepared_logs, prepared_traces.otel_logs if prepared_traces else None
+        )
         findings = self._scan_findings(
             output=output,
             error=error,
             diff_result=prepared_files.result,
             logs=prepared_logs.segments,
         )
-        if self.block_sensitive:
-            try:
-                enforce_sensitive_policy(findings, allow_sensitive=self.allow_sensitive)
-            except BaseException:
-                prepared_logs.abort()
-                raise
+        self._enforce_sensitive(findings, prepared_logs, prepared_traces)
+        summary = self._capture_summary(
+            prepared_logs=prepared_logs,
+            prepared_files=prepared_files,
+            findings=findings,
+            prepared_traces=prepared_traces,
+        )
+        extensions = self._evidence_extensions(
+            input_id=input_id,
+            status=status,
+            output=output,
+            error=error,
+            prepared_logs=prepared_logs,
+            prepared_files=prepared_files,
+            summary=summary,
+            sensitive_detected=bool(findings),
+        )
+        pending_path, final_path = self._prepare_submission_record(
+            input_id=input_id,
+            status=status,
+            output=output,
+            error=error,
+            prepared_logs=prepared_logs,
+            prepared_files=prepared_files,
+            summary=summary,
+            extensions=extensions,
+        )
+        return PreparedEvidence(
+            capture_status=summary.status,
+            file_evidence=prepared_files.evidence,
+            logs=prepared_logs.segments,
+            missing=tuple(dict.fromkeys(summary.missing)),
+            dropped_count=summary.dropped_count,
+            extensions=extensions,
+            _collector=self,
+            _prepared_logs=prepared_logs,
+            _prepared_traces=summary.prepared_traces,
+            _pending_path=pending_path,
+            _final_path=final_path,
+        )
 
+    def _require_active_input(self, input_id: str) -> None:
+        """Require exact association with the currently active Run input."""
+        if self._input_id != input_id:
+            raise InputProtocolError(
+                "Evidence capture does not match the current Input"
+            )
+
+    def _prepare_sources(
+        self,
+        *,
+        logs: Sequence[str] | None,
+    ) -> tuple[PreparedLogs, _PreparedFiles]:
+        """Prepare file, explicit log, and Trace sources without committing them."""
+        prepared_logs = self.log_tracker.prepare(logs)
+        prepared_files = self._prepare_files()
+        return prepared_logs, prepared_files
+
+    def _enforce_sensitive(
+        self,
+        findings: list[SensitiveFinding],
+        prepared_logs: PreparedLogs,
+        prepared_traces: PreparedTraceEvidence | None,
+    ) -> None:
+        """Reject sensitive Evidence for upload while honoring explicit local policy."""
+        if not self.block_sensitive:
+            return
+        try:
+            enforce_sensitive_policy(findings, allow_sensitive=self.allow_sensitive)
+        except BaseException:
+            prepared_logs.abort()
+            if prepared_traces is not None:
+                prepared_traces.abort()
+            raise
+
+    def _capture_summary(
+        self,
+        *,
+        prepared_logs: PreparedLogs,
+        prepared_files: _PreparedFiles,
+        findings: list[SensitiveFinding],
+        prepared_traces: PreparedTraceEvidence | None,
+    ) -> _CaptureSummary:
+        """Combine component status, missing reasons, and dropped counts."""
         missing = list(prepared_logs.missing)
         dropped_count = prepared_logs.dropped_count
         if prepared_files.evidence is not None:
             missing.extend(prepared_files.evidence.errors)
             dropped_count += len(prepared_files.evidence.errors)
-        prepared_traces, trace_component, trace_missing, trace_dropped = (
-            self._trace_summary(input_id)
+        trace_component, trace_missing, trace_dropped = self._trace_summary(
+            prepared_traces
         )
         missing.extend(trace_missing)
-        dropped_count += trace_dropped
-        capture_status = CaptureStatus(
-            file_snapshot=prepared_files.snapshot,
-            file_diff=prepared_files.diff,
-            logs=prepared_logs.component,
-            traces=trace_component,
-            sensitive_scan=self._sensitive_component(findings),
+        return _CaptureSummary(
+            prepared_traces=prepared_traces,
+            status=CaptureStatus(
+                file_snapshot=prepared_files.snapshot,
+                file_diff=prepared_files.diff,
+                logs=prepared_logs.component,
+                traces=trace_component,
+                sensitive_scan=self._sensitive_component(findings),
+            ),
+            missing=missing,
+            dropped_count=dropped_count + trace_dropped,
         )
-        extensions = {
+
+    def _evidence_extensions(
+        self,
+        *,
+        input_id: str,
+        status: str,
+        output: Any,
+        error: str | None,
+        prepared_logs: PreparedLogs,
+        prepared_files: _PreparedFiles,
+        summary: _CaptureSummary,
+        sensitive_detected: bool,
+    ) -> dict[str, Any]:
+        """Build backward-compatible Trace and canonical Runtime Evidence extensions."""
+        extensions: dict[str, Any] = {
             "allow_sensitive": self.allow_sensitive,
-            "sensitive_detected": bool(findings),
+            "sensitive_detected": sensitive_detected,
         }
         trace_evidence = None
-        if prepared_traces is not None and prepared_traces.evidence is not None:
-            trace_evidence = prepared_traces.evidence
+        if (
+            summary.prepared_traces is not None
+            and summary.prepared_traces.evidence is not None
+        ):
+            trace_evidence = summary.prepared_traces.evidence
             extensions["trace_evidence"] = trace_evidence
+            if summary.prepared_traces.capture_summary is not None:
+                extensions["trace_capture_summary"] = (
+                    summary.prepared_traces.capture_summary
+                )
         if self.run_id and self.case_id:
             built = build_runtime_evidence(
                 run_id=self.run_id,
@@ -250,14 +530,29 @@ class EvidenceCollector:
                 trace_evidence=trace_evidence,
             )
             extensions["runtime_evidence"] = built.evidence
-            missing.extend(built.missing)
-            dropped_count += built.dropped_count
+            summary.missing.extend(built.missing)
+            summary.dropped_count += built.dropped_count
+        return extensions
+
+    def _prepare_submission_record(
+        self,
+        *,
+        input_id: str,
+        status: str,
+        output: Any,
+        error: str | None,
+        prepared_logs: PreparedLogs,
+        prepared_files: _PreparedFiles,
+        summary: _CaptureSummary,
+        extensions: Mapping[str, Any],
+    ) -> tuple[Path | None, Path | None]:
+        """Build the optional local history record without writing it yet."""
         record = {
             "input_id": input_id,
             "status": status,
             "output": _plain(output),
             "error": error,
-            "capture_status": _plain(capture_status),
+            "capture_status": _plain(summary.status),
             "file_evidence": _plain(prepared_files.evidence),
             "local_diffs": (
                 {}
@@ -265,28 +560,15 @@ class EvidenceCollector:
                 else dict(prepared_files.result.local_diffs)
             ),
             "logs": _plain(prepared_logs.segments),
-            "missing": missing,
-            "dropped_count": dropped_count,
+            "missing": summary.missing,
+            "dropped_count": summary.dropped_count,
             "extensions": extensions,
         }
         pending_path, final_path, local_failed = self._prepare_local_record(record)
         if local_failed:
-            missing.append("local_evidence_prepare_failed")
-            dropped_count += 1
-
-        return PreparedEvidence(
-            capture_status=capture_status,
-            file_evidence=prepared_files.evidence,
-            logs=prepared_logs.segments,
-            missing=tuple(dict.fromkeys(missing)),
-            dropped_count=dropped_count,
-            extensions=extensions,
-            _collector=self,
-            _prepared_logs=prepared_logs,
-            _prepared_traces=prepared_traces,
-            _pending_path=pending_path,
-            _final_path=final_path,
-        )
+            summary.missing.append("local_evidence_prepare_failed")
+            summary.dropped_count += 1
+        return pending_path, final_path
 
     def trace_output(self, input_id: str) -> Any | None:
         """Return auto-submittable output from the active OTel step, if present."""
@@ -303,23 +585,41 @@ class EvidenceCollector:
             return None
 
     def _trace_summary(
-        self, input_id: str
-    ) -> tuple[
-        PreparedTraceEvidence | None,
-        CaptureComponent,
-        tuple[str, ...],
-        int,
-    ]:
-        prepared = self._prepare_traces(input_id)
+        self, prepared: PreparedTraceEvidence | None
+    ) -> tuple[CaptureComponent, tuple[str, ...], int]:
+        """Project Trace preparation accounting into Submission capture metadata."""
         if prepared is None:
-            return None, CaptureComponent(), (), 0
+            return CaptureComponent(), (), 0
         for reason in prepared.component.reasons:
             warning = f"trace_evidence:{reason}"
             if warning not in self.runtime_warnings:
                 self.runtime_warnings.append(warning)
-        return prepared, prepared.component, prepared.missing, prepared.dropped_count
+        return prepared.component, prepared.missing, prepared.dropped_count
+
+    def _merge_otel_logs(
+        self, prepared_logs: PreparedLogs, otel_logs: PreparedOtelLogs | None
+    ) -> None:
+        """Merge native OTel Logs after explicit logs with deterministic segment numbers."""
+        if otel_logs is None or otel_logs.component.status == "skipped":
+            return
+        prepared_logs.segments += otel_logs.segments
+        prepared_logs.missing += otel_logs.missing
+        prepared_logs.dropped_count += otel_logs.dropped_count
+        for reason in otel_logs.component.reasons:
+            warning = f"otel_logs:{reason}"
+            if warning not in self.runtime_warnings:
+                self.runtime_warnings.append(warning)
+        if prepared_logs.missing:
+            status = "partial" if prepared_logs.segments else "failed"
+        else:
+            status = "complete"
+        prepared_logs.component = CaptureComponent(
+            status=status,
+            reasons=tuple(dict.fromkeys(prepared_logs.missing)),
+        )
 
     def _prepare_traces(self, input_id: str) -> PreparedTraceEvidence | None:
+        """Prepare associated Trace Evidence and isolate capture failures."""
         if self.trace_evidence is None:
             return None
         try:
@@ -339,12 +639,15 @@ class EvidenceCollector:
                 ),
                 missing=("trace_evidence:trace_capture_failed",),
                 dropped_count=1,
+                capture_summary=None,
+                otel_logs=PreparedOtelLogs(),
                 _capture=self.trace_evidence,
                 _association=None,
                 _sequence=-1,
             )
 
     def _prepare_files(self) -> _PreparedFiles:
+        """Capture the after-Snapshot and diff it from the active step baseline."""
         if not self.track_files:
             skipped = CaptureComponent(status="skipped")
             return _PreparedFiles(skipped, skipped, None, None)
@@ -389,6 +692,7 @@ class EvidenceCollector:
         diff_result: DiffResult | None,
         logs: tuple[Mapping[str, Any], ...],
     ) -> list[SensitiveFinding]:
+        """Scan Agent output, error, logs, file paths, and diff text for secrets."""
         findings = list(scan_sensitive_json(output, location="output"))
         if error is not None:
             findings.extend(scan_sensitive_text(error, location="error"))
@@ -414,6 +718,7 @@ class EvidenceCollector:
     def _sensitive_component(
         self, findings: list[SensitiveFinding]
     ) -> CaptureComponent:
+        """Mark Evidence partial when sensitive findings are locally allowed."""
         if not findings:
             return CaptureComponent(status="complete")
         reason = (
@@ -429,9 +734,28 @@ class EvidenceCollector:
     def _prepare_local_record(
         self, record: Mapping[str, Any]
     ) -> tuple[Path | None, Path | None, bool]:
+        """Stage a redacted JSON history record for atomic Submission commit.
+
+        Args:
+            record: Already privacy-filtered Submission record to serialize.
+
+        Returns:
+            Pending/final paths and ``False`` on success; ``(None, None, True)``
+            when bounded local persistence degrades without blocking the Run.
+
+        Postconditions:
+            Success transfers the pending file to :class:`PreparedEvidence`.
+            Failure closes any descriptor not yet owned by ``fdopen`` and removes
+            the partial file, so no local commit is implied.
+
+        Side Effects:
+            Creates the Run-owned submissions directory and one temporary file;
+            it performs no network operation.
+        """
         if not self.save_local or self.persistent_path is None:
             return None, None, False
         submissions = self.persistent_path / "submissions"
+        descriptor: int | None = None
         pending_path: Path | None = None
         try:
             submissions.mkdir(parents=True, exist_ok=True)
@@ -443,16 +767,22 @@ class EvidenceCollector:
             )
             pending_path = Path(temporary_name)
             with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                descriptor = None
                 json.dump(record, handle, ensure_ascii=False, indent=2)
                 handle.write("\n")
             final_path = submissions / f"step-{self._step_index:04d}.json"
             return pending_path, final_path, False
         except (OSError, TypeError, ValueError):
+            if descriptor is not None:
+                with suppress(OSError):
+                    os.close(descriptor)
             if pending_path is not None:
-                pending_path.unlink(missing_ok=True)
+                with suppress(OSError):
+                    pending_path.unlink(missing_ok=True)
             return None, None, True
 
     def cancel_step(self) -> None:
+        """Abort the active step so late telemetry cannot enter another input."""
         if self.trace_evidence is not None:
             try:
                 self.trace_evidence.cancel_step()
@@ -463,6 +793,7 @@ class EvidenceCollector:
         self._baseline = None
 
     def finish_run(self) -> None:
+        """Seal Run capture and discard registrations that could leak across Runs."""
         if self.trace_evidence is None:
             return
         try:
@@ -471,6 +802,7 @@ class EvidenceCollector:
             self.runtime_warnings.append("trace_finish_failed")
 
     def _finish_step(self) -> None:
+        """Clear active step state after commit, abort, or cancellation."""
         self._input_id = None
         self._baseline = None
         self._step_index += 1

--- a/src/kuma/evidence/tracking/logs.py
+++ b/src/kuma/evidence/tracking/logs.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
-import stat
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from itertools import islice
 from pathlib import Path
@@ -13,12 +12,24 @@ from types import MappingProxyType
 from typing import Any
 
 from ...contracts import CaptureComponent
+from ._log_paths import open_verified_log, resolve_log_path
 
 _ALLOWED_SUFFIXES = frozenset({".txt", ".log", ".json", ".jsonl", ".md"})
 
 
 @dataclass(frozen=True, slots=True)
 class LogState:
+    """Remember the last committed read position for one canonical log file.
+
+    Attributes:
+        device: Filesystem device identifier used to detect replacement.
+        inode: File identifier used to detect replacement/rotation.
+        offset: Next byte offset to capture after the previous commit.
+        last_size: File size at the previous committed observation.
+        prefix_sha256: Digest of the stable prefix used to detect rewrite/truncate.
+        segment_no: Monotonic committed segment number for this file.
+    """
+
     device: int
     inode: int
     offset: int
@@ -29,6 +40,14 @@ class LogState:
 
 @dataclass(frozen=True, slots=True)
 class _CapturedLog:
+    """Represent one attempted log read before transaction assembly.
+
+    Attributes:
+        segment: Safe bounded log mapping when capture succeeds.
+        state: Next offset state to install only after Submission commit.
+        reason: Stable omission/degradation code when no complete segment exists.
+    """
+
     segment: Mapping[str, Any] | None = None
     state: LogState | None = None
     reason: str | None = None
@@ -36,6 +55,18 @@ class _CapturedLog:
 
 @dataclass(slots=True)
 class PreparedLogs:
+    """Stage bounded log segments and offsets until Submission commit.
+
+    Attributes:
+        segments: Ordered safe log artifacts prepared for Evidence.
+        component: Public log capture completeness.
+        missing: Stable missing/degradation reasons.
+        dropped_count: Number of log files/segments omitted.
+        _tracker: Log tracker that owns committed offsets.
+        _next_states: Canonical-path offsets to install on commit.
+        _finished: Whether commit or abort already finalized the preparation.
+    """
+
     segments: tuple[Mapping[str, Any], ...]
     component: CaptureComponent
     missing: tuple[str, ...]
@@ -45,23 +76,57 @@ class PreparedLogs:
     _finished: bool = False
 
     def commit(self) -> None:
+        """Commit prepared capture state only after the enclosing submission succeeds."""
         if self._finished:
             return
         self._tracker._commit(self._next_states)
         self._finished = True
 
     def abort(self) -> None:
+        """Discard prepared capture state after a failed enclosing submission."""
         self._finished = True
 
 
 class LogTracker:
+    """Capture bounded incremental log bytes without advancing on failed submit.
+
+    The tracker accepts explicit paths from ``Run.submit(logs=...)`` only after
+    ``EvidenceCollector`` supplies the allowed repository/runtime root. It stages
+    new offsets in :class:`PreparedLogs`; repeated preparation reads the same
+    bytes until a successful Submission commits them.
+    """
+
     def __init__(
         self,
         *,
+        root: Path,
         max_segment_bytes: int = 10 * 1024 * 1024,
         max_files: int = 20,
         max_total_bytes: int = 20 * 1024 * 1024,
     ) -> None:
+        """Initialize incremental log accounting with hard resource limits.
+
+        Args:
+            root: Canonical repository directory that exclusively bounds every
+                relative or absolute log path accepted by this tracker.
+            max_segment_bytes: Maximum new bytes retained from one file per step.
+            max_files: Maximum explicit log paths inspected per Submission.
+            max_total_bytes: Maximum combined new bytes retained per Submission.
+
+        Raises:
+            ValueError: If ``root`` is a symlink/non-directory or any limit is
+                boolean, non-integer, zero, or negative.
+
+        Postconditions:
+            ``root`` is canonical, no path is registered, and no file is read.
+        """
+        expanded_root = Path(root).expanduser()
+        if expanded_root.is_symlink():
+            raise ValueError("log capture root must not be a symlink")
+        self._root_alias = Path(os.path.abspath(expanded_root))
+        self.root = expanded_root.resolve()
+        if not self.root.is_dir():
+            raise ValueError("log capture root must be a directory")
         limits = (max_segment_bytes, max_files, max_total_bytes)
         if any(
             isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0
@@ -73,10 +138,43 @@ class LogTracker:
         self.max_total_bytes = max_total_bytes
         self._states: dict[str, LogState] = {}
 
-    def prepare(self, paths: Iterable[str | os.PathLike[str]] | None) -> PreparedLogs:
-        requested = (
-            [] if paths is None else list(islice(iter(paths), self.max_files + 1))
-        )
+    def prepare(self, paths: Sequence[str | os.PathLike[str]] | None) -> PreparedLogs:
+        """Stage bounded incremental reads from logs under the configured root.
+
+        ``EvidenceCollector`` supplies user-selected paths. This method rejects
+        symlinks and paths outside the allowed root, reads only bytes after each
+        committed offset, and returns ``PreparedLogs``. Its ``commit()`` advances
+        tracker offsets only after the owning Submission commits; ``abort()``
+        leaves offsets unchanged so a retry observes the same bytes.
+
+        Args:
+            paths: Explicit ordered log-file paths, or ``None`` for skipped
+                capture. Relative paths resolve from ``root``. At most
+                ``max_files`` are inspected; additional paths are counted.
+
+        Returns:
+            Transactional :class:`PreparedLogs` containing safe structured
+            segments, completeness, omissions, and staged next offsets.
+
+        Preconditions:
+            ``EvidenceCollector`` supplied the same canonical repository root.
+            Callers must not treat this as arbitrary file access.
+
+        Postconditions:
+            Committed offsets remain unchanged until ``PreparedLogs.commit``.
+            Rejected paths become stable missing reasons, not raw exceptions.
+
+        Side Effects:
+            Reads bounded suffix bytes and file identity/stat metadata. It writes
+            nothing and does not follow symlinks.
+
+        Security/Privacy:
+            Paths outside the root, unsupported suffixes, symlinks/reparse
+            points, binary/invalid content, and oversize data degrade using
+            stable index-based reasons. Evidence contains repository-relative
+            paths only; host absolute paths and OS error text are never retained.
+        """
+        requested = self._requested_paths(paths)
         if not requested:
             return PreparedLogs(
                 segments=(),
@@ -93,23 +191,26 @@ class LogTracker:
         dropped = 0
         if len(requested) > self.max_files:
             requested.pop()
-            missing.append("log_file_limit")
+            missing.append(f"log_file_limit:{self.max_files}")
             dropped += 1
         captured_bytes = 0
-        for supplied in requested:
+        for index, supplied in enumerate(requested):
             remaining_bytes = self.max_total_bytes - captured_bytes
             if remaining_bytes <= 0:
-                missing.append("log_total_size_limit")
+                missing.append(f"log_total_size_limit:{index}")
                 dropped += 1
                 break
-            path, canonical, rejected = self._resolve_path(
-                supplied, seen=seen, next_states=next_states
+            path, canonical, display_path, rejected = self._resolve_path(
+                supplied,
+                index=index,
+                seen=seen,
+                next_states=next_states,
             )
             if rejected is not None:
                 missing.append(rejected)
                 dropped += 1
                 continue
-            if path is None or canonical is None:
+            if path is None or canonical is None or display_path is None:
                 continue
             capture_bytes = min(self.max_segment_bytes, remaining_bytes)
             limit_reason = (
@@ -120,6 +221,8 @@ class LogTracker:
             captured = self._capture_log(
                 path,
                 canonical,
+                display_path=display_path,
+                index=index,
                 capture_bytes=capture_bytes,
                 limit_reason=limit_reason,
             )
@@ -144,44 +247,124 @@ class LogTracker:
             _next_states=MappingProxyType(next_states),
         )
 
+    def _requested_paths(
+        self, paths: Sequence[str | os.PathLike[str]] | None
+    ) -> list[str | os.PathLike[str]]:
+        """Copy at most one path beyond the file limit for bounded accounting.
+
+        Args:
+            paths: Validated ordered paths or ``None``.
+
+        Returns:
+            A bounded mutable copy used only for the current preparation.
+
+        Raises:
+            ValueError: If an internal caller bypasses ``Run.submit`` and passes
+                a scalar or unordered/non-sequence container.
+        """
+        if paths is None:
+            return []
+        if isinstance(paths, (str, bytes, bytearray)) or not isinstance(
+            paths, Sequence
+        ):
+            raise ValueError("log paths must be an ordered path sequence")
+        return list(islice(iter(paths), self.max_files + 1))
+
     def _resolve_path(
         self,
         supplied: str | os.PathLike[str],
         *,
+        index: int,
         seen: set[str],
         next_states: Mapping[str, LogState],
-    ) -> tuple[Path | None, str | None, str | None]:
-        try:
-            path = Path(supplied).expanduser().resolve()
-        except (TypeError, OSError):
-            return None, None, "invalid_log_path"
-        canonical = path.as_posix()
+    ) -> tuple[Path | None, str | None, str | None, str | None]:
+        """Resolve one path within ``root`` without exposing its host spelling.
+
+        Args:
+            supplied: Caller-selected text/path-like value.
+            index: Zero-based position used in public-safe degradation reasons.
+            seen: Canonical internal state keys already handled this preparation.
+            next_states: Staged offsets used to enforce the cross-step file cap.
+
+        Returns:
+            Lexical path, private state key, repository-relative display path,
+            and stable rejection reason. Rejected/duplicate paths use ``None``
+            placeholders and never return caller text.
+
+        Side Effects:
+            Performs bounded ``lstat`` checks on components inside ``root`` only;
+            it does not open a log or follow a link.
+
+        Security/Privacy:
+            Foreign Windows drives/UNC paths, POSIX escapes, ``..`` escapes, and
+            symlink/reparse components are rejected before file content reads.
+        """
+        path, relative, rejected = resolve_log_path(
+            self.root,
+            supplied,
+            index=index,
+            root_alias=self._root_alias,
+        )
+        if rejected is not None or path is None or relative is None:
+            return None, None, None, rejected
+
+        canonical = os.path.normcase(os.path.normpath(str(path)))
+        display_path = relative.as_posix()
         if canonical in seen:
-            return None, None, None
+            return None, None, None, None
         seen.add(canonical)
         if (
             canonical not in self._states
             and canonical not in next_states
             and len(self._states) + len(next_states) >= self.max_files
         ):
-            return None, None, f"log_file_limit:{canonical}"
+            return None, None, None, f"log_file_limit:{index}"
         if path.suffix.casefold() not in _ALLOWED_SUFFIXES:
-            return None, None, f"unsupported_log_type:{canonical}"
-        return path, canonical, None
+            return None, None, None, f"unsupported_log_type:{index}"
+        return path, canonical, display_path, None
 
     def _capture_log(
         self,
         path: Path,
         canonical: str,
         *,
+        display_path: str,
+        index: int,
         capture_bytes: int,
         limit_reason: str,
     ) -> _CapturedLog:
+        """Read one stable bounded UTF-8 suffix and stage its next offset.
+
+        Args:
+            path: Already boundary-checked non-symlink log file.
+            canonical: Stable canonical path key used for committed offset state.
+            display_path: Repository-relative path safe for public Evidence.
+            index: Zero-based request position used in degradation reasons.
+            capture_bytes: Maximum suffix bytes to read this step.
+            limit_reason: Stable reason prefix used when unread bytes remain.
+
+        Returns:
+            Captured segment/next state, or a stable value-free failure reason.
+
+        Preconditions:
+            ``_resolve_path`` accepted the path and budgets are positive.
+
+        Postconditions:
+            Tracker committed offsets are unchanged. The returned next state is
+            installed only by ``PreparedLogs.commit``. Rotation/truncation starts
+            a new segment rather than skipping bytes.
+
+        Side Effects:
+            Opens and reads the file plus stable stat metadata; writes nothing.
+
+        Security/Privacy:
+            Binary files and unstable reads are rejected. Evidence retains only
+            ``display_path`` and index-based reasons; host paths, OS exception
+            text, and arbitrary object representations are not retained.
+        """
         try:
-            with path.open("rb") as handle:
-                frozen = os.fstat(handle.fileno())
-                if not stat.S_ISREG(frozen.st_mode):
-                    raise OSError("not a regular file")
+            handle, frozen = open_verified_log(self.root, path)
+            with handle:
                 size = frozen.st_size
                 prefix_hash = hashlib.sha256(handle.read(min(size, 4096))).hexdigest()
                 segment_no, start = self._segment_position(
@@ -197,19 +380,19 @@ class LogTracker:
                 if len(payload) != end - start:
                     raise OSError("log changed while reading")
         except OSError:
-            return _CapturedLog(reason=f"log_read_failed:{canonical}")
+            return _CapturedLog(reason=f"log_read_failed:{index}")
 
         try:
             content = payload.decode("utf-8")
         except UnicodeDecodeError:
-            return _CapturedLog(reason=f"binary_log_unsupported:{canonical}")
+            return _CapturedLog(reason=f"binary_log_unsupported:{index}")
 
         complete = end == size
         segment = None
         if payload:
             segment = MappingProxyType(
                 {
-                    "path": canonical,
+                    "path": display_path,
                     "segment_no": segment_no,
                     "start_offset": start,
                     "end_offset": end,
@@ -228,7 +411,7 @@ class LogTracker:
             prefix_sha256=prefix_hash,
             segment_no=segment_no,
         )
-        reason = None if complete else f"{limit_reason}:{canonical}"
+        reason = None if complete else f"{limit_reason}:{index}"
         return _CapturedLog(segment=segment, state=state, reason=reason)
 
     def _segment_position(
@@ -240,6 +423,7 @@ class LogTracker:
         size: int,
         prefix_hash: str,
     ) -> tuple[int, int]:
+        """Determine offsets while detecting truncation or file replacement."""
         previous = self._states.get(canonical)
         if previous is None:
             return 0, 0
@@ -252,6 +436,7 @@ class LogTracker:
 
     @staticmethod
     def _capture_status(missing: list[str], segments: list[Mapping[str, Any]]) -> str:
+        """Summarize log capture as complete, partial, failed, or not requested."""
         if missing and not segments:
             return "failed"
         if missing:
@@ -259,6 +444,7 @@ class LogTracker:
         return "complete"
 
     def _commit(self, states: Mapping[str, LogState]) -> None:
+        """Advance file offsets only after the owning Submission commits."""
         self._states.update(states)
 
 

--- a/src/kuma/evidence/tracking/snapshot.py
+++ b/src/kuma/evidence/tracking/snapshot.py
@@ -31,11 +31,26 @@ _EXCLUDED_DIRECTORY_NAMES = frozenset(
         "venv",
     }
 )
-_CONTAINER_EXCLUDED_ROOTS = (Path("/proc"), Path("/sys"), Path("/dev"), Path("/run"))
 
 
 @dataclass(frozen=True, slots=True)
 class SnapshotEntry:
+    """Record one bounded, non-followed filesystem entry observation.
+
+    Attributes:
+        path: Canonical repository-relative path used for deterministic ordering.
+        file_type: Observed ``file``, ``directory``, ``symlink``, or ``special``.
+        mode: Platform mode bits at capture time.
+        size: Observed byte size.
+        mtime_ns: Modification timestamp in nanoseconds.
+        device: Filesystem device identifier used for mount-boundary checks.
+        inode: Filesystem entry identifier.
+        sha256: Content/link digest when hashing completed, otherwise ``None``.
+        hash_complete: Whether the full permitted content was hashed.
+        scan_error: Stable reason for partial observation, never raw OS text.
+        text_content: Bounded safe text retained only for local diff generation.
+    """
+
     path: str
     file_type: str
     mode: int
@@ -51,22 +66,35 @@ class SnapshotEntry:
 
 @dataclass(frozen=True, slots=True)
 class Snapshot:
+    """Freeze one deterministic view of the allowed repository root.
+
+    Attributes:
+        root: Canonical root that bounds every entry.
+        entries: Read-only mapping from relative paths to observations.
+        errors: Stable scan-level degradation reasons.
+        complete: Whether entry count, mount, path, and read limits allowed a
+            complete bounded scan.
+    """
+
     root: Path
     entries: Mapping[str, SnapshotEntry]
     errors: tuple[str, ...] = ()
     complete: bool = True
 
     def __post_init__(self) -> None:
+        """Freeze Snapshot entries and reasons for deterministic comparison."""
         object.__setattr__(self, "root", self.root.resolve())
         object.__setattr__(self, "entries", MappingProxyType(dict(self.entries)))
         object.__setattr__(self, "errors", tuple(self.errors))
 
 
 def _canonical(path: Path) -> str:
+    """Resolve a path without requiring the target to exist."""
     return Path(os.path.abspath(path)).as_posix()
 
 
 def _is_within(path: Path, root: Path) -> bool:
+    """Return whether a resolved path remains under the allowed root."""
     try:
         path.relative_to(root)
         return True
@@ -75,6 +103,13 @@ def _is_within(path: Path, root: Path) -> bool:
 
 
 class Snapshotter:
+    """Capture a bounded repository tree without following boundary escapes.
+
+    Symlinks are recorded as symlinks and not traversed. Descendant mount/device
+    changes, excluded runtime roots, filesystem roots, and paths outside the
+    canonical root are rejected or recorded as partial rather than scanned.
+    """
+
     def __init__(
         self,
         root: Path,
@@ -85,19 +120,23 @@ class Snapshotter:
         max_text_bytes: int = 1024 * 1024,
         max_total_text_bytes: int = 32 * 1024 * 1024,
     ) -> None:
-        self.root = root.expanduser().resolve()
+        """Bind scanning to one canonical root, exclusions, and resource budget."""
+        expanded_root = root.expanduser()
+        if expanded_root.is_symlink():
+            raise ValueError("snapshot root must not be a symbolic link")
+        self.root = expanded_root.resolve()
         self.max_entries = max_entries
         self.max_hash_bytes = max_hash_bytes
         self.max_text_bytes = max_text_bytes
         self.max_total_text_bytes = max_total_text_bytes
-        defaults = (
-            _CONTAINER_EXCLUDED_ROOTS if self.root == Path(self.root.anchor) else ()
-        )
         self.excluded_roots = tuple(
-            path.expanduser().resolve() for path in (*defaults, *excluded_roots)
+            path.expanduser().resolve() for path in excluded_roots
         )
         if not self.root.is_dir():
             raise ValueError("snapshot root must be an existing directory")
+        if self.root == Path(self.root.anchor):
+            raise ValueError("snapshot root must not be a filesystem root")
+        self._root_device = self.root.lstat().st_dev
         limits = (max_entries, max_hash_bytes, max_text_bytes, max_total_text_bytes)
         if any(
             isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0
@@ -106,6 +145,7 @@ class Snapshotter:
             raise ValueError("snapshot limits must be positive integers")
 
     def capture(self) -> Snapshot:
+        """Capture a bounded snapshot without following unsafe filesystem targets."""
         entries: dict[str, SnapshotEntry] = {}
         errors: list[str] = []
         pending = [self.root]
@@ -150,6 +190,7 @@ class Snapshotter:
     def _scan_directory(
         directory: Path, remaining: int
     ) -> tuple[list[os.DirEntry[str]], bool, str | None]:
+        """Scan one verified directory without crossing mounts or following symlinks."""
         try:
             with os.scandir(directory) as iterator:
                 scanned = list(islice(iterator, remaining + 1))
@@ -165,11 +206,15 @@ class Snapshotter:
         entries: dict[str, SnapshotEntry],
         retained_text_bytes: int,
     ) -> tuple[list[Path], list[str], int, bool]:
+        """Capture sorted direct children while enforcing entry and byte budgets."""
         child_directories: list[Path] = []
         errors: list[str] = []
         text_limit_hit = False
         for child in children:
             path = Path(child.path)
+            if not _is_within(Path(os.path.abspath(path)), self.root):
+                errors.append(f"path_outside_root:{_canonical(path)}")
+                continue
             if self._excluded(path):
                 continue
             entry, error = self._capture_entry(path)
@@ -179,7 +224,7 @@ class Snapshotter:
                 )
                 text_limit_hit |= text_dropped
                 entries[entry.path] = entry
-                if entry.file_type == "directory":
+                if entry.file_type == "directory" and error is None:
                     child_directories.append(path)
             if error is not None:
                 errors.append(error)
@@ -188,6 +233,7 @@ class Snapshotter:
     def _budget_text(
         self, entry: SnapshotEntry, retained_bytes: int
     ) -> tuple[SnapshotEntry, int, bool]:
+        """Return the stable reason for whichever Snapshot budget was exhausted."""
         if entry.text_content is None:
             return entry, retained_bytes, False
         if retained_bytes + entry.size <= self.max_total_text_bytes:
@@ -195,6 +241,7 @@ class Snapshotter:
         return replace(entry, text_content=None), retained_bytes, True
 
     def _excluded(self, path: Path) -> bool:
+        """Return whether a canonical path is inside an explicitly excluded root."""
         resolved = Path(os.path.abspath(path))
         if any(
             resolved == root or _is_within(resolved, root)
@@ -204,6 +251,7 @@ class Snapshotter:
         return path != self.root and path.name.casefold() in _EXCLUDED_DIRECTORY_NAMES
 
     def _capture_entry(self, path: Path) -> tuple[SnapshotEntry | None, str | None]:
+        """Classify one entry without following links or leaving the repository device."""
         canonical = _canonical(path)
         try:
             before = path.lstat()
@@ -217,6 +265,14 @@ class Snapshotter:
             "device": before.st_dev,
             "inode": before.st_ino,
         }
+        if before.st_dev != self._root_device:
+            return SnapshotEntry(
+                **common,
+                file_type="directory" if stat.S_ISDIR(before.st_mode) else "special",
+                sha256=None,
+                hash_complete=False,
+                scan_error="mount_boundary",
+            ), f"mount_boundary:{canonical}"
         if stat.S_ISLNK(before.st_mode):
             return self._capture_symlink(path, canonical, common)
         if stat.S_ISDIR(before.st_mode):
@@ -249,6 +305,7 @@ class Snapshotter:
     def _capture_symlink(
         path: Path, canonical: str, common: Mapping[str, int | str]
     ) -> tuple[SnapshotEntry, str | None]:
+        """Record symlink metadata without opening or following its target."""
         try:
             target = os.readlink(path)
         except OSError:
@@ -277,6 +334,7 @@ class Snapshotter:
         before: os.stat_result,
         common: Mapping[str, int | str],
     ) -> tuple[SnapshotEntry, str | None]:
+        """Hash and optionally retain bounded UTF-8 text for one regular file."""
         digest = hashlib.sha256()
         captured = bytearray()
         try:

--- a/src/kuma/exceptions.py
+++ b/src/kuma/exceptions.py
@@ -1,4 +1,4 @@
-"""Status-code-oriented exceptions for HTTP client consumers.
+"""Backward-compatible v0.2 exception names.
 
 New code should import the stable v4 hierarchy from :mod:`kuma.errors`.
 """
@@ -19,6 +19,7 @@ class KumaAPIError(ServiceError):
     """The KUMA API returned an error response."""
 
     def __init__(self, status_code: int, message: str, body: Any = None) -> None:
+        """Retain legacy HTTP status and message for compatibility callers."""
         self.status_code = status_code
         self.body = body
         super().__init__(

--- a/src/kuma/local_quickstart.py
+++ b/src/kuma/local_quickstart.py
@@ -20,7 +20,16 @@ QUICKSTART_INPUT_SHA256 = hashlib.sha256(QUICKSTART_INPUT.encode("utf-8")).hexdi
 
 @dataclass(frozen=True, slots=True)
 class LocalQuickstartResult:
-    """Stable beginner-facing result from one isolated local demonstration."""
+    """Summarize one deterministic credential-free local demonstration.
+
+    Attributes:
+        passed: Whether the transparent exact-match evaluator accepted output.
+        score: Deterministic integer score, currently ``0`` or ``100``.
+        reason: Human-readable evaluator explanation with no provider internals.
+        input_text: Fixed packaged demonstration input given to the fake Agent.
+        input_sha256: Stable SHA-256 digest proving the input is repeatable.
+        artifact_path: Absolute path of the locally written result JSON.
+    """
 
     passed: bool
     score: int
@@ -31,16 +40,16 @@ class LocalQuickstartResult:
 
 
 class _LocalCaseProvider:
+    """Provide the packaged deterministic Case without repository or network reads."""
+
     requirement_required = False
 
     def generate_case(self, _context: CaseGenerationContext) -> dict[str, Any]:
+        """Return the fixed local Case without reading a repository or network."""
         return {
             "case_id": "case_local_quickstart_v1",
             "input_type": "text",
-            "rubric": {
-                "rule": "exact_text_match",
-                "expected_output": QUICKSTART_EXPECTED_OUTPUT,
-            },
+            "rubric": {"rule": "exact_text_match"},
             "inputs": [
                 {
                     "input_id": "input_local_quickstart_v1",
@@ -52,6 +61,7 @@ class _LocalCaseProvider:
 
 
 def _local_judge(context: JudgeContext) -> dict[str, Any]:
+    """Score the quickstart output with a transparent deterministic rule."""
     output = context.history[0].submission.output
     passed = output == QUICKSTART_EXPECTED_OUTPUT
     reason = (
@@ -80,6 +90,7 @@ def _local_judge(context: JudgeContext) -> dict[str, Any]:
 
 
 def _write_artifact(*, output: str, score: int, reason: str) -> Path:
+    """Atomically write the local result JSON under the chosen output directory."""
     artifact_root = Path(tempfile.mkdtemp(prefix="kuma-local-result-")).resolve()
     artifact = artifact_root / "result.json"
     artifact.write_text(
@@ -121,7 +132,7 @@ def run_local_quickstart(*, demonstrate_failure: bool = False) -> LocalQuickstar
             repo_path=isolated_repo,
             case_provider=_LocalCaseProvider(),
             judge_provider=_local_judge,
-            max_inputs=1,
+            max_steps=1,
             judge=True,
             on_failure="stop",
             allow_local=True,

--- a/src/kuma/otel.py
+++ b/src/kuma/otel.py
@@ -6,6 +6,7 @@ import threading
 import weakref
 from collections.abc import Sequence
 from contextlib import suppress
+from dataclasses import dataclass, field
 from typing import Any
 
 from .errors import ConfigurationError
@@ -13,6 +14,12 @@ from .evidence.trace import TraceEvidenceCapture, TraceEvidenceLimits
 
 try:
     from opentelemetry import trace
+    from opentelemetry._logs import get_logger_provider
+    from opentelemetry.sdk._logs.export import (
+        LogRecordExporter,
+        LogRecordExportResult,
+        SimpleLogRecordProcessor,
+    )
     from opentelemetry.sdk.trace import SpanProcessor
     from opentelemetry.sdk.trace.export import (
         SpanExporter,
@@ -25,7 +32,30 @@ except ImportError as exc:  # pragma: no cover - exercised without the optional 
 
 
 _ATTACH_LOCK = threading.RLock()
-_ATTACHED_CAPTURES: weakref.WeakKeyDictionary[Any, TraceEvidenceCapture] = (
+
+
+@dataclass(slots=True)
+class _CaptureAttachment:
+    """Track idempotent processors attached to one user-owned OTel provider.
+
+    Attributes:
+        capture: Shared bounded capture reused by Runs using this provider.
+        trace_processor: Single span processor installed on the tracer provider.
+        log_processors: Log processors successfully installed on compatible
+            logger providers.
+        logger_attempts: Weak provider set preventing duplicate log attachment
+            while allowing late compatible logger configuration.
+    """
+
+    capture: TraceEvidenceCapture
+    trace_processor: TraceEvidenceSpanProcessor
+    log_processors: list[Any] = field(default_factory=list)
+    logger_attempts: weakref.WeakKeyDictionary[Any, bool] = field(
+        default_factory=weakref.WeakKeyDictionary
+    )
+
+
+_ATTACHED_CAPTURES: weakref.WeakKeyDictionary[Any, _CaptureAttachment] = (
     weakref.WeakKeyDictionary()
 )
 
@@ -34,15 +64,19 @@ class TraceEvidenceSpanExporter(SpanExporter):
     """Standard exporter that never propagates capture failures to user code."""
 
     def __init__(self, capture: TraceEvidenceCapture) -> None:
+        """Bind the standard exporter extension point to one bounded capture."""
         self.capture = capture
 
     def export(self, spans: Sequence[Any]) -> SpanExportResult:
+        """Export ended spans that were not associated through ``on_start``."""
         return self._export(spans, registered=False)
 
     def export_registered(self, spans: Sequence[Any]) -> SpanExportResult:
+        """Export a registered span using its captured Run association."""
         return self._export(spans, registered=True)
 
     def _export(self, spans: Sequence[Any], *, registered: bool) -> SpanExportResult:
+        """Isolate each span failure and record only a stable value-free reason."""
         failed = False
         for span in spans:
             try:
@@ -54,17 +88,17 @@ class TraceEvidenceSpanExporter(SpanExporter):
                 failed = True
                 try:
                     self.capture.record_failure("trace_export_failed")
-                except Exception:  # nosec B112
-                    # The failure is already represented by this export result;
-                    # one broken span must not prevent later spans from exporting.
+                except Exception:
                     continue
         return SpanExportResult.FAILURE if failed else SpanExportResult.SUCCESS
 
     def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        """Flush accepted telemetry within the caller-provided time bound."""
         del timeout_millis
         return True
 
     def shutdown(self) -> None:
+        """Finish this telemetry adapter without changing the user's provider."""
         return None
 
 
@@ -72,9 +106,11 @@ class TraceEvidenceSpanProcessor(SpanProcessor):
     """Bind spans to the active step at start, including worker threads."""
 
     def __init__(self, exporter: TraceEvidenceSpanExporter) -> None:
+        """Bind one exporter to OTel span lifecycle callbacks."""
         self.exporter = exporter
 
     def on_start(self, span: Any, parent_context: Any | None = None) -> None:
+        """Register a started span for later same-process Run association."""
         del parent_context
         try:
             self.exporter.capture.register_span(span)
@@ -85,18 +121,67 @@ class TraceEvidenceSpanProcessor(SpanProcessor):
                 return
 
     def on_end(self, span: Any) -> None:
+        """Export an ended span while isolating instrumentation failures."""
         self.exporter.export_registered((span,))
 
     def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        """Flush accepted telemetry within the caller-provided time bound."""
         return self.exporter.force_flush(timeout_millis)
 
     def shutdown(self) -> None:
+        """Finish this telemetry adapter without changing the user's provider."""
         self.exporter.shutdown()
 
 
-def _attach_trace_evidence(
+class TraceEvidenceLogRecordExporter(LogRecordExporter):
+    """Standard OTel Logs exporter with per-record capture isolation."""
+
+    def __init__(self, capture: TraceEvidenceCapture) -> None:
+        """Bind the OTel Logs exporter extension point to one bounded capture."""
+        self.capture = capture
+
+    def export(self, batch: Sequence[Any]) -> LogRecordExportResult:
+        """Export each LogRecord independently without retaining raw sensitive text."""
+        failed = False
+        for record in batch:
+            try:
+                self.capture.export_log_record(record)
+            except Exception:
+                failed = True
+                try:
+                    self.capture.record_log_failure("otel_log_export_failed")
+                except Exception:
+                    # A failing exporter must not block later LogRecords.
+                    continue
+        return (
+            LogRecordExportResult.FAILURE if failed else LogRecordExportResult.SUCCESS
+        )
+
+    def shutdown(self) -> None:
+        """Finish this telemetry adapter without changing the user's provider."""
+        return None
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        """Flush accepted telemetry within the caller-provided time bound."""
+        del timeout_millis
+        return True
+
+
+def _log_processor_adder(logger_provider: Any) -> Any:
+    """Require the official LoggerProvider processor extension point."""
+    add_log_processor = getattr(logger_provider, "add_log_record_processor", None)
+    if not callable(add_log_processor):
+        raise ConfigurationError(
+            "OTel log Evidence requires an SDK LoggerProvider with "
+            "add_log_record_processor()"
+        )
+    return add_log_processor
+
+
+def _new_trace_attachment(
     provider: Any, limits: TraceEvidenceLimits | None
-) -> TraceEvidenceCapture:
+) -> _CaptureAttachment:
+    """Attach exactly one span processor and install capture-level flush handling."""
     add_processor = getattr(provider, "add_span_processor", None)
     if not callable(add_processor):
         raise ConfigurationError(
@@ -106,46 +191,138 @@ def _attach_trace_evidence(
     exporter = TraceEvidenceSpanExporter(capture)
     processor = TraceEvidenceSpanProcessor(exporter)
     add_processor(processor)
-    capture._set_force_flush(processor.force_flush)
-    return capture
+    attachment = _CaptureAttachment(capture, processor)
+
+    def force_flush() -> bool:
+        """Flush accepted telemetry within the caller-provided time bound."""
+        trace_flushed = processor.force_flush()
+        for log_processor in tuple(attachment.log_processors):
+            try:
+                if not log_processor.force_flush():
+                    capture.record_log_failure("otel_log_capture_failed")
+            except Exception:
+                capture.record_log_failure("otel_log_capture_failed")
+        return trace_flushed
+
+    capture._set_force_flush(force_flush)
+    return attachment
+
+
+def _attach_logger_once(attachment: _CaptureAttachment, logger_provider: Any) -> None:
+    """Attach one deduplicated log processor, skipping unsafe proxy wrappers."""
+    add_log_processor = _log_processor_adder(logger_provider)
+    try:
+        previous = attachment.logger_attempts.get(logger_provider)
+    except TypeError:
+        # Automatic mode cannot safely deduplicate this logger wrapper. Keep the
+        # already attached trace capture and skip logs without changing the Run.
+        return
+    if previous is True:
+        return
+    if previous is False:
+        raise ConfigurationError("Automatic OTel log Evidence attachment failed")
+
+    log_processor = SimpleLogRecordProcessor(
+        TraceEvidenceLogRecordExporter(attachment.capture)
+    )
+    try:
+        attachment.logger_attempts[logger_provider] = False
+    except TypeError:
+        return
+    # Register before the provider call: a provider may retain the processor and
+    # then raise, so retrying would otherwise accumulate duplicate processors.
+    attachment.log_processors.append(log_processor)
+    add_log_processor(log_processor)
+    attachment.logger_attempts[logger_provider] = True
+
+
+def _attach_logger_explicit(
+    attachment: _CaptureAttachment, logger_provider: Any
+) -> None:
+    """Attach the explicitly requested LoggerProvider or fail configuration."""
+    add_log_processor = _log_processor_adder(logger_provider)
+    log_processor = SimpleLogRecordProcessor(
+        TraceEvidenceLogRecordExporter(attachment.capture)
+    )
+    attachment.log_processors.append(log_processor)
+    add_log_processor(log_processor)
+
+
+def _attach_trace_evidence(
+    provider: Any,
+    *,
+    logger_provider: Any | None,
+    limits: TraceEvidenceLimits | None,
+) -> _CaptureAttachment:
+    """Attach explicit trace and optional log processors without replacing providers."""
+    if logger_provider is not None:
+        _log_processor_adder(logger_provider)
+    attachment = _new_trace_attachment(provider, limits)
+    if logger_provider is not None:
+        _attach_logger_explicit(attachment, logger_provider)
+    return attachment
 
 
 def configure_trace_evidence(
     tracer_provider: Any | None = None,
     *,
+    logger_provider: Any | None = None,
     limits: TraceEvidenceLimits | None = None,
 ) -> TraceEvidenceCapture:
-    """Attach bounded Trace Evidence to an SDK-capable TracerProvider.
+    """Explicitly attach bounded KUMA capture to existing OTel SDK providers.
 
     Args:
-        tracer_provider: Existing OpenTelemetry SDK ``TracerProvider`` or
-            compatible object exposing ``add_span_processor``. ``None`` selects
-            the current global provider.
-        limits: Optional :class:`TraceEvidenceLimits`; ``None`` uses bounded
-            defaults.
+        tracer_provider: Existing OpenTelemetry SDK ``TracerProvider`` exposing
+            ``add_span_processor``. ``None`` selects the current global provider;
+            the function never installs or replaces a provider.
+        logger_provider: Optional existing OTel SDK ``LoggerProvider`` exposing
+            ``add_log_record_processor``. Supply it to capture native OTel logs;
+            ``None`` leaves logs unattached in explicit mode.
+        limits: Capture budgets for spans, attributes, events, text, logs, and
+            total per-Run bytes. ``None`` uses :class:`TraceEvidenceLimits`.
 
     Returns:
-        Capture to pass as ``create_run(trace_evidence=...)``. Existing
-        instrumentation and exporters remain attached to their Provider.
+        Thread-safe :class:`TraceEvidenceCapture` to pass as
+        ``create_run(trace_evidence=...)``. Reusing the same compatible provider
+        returns/records through one attachment rather than replacing user setup.
 
     Raises:
-        ConfigurationError: The selected Provider cannot accept a span processor
-            or the limits are invalid.
+        ConfigurationError: If a provider lacks the required official extension
+            point, cannot satisfy explicit weak-reference/idempotency guarantees,
+            or the supplied limits are invalid.
 
-    This function never replaces or resets the global Provider. Call it once for
-    an explicit Provider; automatic ``create_run`` discovery can reuse a
-    weak-referenceable configured Provider.
+    Preconditions:
+        Install the optional ``kuma-defuzex[otel]`` extra and configure the OTel
+        SDK provider/instrumentation that produces spans. This function does not
+        create spans by itself.
+
+    Postconditions:
+        The provider retains all existing processors and gains one KUMA span
+        processor plus, when supplied, one log processor. No global provider is
+        reset. The returned capture is ready for Run step association.
+
+    Side Effects:
+        Mutates the supplied providers through their standard processor APIs.
+        It performs no network export and starts no OTLP receiver.
+
+    Security/Privacy:
+        KUMA keeps only allowlisted bounded metadata/hashes. Raw prompts,
+        completions, log bodies, tool arguments, source, and credentials are not
+        retained by default. ``allow_sensitive`` cannot bypass this allowlist.
     """
 
     provider = tracer_provider or trace.get_tracer_provider()
     with _ATTACH_LOCK:
-        capture = _attach_trace_evidence(provider, limits)
-        # Automatic mode can later reuse explicit configuration. Custom wrappers
-        # that cannot be weakly referenced remain available only through the
-        # explicit capture returned to their caller.
+        attachment = _attach_trace_evidence(
+            provider,
+            logger_provider=logger_provider,
+            limits=limits,
+        )
+        # Automatic mode must be able to reuse a provider without accumulating
+        # processors; non-weak-referenceable custom wrappers remain explicit-only.
         with suppress(TypeError):
-            _ATTACHED_CAPTURES[provider] = capture
-        return capture
+            _ATTACHED_CAPTURES[provider] = attachment
+        return attachment.capture
 
 
 def _automatic_trace_evidence() -> TraceEvidenceCapture | None:
@@ -156,18 +333,25 @@ def _automatic_trace_evidence() -> TraceEvidenceCapture | None:
         return None
     with _ATTACH_LOCK:
         try:
-            capture = _ATTACHED_CAPTURES.get(provider)
+            attachment = _ATTACHED_CAPTURES.get(provider)
         except TypeError:
             return None
-        if capture is None:
-            capture = _attach_trace_evidence(provider, None)
-            _ATTACHED_CAPTURES[provider] = capture
-        return capture
+        if attachment is None:
+            attachment = _new_trace_attachment(provider, None)
+            _ATTACHED_CAPTURES[provider] = attachment
+        try:
+            logger_provider = get_logger_provider()
+        except Exception:
+            logger_provider = None
+        if callable(getattr(logger_provider, "add_log_record_processor", None)):
+            _attach_logger_once(attachment, logger_provider)
+        return attachment.capture
 
 
 __all__ = [
     "TraceEvidenceCapture",
     "TraceEvidenceLimits",
+    "TraceEvidenceLogRecordExporter",
     "TraceEvidenceSpanExporter",
     "TraceEvidenceSpanProcessor",
     "configure_trace_evidence",

--- a/src/kuma/providers/_evidence_projection.py
+++ b/src/kuma/providers/_evidence_projection.py
@@ -15,6 +15,7 @@ _MAX_TRACE_DROPPED_COUNT = 999_999_999
 
 
 def _encode(evidence: Mapping[str, Any]) -> bytes:
+    """Serialize a value with the canonical compact UTF-8 JSON encoding."""
     return json.dumps(
         evidence,
         ensure_ascii=False,
@@ -24,19 +25,23 @@ def _encode(evidence: Mapping[str, Any]) -> bytes:
 
 
 def _fits(evidence: Mapping[str, Any], limit: int) -> bool:
+    """Return whether canonical serialization fits the negotiated byte limit."""
     return len(_encode(evidence)) <= limit
 
 
 def _submissions(evidence: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return mutable Submission projections from ordered history entries."""
     return [item["submission"] for item in evidence["history"]]
 
 
 def _append_once(values: list[Any], reason: str) -> None:
+    """Append one stable degradation reason without duplicates."""
     if reason not in values:
         values.append(reason)
 
 
 def _mark_component(submission: dict[str, Any], name: str, reason: str) -> None:
+    """Mark a non-failed capture component partial for transport truncation."""
     component = submission["capture_status"][name]
     if component.get("status") != "failed":
         component["status"] = "partial"
@@ -46,6 +51,7 @@ def _mark_component(submission: dict[str, Any], name: str, reason: str) -> None:
 def _mark_submission_gap(
     submission: dict[str, Any], *, component: str, reason: str, dropped: int
 ) -> None:
+    """Record one Submission-level omission and its dropped item count."""
     _append_once(submission["missing"], reason)
     submission["dropped_count"] += dropped
     _mark_component(submission, component, reason)
@@ -54,6 +60,7 @@ def _mark_submission_gap(
 def _log_entries(
     evidence: Mapping[str, Any],
 ) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    """Return ordered log entries paired with their owning Submission."""
     result: list[tuple[dict[str, Any], dict[str, Any]]] = []
     for submission in _submissions(evidence):
         result.extend((submission, log) for log in submission["logs"])
@@ -72,6 +79,7 @@ def _retain_log_prefix(
     base_submission_drop: int,
     base_projection_drop: int,
 ) -> None:
+    """Replace log content with a UTF-8 prefix and account for dropped bytes."""
     prefix = content[:characters]
     retained_bytes = len(prefix.encode("utf-8"))
     log.update(
@@ -93,6 +101,7 @@ def _retain_log_prefix(
 def _truncate_log_content(
     evidence: dict[str, Any], limit: int, projection: dict[str, Any]
 ) -> None:
+    """Binary-search deterministic log prefixes until the upload fits."""
     for submission, log in reversed(_log_entries(evidence)):
         if _fits(evidence, limit):
             return
@@ -138,6 +147,7 @@ def _truncate_log_content(
 def _trace_entries(
     evidence: Mapping[str, Any],
 ) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    """Return ordered Trace envelopes paired with their owning Submission."""
     result: list[tuple[dict[str, Any], dict[str, Any]]] = []
     for submission in _submissions(evidence):
         trace = submission.get("trace_evidence")
@@ -158,6 +168,7 @@ def _retain_trace_prefix(
     base_submission_drop: int,
     base_projection_drop: int,
 ) -> None:
+    """Retain an ordered span prefix and account for all removed spans."""
     dropped = len(original_spans) - count
     trace["spans"] = original_spans[:count]
     trace["dropped_count"] = min(
@@ -173,6 +184,7 @@ def _retain_trace_prefix(
 def _truncate_trace_spans(
     evidence: dict[str, Any], limit: int, projection: dict[str, Any]
 ) -> None:
+    """Binary-search deterministic span prefixes until the upload fits."""
     for submission, trace in reversed(_trace_entries(evidence)):
         if _fits(evidence, limit):
             return

--- a/src/kuma/providers/_official_evidence_upload.py
+++ b/src/kuma/providers/_official_evidence_upload.py
@@ -8,14 +8,15 @@ from dataclasses import dataclass
 from typing import Any
 
 from ..errors import LimitExceededError, ProviderError
-from ..evidence.runtime import runtime_submission_id
+from ..evidence.runtime import project_runtime_evidence_v2, runtime_submission_id
 from ..evidence.runtime_contract import (
     RUNTIME_EVIDENCE_MEDIA_TYPE,
-    RUNTIME_EVIDENCE_SCHEMA,
+    RUNTIME_EVIDENCE_SCHEMA_V1,
+    RUNTIME_EVIDENCE_SCHEMA_V2,
     runtime_evidence_json,
     validate_runtime_evidence,
 )
-from ..repository.privacy import scan_sensitive_json
+from ..repository.privacy import enforce_sensitive_policy, scan_sensitive_json
 from ..transport.backend import UploadPart
 from ._evidence_projection import project_run_evidence
 from ._official_wire import history_evidence, plain_json
@@ -26,6 +27,18 @@ _MAX_BATCH_ITEMS = 20
 
 @dataclass(frozen=True, slots=True)
 class JudgeUploadConfig:
+    """Hold the validated dynamic public Judge upload limits.
+
+    Attributes:
+        max_files: Maximum multipart Evidence files accepted per request.
+        max_file_bytes: Maximum bytes accepted for one Evidence part.
+        max_total_bytes: Maximum combined multipart Evidence bytes.
+        manifest_schema_version: Exact public manifest version to serialize.
+        max_batch_items: Maximum Runs accepted by synchronous batch Judge.
+        evidence_types: Closed public Evidence media/type identifiers advertised
+            by the Backend.
+    """
+
     max_files: int
     max_file_bytes: int
     max_total_bytes: int
@@ -79,8 +92,21 @@ def judge_upload_config(response: Mapping[str, Any]) -> JudgeUploadConfig:
 
 
 def _runtime_evidence_part(
-    item: Any, *, index: int, max_file_bytes: int, part_prefix: str
+    item: Any,
+    *,
+    index: int,
+    max_file_bytes: int,
+    part_prefix: str,
+    schema_version: str = RUNTIME_EVIDENCE_SCHEMA_V1,
 ) -> tuple[UploadPart, dict[str, Any], list[Any]] | None:
+    """Build one negotiated Runtime Evidence part from stored v1 history.
+
+    The local Submission extension remains v1. When the Backend explicitly
+    advertises v2, this boundary creates a detached v2 view and performs a
+    mandatory Agent-output sensitive scan that ignores ``allow_sensitive``.
+    No multipart object is returned until association, privacy, schema, and byte
+    limits pass.
+    """
     value = item.submission.extensions.get("runtime_evidence")
     if value is None:
         return None
@@ -94,7 +120,23 @@ def _runtime_evidence_part(
             input_id=item.submission.input_id,
             step_id=item.test_input.input_id,
             submission_id=submission_id,
+            schema_version=RUNTIME_EVIDENCE_SCHEMA_V1,
         )
+        if schema_version == RUNTIME_EVIDENCE_SCHEMA_V2:
+            if item.submission.status == "completed":
+                output_findings = scan_sensitive_json(
+                    item.submission.output, location="agent_output"
+                )
+                enforce_sensitive_policy(output_findings, allow_sensitive=False)
+            value = project_runtime_evidence_v2(
+                value,
+                run_id=item.submission.run_id,
+                input_id=item.submission.input_id,
+                step_id=item.test_input.input_id,
+                submission_id=submission_id,
+                status=item.submission.status,
+                output=item.submission.output,
+            )
     except ValueError as exc:
         raise ProviderError(
             "Runtime Evidence is invalid", code="runtime_evidence_invalid"
@@ -116,7 +158,7 @@ def _runtime_evidence_part(
         {
             "name": filename,
             "sha256": hashlib.sha256(encoded).hexdigest(),
-            "evidence_type": RUNTIME_EVIDENCE_SCHEMA,
+            "evidence_type": schema_version,
         },
         scan_sensitive_json(value, location="runtime_evidence"),
     )
@@ -125,7 +167,12 @@ def _runtime_evidence_part(
 def _runtime_evidence_parts(
     context: JudgeContext, config: JudgeUploadConfig, part_prefix: str
 ) -> tuple[list[UploadPart], list[dict[str, Any]], list[Any]]:
-    if RUNTIME_EVIDENCE_SCHEMA not in config.evidence_types:
+    """Collect the highest explicitly negotiated Runtime Evidence version."""
+    if RUNTIME_EVIDENCE_SCHEMA_V2 in config.evidence_types:
+        schema_version = RUNTIME_EVIDENCE_SCHEMA_V2
+    elif RUNTIME_EVIDENCE_SCHEMA_V1 in config.evidence_types:
+        schema_version = RUNTIME_EVIDENCE_SCHEMA_V1
+    else:
         return [], [], []
     parts: list[UploadPart] = []
     manifest: list[dict[str, Any]] = []
@@ -136,6 +183,7 @@ def _runtime_evidence_parts(
             index=index,
             max_file_bytes=config.max_file_bytes,
             part_prefix=part_prefix,
+            schema_version=schema_version,
         )
         if built is None:
             continue
@@ -152,6 +200,7 @@ def _typed_upload(
     findings: list[Any],
     config: JudgeUploadConfig,
 ) -> tuple[tuple[UploadPart, ...], dict[str, Any], list[Any]]:
+    """Enforce dynamic file and byte limits for canonical typed Evidence."""
     if len(parts) > config.max_files:
         raise LimitExceededError(
             "Runtime Evidence exceeds the Judge file-count limit",
@@ -172,6 +221,7 @@ def _typed_upload(
 def _legacy_upload(
     context: JudgeContext, config: JudgeUploadConfig, part_prefix: str
 ) -> tuple[tuple[UploadPart, ...], dict[str, Any], list[Any]]:
+    """Project complete history into one bounded legacy Evidence file."""
     evidence = {
         "schema_version": "defuzex.run_evidence.v1",
         "run_status": context.run_status,

--- a/src/kuma/providers/_official_judgment.py
+++ b/src/kuma/providers/_official_judgment.py
@@ -18,6 +18,7 @@ from ._official_wire import (
 def _validated_collections(
     response: Mapping[str, Any],
 ) -> tuple[list[Any], list[Any], list[Any]]:
+    """Validate optional issue and step-result arrays without private fields."""
     issues = response.get("issues", [])
     step_results = response.get("step_results", [])
     evidence_gaps = response.get("evidence_gaps", [])
@@ -43,6 +44,7 @@ def _validated_collections(
 
 
 def _validated_confidence(value: Any) -> str | int | float | None:
+    """Accept bounded numeric confidence and legacy low/medium/high labels."""
     if value is None:
         return None
     if (isinstance(value, str) and value in {"low", "medium", "high"}) or (

--- a/src/kuma/providers/_official_wire.py
+++ b/src/kuma/providers/_official_wire.py
@@ -59,6 +59,7 @@ _SPAN_FIELDS = frozenset(
 
 
 def plain_json(value: Any) -> Any:
+    """Return a detached JSON value after rejecting unsupported objects."""
     if is_dataclass(value) and not isinstance(value, type):
         return {
             field.name: plain_json(getattr(value, field.name))
@@ -74,6 +75,7 @@ def plain_json(value: Any) -> Any:
 
 
 def canonical_sha256(value: Any) -> str:
+    """Return a deterministic SHA-256 digest of a JSON-compatible value."""
     raw = json.dumps(
         plain_json(value),
         ensure_ascii=False,
@@ -85,10 +87,12 @@ def canonical_sha256(value: Any) -> str:
 
 
 def contains_private_fields(value: Any) -> bool:
+    """Return whether private fields satisfies the official public-wire validation contract."""
     return contains_private_data(value, extra_fields=("rubric",))
 
 
 def required_text(value: Any, label: str) -> str:
+    """Require a non-empty public text field from an official response."""
     if not isinstance(value, str) or not value.strip():
         raise ProviderError(
             f"The Backend returned an invalid {label}", code="invalid_response"
@@ -121,6 +125,7 @@ def validate_official_case_provenance(value: Any) -> dict[str, str]:
 
 
 def valid_judgment_issue(value: Mapping[str, Any]) -> bool:
+    """Return whether judgment issue satisfies the official public-wire validation contract."""
     return (
         isinstance(value.get("issue_id"), str)
         and bool(value["issue_id"])
@@ -131,6 +136,7 @@ def valid_judgment_issue(value: Mapping[str, Any]) -> bool:
 
 
 def valid_step_result(value: Mapping[str, Any]) -> bool:
+    """Return whether step result satisfies the official public-wire validation contract."""
     return (
         isinstance(value.get("step_id"), str)
         and bool(value["step_id"])
@@ -141,6 +147,7 @@ def valid_step_result(value: Mapping[str, Any]) -> bool:
 
 
 def _valid_trace_attributes(value: Any, *, resource: bool = False) -> bool:
+    """Return whether trace attributes satisfies the official public-wire validation contract."""
     return isinstance(value, Mapping) and all(
         isinstance(key, str) and attribute_key_allowed(key, resource=resource)
         for key in value
@@ -148,6 +155,7 @@ def _valid_trace_attributes(value: Any, *, resource: bool = False) -> bool:
 
 
 def _valid_trace_event(value: Any) -> bool:
+    """Return whether trace event satisfies the official public-wire validation contract."""
     return (
         isinstance(value, Mapping)
         and set(value) == {"name", "time_unix_nano", "attributes"}
@@ -158,10 +166,12 @@ def _valid_trace_event(value: Any) -> bool:
 
 
 def _valid_non_negative_int(value: Any) -> bool:
+    """Return whether non negative int satisfies the official public-wire validation contract."""
     return not isinstance(value, bool) and isinstance(value, int) and value >= 0
 
 
 def _valid_trace_span(value: Any) -> bool:
+    """Return whether trace span satisfies the official public-wire validation contract."""
     if not isinstance(value, Mapping) or set(value) != _SPAN_FIELDS:
         return False
     parent = value["parent_span_id"]
@@ -197,6 +207,7 @@ def _valid_trace_span(value: Any) -> bool:
 def valid_trace_evidence(
     value: Any, *, run_id: str, case_id: str, input_id: str
 ) -> bool:
+    """Return whether trace evidence satisfies the official public-wire validation contract."""
     if not isinstance(value, Mapping) or set(value) != _TRACE_FIELDS:
         return False
     spans = value["spans"]

--- a/src/kuma/providers/base.py
+++ b/src/kuma/providers/base.py
@@ -13,15 +13,51 @@ from ..errors import ConfigurationError, ProviderError
 
 
 def _immutable_mapping(value: Mapping[str, Any] | None) -> Mapping[str, Any]:
+    """Detach and recursively freeze Provider context metadata."""
     return MappingProxyType(dict(value or {}))
 
 
 @dataclass(frozen=True, slots=True)
 class CaseGenerationContext:
-    """Validated local inputs made available to a Case Provider.
+    """Describe exactly what a Case Provider may use to create one public Case.
 
-    ``repo_meta`` is metadata only. Official Providers reduce it again to the
-    public wire allowlist before any network request.
+    A custom provider receives this object in ``generate_case``. It may inspect
+    the explicitly selected repository and requirement data, then must return a
+    public :class:`~kuma.contracts.Case` (or a supported mapping) containing no
+    private rubric or hidden answer. The object is immutable so provider code
+    cannot change the values used by later normalization and judging.
+
+    Attributes:
+        repo_path: Absolute path to the repository selected by the caller. The
+            provider may inspect this repository only; it must not infer that
+            parent directories or unrelated paths are in scope.
+        repo_meta: Read-only repository metadata collected by KUMA, such as the
+            bounded tree and repository fingerprint. It is not repository file
+            content. Official providers reduce it to the public HTTP allowlist
+            before transmission.
+        requirement: Requirement body supplied by the caller, or ``None`` when
+            no requirement file was selected. Custom providers that declare
+            ``requirement_required=False`` may support the omitted case.
+        input_type: Required public input payload kind: ``"text"`` or
+            ``"structured"``. Returned Case inputs must use this kind.
+        input_schema: Read-only JSON Schema for structured inputs, or ``None``
+            when no schema applies. A provider must not mutate this mapping.
+        strategy: Requested public Case strategy identifier. ``"auto"`` asks
+            an official service to select a supported strategy; custom providers
+            decide how to interpret it and must not treat it as private rubric.
+        max_steps: Positive upper bound on the number of Case steps the provider
+            may return. It is a maximum, not a request for exactly that many
+            steps; returning any non-empty sequence up to this value is valid.
+        agent_description: Front-matter description of the Agent under test, or
+            ``None``. It deliberately excludes the requirement body and secrets.
+        requirement_sections: Read-only named sections parsed from the public
+            requirement. Values remain local unless the selected provider's
+            documented public contract transmits an allowlisted subset.
+
+    Security/Privacy:
+        This context never contains a private rubric, hidden answer, provider
+        credential, MCP address, or model configuration. Possession of
+        ``repo_path`` is not permission to read outside that repository.
     """
 
     repo_path: Path
@@ -30,12 +66,38 @@ class CaseGenerationContext:
     input_type: str
     input_schema: Mapping[str, Any] | None
     strategy: str
-    max_inputs: int
+    max_steps: int
     agent_description: str | None = None
     requirement_sections: Mapping[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "repo_path", self.repo_path.resolve())
+        """Resolve and freeze provider inputs before the provider is invoked.
+
+        Raises:
+            ConfigurationError: If ``max_steps`` is not positive.
+
+        Preconditions:
+            The caller has already chosen the repository and parsed any
+            requirement file; this method does not read repository contents.
+
+        Postconditions:
+            ``repo_path`` is absolute and the three mapping attributes are
+            detached, read-only snapshots. A failure leaves no external state.
+
+        Side Effects:
+            Resolves the path lexically/filesystem-wise through ``Path.resolve``;
+            performs no network request and writes no files.
+        """
+        path_failed = False
+        try:
+            resolved_repo = self.repo_path.resolve()
+        except (AttributeError, TypeError, ValueError, OSError, RuntimeError):
+            path_failed = True
+        if path_failed:
+            raise ConfigurationError(
+                "Case Provider repository path is unavailable"
+            ) from None
+        object.__setattr__(self, "repo_path", resolved_repo)
         object.__setattr__(self, "repo_meta", _immutable_mapping(self.repo_meta))
         if self.input_schema is not None:
             object.__setattr__(
@@ -46,15 +108,32 @@ class CaseGenerationContext:
             "requirement_sections",
             MappingProxyType(dict(self.requirement_sections)),
         )
-        if self.max_inputs <= 0:
+        if self.max_steps <= 0:
             raise ConfigurationError(
-                "Custom Case Providers require a positive max_inputs"
+                "Custom Case Providers require a positive max_steps"
             )
 
 
 @dataclass(frozen=True, slots=True)
 class JudgeContext:
-    """Immutable completed Run history supplied to a Judge Provider."""
+    """Supply one completed public Run to a Judge Provider.
+
+    Attributes:
+        case: Public Case whose inputs were executed. Private official rubric
+            provenance, when present, remains an opaque validated extension.
+        history: Ordered immutable pairs of delivered inputs and committed
+            submissions. The order is the order observed by the Run.
+        run_status: Public terminal Run status passed to the provider. Current
+            callers use ``"completed"`` before judging.
+        evidence_summary: Read-only bounded summary such as history length and
+            dropped-evidence count. It is not a substitute for per-submission
+            Evidence and contains no private Judge material.
+
+    Security/Privacy:
+        Custom judges receive only public Case data and SDK-collected Run
+        history. Official judges serialize this context through the public
+        Backend boundary; they never receive a private rubric from the SDK.
+    """
 
     case: Case
     history: tuple[HistoryItem, ...]
@@ -62,6 +141,18 @@ class JudgeContext:
     evidence_summary: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
+        """Detach the completed history and summary before Judge invocation.
+
+        Preconditions:
+            ``history`` contains only committed :class:`HistoryItem` values from
+            one Run; the Run lifecycle is responsible for that correlation.
+
+        Postconditions:
+            ``history`` is a tuple and ``evidence_summary`` is a read-only copy.
+
+        Side Effects:
+            Performs no file, network, model, or credential access.
+        """
         object.__setattr__(self, "history", tuple(self.history))
         object.__setattr__(
             self, "evidence_summary", _immutable_mapping(self.evidence_summary)
@@ -72,24 +163,90 @@ class JudgeContext:
 class CaseProvider(Protocol):
     """Port for producing one complete Case before a Run delivers any Input."""
 
-    def generate_case(self, context: CaseGenerationContext) -> Any: ...
+    def generate_case(self, context: CaseGenerationContext) -> Any:
+        """Produce one public Case for a validated generation context.
+
+        Args:
+            context: Immutable repository, requirement, strategy, and step-limit
+                inputs described by :class:`CaseGenerationContext`.
+
+        Returns:
+            A :class:`Case`; a Case mapping with required ``inputs``; one text
+            or :class:`KumaInput`; or a ``list``/``tuple`` of public Inputs.
+            A top-level mapping without ``inputs`` is not an Input fallback.
+
+        Raises:
+            ProviderError: If generation fails or no valid public Case can be
+                returned. Implementations may raise a more specific ``KumaError``.
+
+        Postconditions:
+            A successful result contains one through ``context.max_steps``
+            inputs and no private rubric, expected output, hidden answer, or
+            provider secret.
+        """
+        ...
 
 
 @runtime_checkable
 class JudgeProvider(Protocol):
     """Port for synchronously judging a completed Run history."""
 
-    def judge(self, context: JudgeContext) -> Any: ...
+    def judge(self, context: JudgeContext) -> Any:
+        """Judge one completed Run without mutating its committed history.
+
+        Args:
+            context: Immutable public Case, ordered history, terminal status,
+                and bounded Evidence summary for exactly one Run.
+
+        Returns:
+            A :class:`TestReport` or supported mapping that KUMA normalizes into
+            the stable public report contract.
+
+        Raises:
+            ProviderError: If judging fails or returns an invalid public result.
+
+        Postconditions:
+            Success yields a report correlated to the context Run; failure must
+            not fabricate a report or rewrite committed submissions.
+        """
+        ...
 
 
 @dataclass(frozen=True, slots=True)
 class CallableCaseProvider:
-    """Adapt a Case callback while replacing unsafe callback error text."""
+    """Expose a plain Python callback through the typed Case Provider protocol.
+
+    Attributes:
+        callback: Function called once with :class:`CaseGenerationContext`; its
+            return value follows :meth:`CaseProvider.generate_case`.
+        requirement_required: Whether :func:`kuma.create_run` must receive a
+            requirement before invoking this callback. Set ``False`` only when
+            the callback intentionally supports requirement-free generation.
+    """
 
     callback: Callable[[CaseGenerationContext], Any]
     requirement_required: bool = True
 
     def generate_case(self, context: CaseGenerationContext) -> Any:
+        """Invoke the callback while preserving only safe public failures.
+
+        Args:
+            context: Immutable inputs for the Case generation request.
+
+        Returns:
+            The callback result, which the caller subsequently normalizes.
+
+        Raises:
+            ProviderError: Re-raises an intentional provider error, or replaces
+                any other callback exception with a stable non-sensitive error.
+
+        Side Effects:
+            Whatever the user-supplied callback performs. KUMA itself performs
+            no additional I/O in this adapter.
+
+        Security/Privacy:
+            Arbitrary callback exception text is not exposed through the SDK.
+        """
         try:
             return self.callback(context)
         except ProviderError:
@@ -100,11 +257,31 @@ class CallableCaseProvider:
 
 @dataclass(frozen=True, slots=True)
 class CallableJudgeProvider:
-    """Adapt a Judge callback while replacing unsafe callback error text."""
+    """Expose a plain Python callback through the typed Judge Provider protocol.
+
+    Attributes:
+        callback: Function called with one immutable :class:`JudgeContext`; its
+            result follows :meth:`JudgeProvider.judge`.
+    """
 
     callback: Callable[[JudgeContext], Any]
 
     def judge(self, context: JudgeContext) -> Any:
+        """Invoke the callback while preserving only safe public failures.
+
+        Args:
+            context: Completed Run data supplied to the custom judge.
+
+        Returns:
+            The callback result, which KUMA subsequently normalizes.
+
+        Raises:
+            ProviderError: Re-raises an intentional provider error, or maps an
+                arbitrary callback exception to a safe stable failure.
+
+        Security/Privacy:
+            Arbitrary callback exception text is not propagated to callers.
+        """
         try:
             return self.callback(context)
         except ProviderError:
@@ -116,6 +293,23 @@ class CallableJudgeProvider:
 def adapt_case_provider(
     provider: CaseProvider | Callable[[CaseGenerationContext], Any],
 ) -> CaseProvider:
+    """Return a Case Provider for either supported user-facing input form.
+
+    Args:
+        provider: Existing :class:`CaseProvider` instance or a callback accepting
+            :class:`CaseGenerationContext`.
+
+    Returns:
+        ``provider`` unchanged when it implements the protocol; otherwise a
+        :class:`CallableCaseProvider` wrapper.
+
+    Raises:
+        ConfigurationError: If the value is neither a protocol implementation
+            nor callable.
+
+    Postconditions:
+        The returned object always exposes ``generate_case(context)``.
+    """
     if isinstance(provider, CaseProvider):
         return provider
     if callable(provider):
@@ -126,6 +320,23 @@ def adapt_case_provider(
 def adapt_judge_provider(
     provider: JudgeProvider | Callable[[JudgeContext], Any],
 ) -> JudgeProvider:
+    """Return a Judge Provider for either supported user-facing input form.
+
+    Args:
+        provider: Existing :class:`JudgeProvider` instance or a callback
+            accepting :class:`JudgeContext`.
+
+    Returns:
+        ``provider`` unchanged when it implements the protocol; otherwise a
+        :class:`CallableJudgeProvider` wrapper.
+
+    Raises:
+        ConfigurationError: If the value is neither a protocol implementation
+            nor callable.
+
+    Postconditions:
+        The returned object always exposes ``judge(context)``.
+    """
     if isinstance(provider, JudgeProvider):
         return provider
     if callable(provider):

--- a/src/kuma/providers/normalization.py
+++ b/src/kuma/providers/normalization.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-import json
 import uuid
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
+from .._json_values import detach_json
 from ..contracts import Case, KumaInput, TestReport
 from ..errors import ProviderError, ValidationError
-from ..repository.privacy import PRIVATE_DATA_FIELDS, contains_private_data
+from ..repository.privacy import contains_private_data
 from ..repository.requirements import validate_schema, validate_structured_input
 
 _CASE_FIELDS = frozenset(
@@ -32,44 +32,122 @@ _REPORT_FIELDS = frozenset(
         "extensions",
     }
 )
+_PRIVATE_INPUT_FIELDS = ("rubric",)
+_PRIVATE_CASE_ERROR = "Custom Case contains prohibited private fields"
 
 
 def _new_id(prefix: str) -> str:
+    """Create a random local identifier for normalized custom Provider data."""
     return f"{prefix}_{uuid.uuid4().hex}"
 
 
 def _plain_json(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {str(key): _plain_json(child) for key, child in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_plain_json(child) for child in value]
-    return value
+    """Detach bounded Provider JSON or raise one non-sensitive Provider error."""
+    try:
+        return detach_json(value)
+    except Exception:
+        raise ProviderError("Provider value must be JSON serializable") from None
 
 
 def _ensure_json(value: Any, description: str) -> None:
+    """Detach a Provider value and reject non-JSON or non-finite content."""
     try:
-        json.dumps(_plain_json(value), allow_nan=False)
-    except (TypeError, ValueError) as exc:
-        raise ProviderError(f"{description} must be JSON serializable") from exc
+        _plain_json(value)
+    except ProviderError:
+        raise ProviderError(f"{description} must be JSON serializable") from None
 
 
-def _bounded_inputs(value: Any, max_inputs: int) -> list[Any]:
+def _bounded_inputs(value: Any, max_steps: int) -> list[Any]:
+    """Accept only the documented single-input or list/tuple fallback shapes."""
     if isinstance(value, (str, bytes, Mapping, KumaInput)):
         return [value]
-    if not isinstance(value, Iterable):
-        raise ProviderError("Case Provider must return a Case or iterable Inputs")
-    iterator = iter(value)
+    if not isinstance(value, (list, tuple)):
+        raise ProviderError(
+            "Case Provider must return a Case, explicit Case mapping, single text "
+            "or KumaInput, or a list/tuple of Inputs"
+        )
     inputs: list[Any] = []
-    for item in iterator:
+    for item in value:
         inputs.append(item)
-        if len(inputs) > max_inputs:
-            raise ProviderError("Case Provider returned more than max_inputs")
+        if len(inputs) > max_steps:
+            raise ProviderError("Case Provider returned more than max_steps")
     return inputs
+
+
+def _public_input_value(value: Any) -> Any:
+    """Project a typed Input to the same public fields scanned on mapping inputs."""
+    if not isinstance(value, KumaInput):
+        return value
+    return {
+        "payload": value.payload,
+        "public_constraints": value.public_constraints,
+        "extensions": value.extensions,
+    }
+
+
+def _reject_private_case_data(value: Any) -> None:
+    """Reject private evaluation keys without retaining or echoing their values."""
+    if contains_private_data(value, extra_fields=_PRIVATE_INPUT_FIELDS):
+        raise ProviderError(_PRIVATE_CASE_ERROR)
+
+
+def _case_envelope_json(result: Mapping[Any, Any]) -> tuple[dict[str, Any], Any]:
+    """Validate Case metadata as JSON while preserving the typed Input field.
+
+    Args:
+        result: Custom Provider Case envelope. Its key that stringifies to
+            ``inputs`` may contain documented :class:`KumaInput` instances;
+            every other field must be ordinary bounded JSON.
+
+    Returns:
+        A detached JSON envelope whose ``inputs`` value is a harmless sentinel,
+        plus the original Input value for the dedicated Input normalizer.
+
+    Raises:
+        ProviderError: If mapping iteration, key conversion, envelope traversal,
+            cycle/depth validation, or the required ``inputs`` field fails.
+
+    Preconditions:
+        ``result`` came from a custom Case Provider and has not been exposed as
+        a public :class:`Case`.
+
+    Postconditions:
+        Success proves all non-Input metadata is bounded acyclic JSON. Input
+        contents remain untouched for typed projection and per-Input checks.
+
+    Side Effects:
+        Iterates the Provider mapping locally. It performs no persistence,
+        Evidence capture, network request, model call, or billing action.
+
+    Security/Privacy:
+        Traversal failures become stable Provider errors and never include a
+        key, value, object representation, or original exception.
+    """
+    missing = object()
+    raw_inputs: Any = missing
+    envelope: dict[str, Any] = {}
+    try:
+        for key, value in result.items():
+            normalized_key = str(key)
+            if normalized_key == "inputs":
+                raw_inputs = value
+                envelope[normalized_key] = None
+            else:
+                envelope[normalized_key] = value
+    except Exception:
+        raise ProviderError("Provider value must be JSON serializable") from None
+
+    plain = _plain_json(envelope)
+    if raw_inputs is missing:
+        _reject_private_case_data(plain)
+        raise ProviderError("Case Provider mapping must contain an 'inputs' field")
+    return plain, raw_inputs
 
 
 def _input_parts(
     value: Any,
 ) -> tuple[Any, str, str | None, Mapping[str, Any], Mapping[str, Any]]:
+    """Validate and detach one Input mapping into normalized public parts."""
     if isinstance(value, KumaInput):
         return (
             _plain_json(value.payload),
@@ -104,6 +182,18 @@ def _input_parts(
 
 @dataclass(frozen=True, slots=True)
 class _CaseParts:
+    """Detach the supported public fields from a raw Case Provider result.
+
+    Attributes:
+        inputs: Raw input value or sequence awaiting normalization.
+        case_id: Optional provider-supplied public Case identifier.
+        input_type: Optional declared ``text``/``structured`` payload kind.
+        input_schema: Optional public structured-input JSON Schema.
+        rubric: Optional public custom-provider rubric; official private rubric
+            content is forbidden here.
+        extensions: Optional public extension metadata awaiting validation.
+    """
+
     inputs: Any
     case_id: str | None = None
     input_type: str | None = None
@@ -113,7 +203,23 @@ class _CaseParts:
 
 
 def _case_parts(result: Any) -> _CaseParts:
+    """Detach one supported Case shape without serializing typed Inputs.
+
+    Mapping envelopes are split at the public ``inputs`` boundary. Non-Input
+    metadata is validated as one bounded JSON graph, while typed Inputs retain
+    their public type until the normalizer projects and scans their payload,
+    constraints, and extensions. This preserves the documented Case mapping
+    contract without allowing opaque objects in metadata.
+    """
     if isinstance(result, Case):
+        _reject_private_case_data(
+            {
+                "inputs": [_public_input_value(item) for item in result.inputs],
+                "input_schema": result.input_schema,
+                "extensions": result.extensions,
+            }
+        )
+        _reject_private_case_data(result.rubric)
         return _CaseParts(
             inputs=result.inputs,
             case_id=result.case_id,
@@ -122,23 +228,20 @@ def _case_parts(result: Any) -> _CaseParts:
             rubric=result.rubric,
             extensions=result.extensions,
         )
-    if not isinstance(result, Mapping) or "inputs" not in result:
+    if not isinstance(result, Mapping):
         return _CaseParts(inputs=result)
+    result, raw_inputs = _case_envelope_json(result)
 
-    private = {str(key) for key in result if str(key).casefold() in PRIVATE_DATA_FIELDS}
-    if private:
-        fields = ", ".join(sorted(private))
-        raise ProviderError(f"Custom Case contains prohibited private fields: {fields}")
     public_case = {key: value for key, value in result.items() if key != "rubric"}
-    if contains_private_data(public_case):
-        raise ProviderError("Custom Case contains nested private fields")
+    _reject_private_case_data(public_case)
+    _reject_private_case_data(result.get("rubric"))
     supplied_extensions = result.get("extensions", {})
     if not isinstance(supplied_extensions, Mapping):
         raise ProviderError("Case extensions must be a mapping")
     extensions = dict(supplied_extensions)
     extensions.update({str(key): result[key] for key in set(result) - _CASE_FIELDS})
     return _CaseParts(
-        inputs=result["inputs"],
+        inputs=raw_inputs,
         case_id=result.get("case_id"),
         input_type=result.get("input_type"),
         input_schema=result.get("input_schema"),
@@ -153,6 +256,7 @@ def _resolved_input_type(
     declared: str | None,
     required: str | None,
 ) -> str:
+    """Resolve Case input type while enforcing the requirement's declared type."""
     inferred_types = {item[1] for item in parsed}
     if len(inferred_types) != 1:
         raise ProviderError("A Case cannot mix text and structured Inputs")
@@ -172,6 +276,7 @@ def _resolved_input_schema(
     declared: Mapping[str, Any] | None,
     required: Mapping[str, Any] | None,
 ) -> Mapping[str, Any] | None:
+    """Resolve and validate the schema required for structured Inputs."""
     resolved = required if required is not None else declared
     if (
         required is not None
@@ -193,6 +298,7 @@ def _validate_structured_payloads(
     parsed: list[tuple[Any, str, str | None, Mapping[str, Any], Mapping[str, Any]]],
     schema: Mapping[str, Any] | None,
 ) -> None:
+    """Validate every structured Input against the accepted JSON Schema."""
     if schema is None:
         return
     for payload, *_ in parsed:
@@ -210,6 +316,7 @@ def _normalized_inputs(
     run_id: str,
     case_id: str,
 ) -> tuple[KumaInput, ...]:
+    """Create immutable Inputs with unique IDs and validated payload shapes."""
     inputs: list[KumaInput] = []
     input_ids: set[str] = set()
     for index, parts in enumerate(parsed):
@@ -245,14 +352,49 @@ def normalize_case(
     result: Any,
     *,
     run_id: str,
-    max_inputs: int,
+    max_steps: int,
     required_input_type: str | None,
     required_input_schema: Mapping[str, Any] | None,
 ) -> Case:
-    """Normalize one complete custom Case before exposing any Input."""
+    """Validate and freeze one Provider Case before any Input is exposed.
 
-    if max_inputs <= 0:
-        raise ProviderError("max_inputs must be positive")
+    ``create_run`` calls this boundary for both official normalized mappings and
+    custom Provider output. It enforces the Run's Input limit, requirement type
+    and schema, unique identities, JSON safety, and reserved-extension rules,
+    returning the immutable public ``Case`` contract or raising ``ProviderError``.
+
+    Args:
+        result: Provider result as a :class:`Case`, Case mapping with required
+            ``inputs``, one text/:class:`KumaInput`, or a ``list``/``tuple`` of
+            public Inputs. Other mappings and iterables are rejected.
+        run_id: Owning Run identifier assigned to every normalized input.
+        max_steps: Positive maximum number of inputs accepted; fewer are valid.
+        required_input_type: Required ``text``/``structured`` type from the
+            requirement, or ``None`` when provider declaration decides.
+        required_input_schema: Required structured JSON Schema, or ``None``.
+
+    Returns:
+        New immutable :class:`Case` with correlated IDs and detached JSON values.
+
+    Raises:
+        ProviderError: If shape, count, identifiers, schema, payload, rubric, or
+            extensions violate the public Provider contract.
+
+    Preconditions:
+        ``run_id`` identifies the Run being assembled and ``max_steps`` is the
+        selected provider boundary.
+
+    Postconditions:
+        Success contains one through ``max_steps`` inputs, all sharing Run/Case
+        identity and payload type. Caller-owned objects cannot mutate it.
+
+    Security/Privacy:
+        Private fields and forged official provenance from custom providers fail
+        closed; normalization never manufactures official status.
+    """
+
+    if max_steps <= 0:
+        raise ProviderError("max_steps must be positive")
     parts = _case_parts(result)
     if parts.case_id is not None and (
         not isinstance(parts.case_id, str) or not parts.case_id.strip()
@@ -264,10 +406,19 @@ def normalize_case(
     if parts.input_schema is not None and not isinstance(parts.input_schema, Mapping):
         raise ProviderError("Case input_schema must be a mapping")
 
-    raw_sequence = _bounded_inputs(parts.inputs, max_inputs)
+    raw_sequence = _bounded_inputs(parts.inputs, max_steps)
     if not raw_sequence:
         raise ProviderError("Case Provider returned no Inputs")
-    parsed = [_input_parts(value) for value in raw_sequence]
+    parsed = []
+    for value in raw_sequence:
+        public_value = _public_input_value(value)
+        scanned_value = (
+            public_value if isinstance(value, KumaInput) else _plain_json(public_value)
+        )
+        _reject_private_case_data(scanned_value)
+        parsed.append(
+            _input_parts(value if isinstance(value, KumaInput) else public_value)
+        )
     resolved_type = _resolved_input_type(
         parsed,
         declared=parts.input_type,
@@ -295,6 +446,7 @@ def normalize_case(
 
 
 def normalize_report(result: Any, *, run_id: str) -> TestReport:
+    """Normalize custom Judge output into the stable public Report contract."""
     if isinstance(result, TestReport):
         if result.run_id != run_id:
             raise ProviderError("Judge Provider returned a report for another Run")

--- a/src/kuma/providers/official_case.py
+++ b/src/kuma/providers/official_case.py
@@ -6,6 +6,7 @@ import json
 from collections.abc import Mapping
 from typing import Any
 
+from ..config import DEFAULT_CASE_MAX_STEPS
 from ..errors import (
     ConfigurationError,
     LimitExceededError,
@@ -39,8 +40,72 @@ _MAX_BEHAVIOR_FIELD_BYTES = 8 * 1024
 _MAX_BEHAVIOR_SPEC_BYTES = 16 * 1024
 
 
-def _official_inputs(steps: Any, *, max_inputs: int) -> list[dict[str, str]]:
-    if not isinstance(steps, list) or not 1 <= len(steps) <= max_inputs:
+def _casegen_max_steps_limit(entitlements: Mapping[str, Any]) -> int:
+    """Return the closed public Case ceiling, using 10 for legacy omission.
+
+    Args:
+        entitlements: Validated top-level response from ``GET /sdk/entitlements/``.
+
+    Returns:
+        Integer service ceiling from 1 through 10. Older responses may omit only
+        ``casegen_max_steps`` and therefore use the historical default of 10.
+
+    Raises:
+        ProviderError: If ``limits`` or the advertised ceiling has an invalid
+            public shape.
+    """
+    limits = entitlements.get("limits")
+    if not isinstance(limits, Mapping):
+        raise ProviderError(
+            "The Backend returned invalid Case generation limits",
+            code="invalid_response",
+        )
+    value = limits.get("casegen_max_steps", DEFAULT_CASE_MAX_STEPS)
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 1 <= value <= DEFAULT_CASE_MAX_STEPS
+    ):
+        raise ProviderError(
+            "The Backend returned invalid Case generation limits",
+            code="invalid_response",
+        )
+    return value
+
+
+def _validate_requested_max_steps(
+    entitlements: Mapping[str, Any], requested: int
+) -> None:
+    """Reject an explicit Case ceiling above the service limit before POST.
+
+    Args:
+        entitlements: Current public entitlement response for this API key.
+        requested: Positive step ceiling explicitly supplied by the caller.
+
+    Raises:
+        ProviderError: If the service-limit response is malformed.
+        LimitExceededError: If ``requested`` exceeds the advertised ceiling;
+            ``details["max_allowed_steps"]`` contains the safe integer maximum.
+
+    Postconditions:
+        Success proves the request may be posted under the observed limit. A
+        rejection occurs before an operation, credit reservation, or model call.
+
+    Side Effects:
+        None. The caller owns the entitlement GET and subsequent Case POST.
+    """
+    allowed = _casegen_max_steps_limit(entitlements)
+    if requested > allowed:
+        raise LimitExceededError(
+            f"max_steps exceeds the Case service limit; maximum allowed is {allowed}.",
+            code="case_step_limit_exceeded",
+            details={"max_allowed_steps": allowed},
+        )
+
+
+def _official_inputs(steps: Any, *, max_steps: int) -> list[dict[str, str]]:
+    """Validate bounded public Case steps and map them to text Input payloads."""
+    if not isinstance(steps, list) or not 1 <= len(steps) <= max_steps:
         raise ProviderError(
             "The Backend returned an invalid number of Case steps",
             code="invalid_response",
@@ -78,6 +143,7 @@ def _case_matches_request(
     strategy_version: str,
     repo_fingerprint: str,
 ) -> bool:
+    """Check batch, strategy, repository, and signature metadata as one integrity unit."""
     returned_fingerprint = str(raw_case.get("repo_fingerprint", ""))
     return (
         batch.get("case_ids") == [case_id]
@@ -95,10 +161,11 @@ def _case_matches_request(
 def _official_case_response(
     response: Mapping[str, Any],
     *,
-    max_inputs: int,
+    max_steps: int,
     requested_strategy_id: str,
     repo_fingerprint: str,
 ) -> tuple[str, str, str, str, Mapping[str, Any], list[dict[str, str]]]:
+    """Validate an official Case result and return its normalized public parts."""
     batch, raw_case = _case_response_envelope(response)
     case_id = required_text(raw_case.get("case_id"), "case_id")
     batch_id = required_text(batch.get("batch_id"), "batch_id")
@@ -125,13 +192,14 @@ def _official_case_response(
         strategy_id,
         strategy_version,
         raw_case,
-        _official_inputs(raw_case.get("steps"), max_inputs=max_inputs),
+        _official_inputs(raw_case.get("steps"), max_steps=max_steps),
     )
 
 
 def _case_response_envelope(
     response: Mapping[str, Any],
 ) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    """Require one public Case and reject private fields in the Backend envelope."""
     batch = response.get("batch")
     cases = response.get("cases")
     if (
@@ -155,6 +223,7 @@ def _case_response_envelope(
 def _selected_strategy(
     batch: Mapping[str, Any], *, requested_strategy_id: str
 ) -> tuple[str, str]:
+    """Validate the Backend's actual strategy selection against an explicit request."""
     selected_strategy_id = required_text(
         batch.get("strategy_id"), "selected strategy_id"
     )
@@ -178,6 +247,7 @@ def _selected_strategy(
 
 
 def _agent_description(context: CaseGenerationContext) -> str:
+    """Return only bounded front-matter Agent description, never requirement text."""
     value = (
         context.agent_description.strip()
         if isinstance(context.agent_description, str)
@@ -192,6 +262,7 @@ def _agent_description(context: CaseGenerationContext) -> str:
 
 
 def _behavior_spec(context: CaseGenerationContext) -> dict[str, str]:
+    """Validate the three required public behavior sections within UTF-8 budgets."""
     sections = context.requirement_sections
     if set(sections) != set(_BEHAVIOR_SPEC_FIELDS):
         raise ValidationError(
@@ -245,7 +316,41 @@ def _safe_case_payload(
     *,
     allow_sensitive: bool,
     evidence_capabilities: tuple[str, ...],
+    max_steps: int | None,
 ) -> tuple[dict[str, Any], str]:
+    """Build and privacy-scan the exact public Case-generation request payload.
+
+    ``max_steps`` remains the caller's requested upper bound on the public wire.
+    A separate entitlement preflight rejects unsupported values before this
+    payload can start a paid operation; Backend validation remains authoritative.
+
+    Args:
+        context: Validated requirement, repository metadata, strategy, and local
+            Case normalization ceiling for this Run.
+        allow_sensitive: Whether ordinary allowlisted metadata may pass the
+            scanner. Secrets and private fields remain forbidden.
+        evidence_capabilities: Canonically ordered runtime Evidence kinds that
+            this Run can truthfully produce.
+        max_steps: Explicit user ceiling to serialize, or ``None`` to omit the
+            field and select the service default.
+
+    Returns:
+        Detached public JSON payload and the canonical repository fingerprint
+        used later to validate the returned Case.
+
+    Raises:
+        ConfigurationError: If official generation cannot represent the Input.
+        ValidationError: If required behavior sections are malformed.
+        LimitExceededError: If public text or metadata exceeds a size bound.
+        SensitiveDataError: If the upload scanner rejects the public fields.
+
+    Postconditions:
+        The payload contains no raw requirement body, repository contents,
+        private rubric, service key, or model configuration.
+
+    Side Effects:
+        None. This helper does not perform entitlement or Case network requests.
+    """
     if context.input_type != "text":
         raise ConfigurationError(
             "The official Case service currently supports text Inputs only"
@@ -263,6 +368,10 @@ def _safe_case_payload(
         "count": 1,
         **safe_fields,
     }
+    # Omission and explicit 10 are the same frozen public request. Keeping both
+    # off the wire preserves the legacy request identity and idempotency key.
+    if max_steps is not None and max_steps != DEFAULT_CASE_MAX_STEPS:
+        payload["max_steps"] = max_steps
     if evidence_capabilities:
         payload["evidence_capabilities"] = list(evidence_capabilities)
     return payload, repo_meta["repo_fingerprint"]
@@ -274,6 +383,7 @@ def _case_operation_store(
     payload: Mapping[str, Any],
     base_url: str,
 ) -> PendingOperationStore:
+    """Bind resumable Case metadata to the request hash and Backend identity."""
     identity = request_identity(payload, base_url=base_url)
     return PendingOperationStore(
         context.repo_path / ".kuma" / "operations" / "cases" / f"{identity}.json",
@@ -287,11 +397,34 @@ def _normalized_case(
     *,
     context: CaseGenerationContext,
     repo_fingerprint: str,
+    max_steps: int,
 ) -> Mapping[str, Any]:
+    """Convert a bounded Backend result to public Case data with opaque provenance.
+
+    Args:
+        response: Terminal operation result returned by the public Backend.
+        context: Immutable repository, requirement, and strategy correlation for
+            the current Run.
+        repo_fingerprint: Digest sent in the Case request and required in every
+            returned Case.
+        max_steps: Effective public step ceiling. Omitted and explicit-default
+            requests both use 10, rather than the legacy internal ceiling of 50.
+
+    Returns:
+        Normalized text Case mapping with validated, opaque official provenance.
+
+    Raises:
+        ProviderError: If the response exceeds ``max_steps`` or violates the
+            closed public Case/integrity contract.
+
+    Postconditions:
+        The result contains the complete Case; it is never truncated to fit the
+        requested upper bound.
+    """
     case_id, batch_id, strategy_id, strategy_version, raw_case, inputs = (
         _official_case_response(
             response,
-            max_inputs=context.max_inputs,
+            max_steps=max_steps,
             requested_strategy_id=context.strategy,
             repo_fingerprint=repo_fingerprint,
         )
@@ -316,7 +449,13 @@ def _normalized_case(
 
 
 class OfficialCaseProvider:
-    """Generate and validate text Cases through the public Website Backend."""
+    """Generate and validate public text Cases through the Website Backend.
+
+    The provider submits an idempotent asynchronous v2 operation, polls its
+    opaque operation ID, validates the complete public result and provenance,
+    and only then clears resumable metadata. It never calls Core MCP, a model,
+    or a database directly.
+    """
 
     requirement_required = True
 
@@ -326,13 +465,67 @@ class OfficialCaseProvider:
         *,
         allow_sensitive: bool = False,
         operation_wait_timeout: float = 600.0,
+        max_steps: int | None = None,
     ) -> None:
+        """Configure public Case transport, privacy policy, and wait deadline.
+
+        Args:
+            client: Authenticated public Backend client.
+            allow_sensitive: Whether ordinary requirement metadata accepted by
+                the scanner may be transmitted. Private fields/secrets remain
+                forbidden regardless of this value.
+            operation_wait_timeout: Total positive seconds allowed for POST plus
+                all polls of one accepted operation.
+            max_steps: Optional caller-requested Case step ceiling sent to the
+                Backend. When supplied directly, it must equal the later
+                ``CaseGenerationContext.max_steps``. Values above the advertised
+                service ceiling fail before operation creation; ``None`` lets
+                the context select a non-default ceiling or the default of 10.
+
+        Preconditions:
+            ``client`` targets the public Backend and owns a validated key. If
+            ``max_steps`` is supplied, callers must pass the same value in every
+            context generated by this provider.
+
+        Postconditions:
+            No request has occurred; Evidence capability negotiation starts empty.
+
+        Raises:
+            ConfigurationError: If ``max_steps`` is not a positive integer or
+                ``None``.
+        """
+        if max_steps is not None and (
+            isinstance(max_steps, bool)
+            or not isinstance(max_steps, int)
+            or max_steps < 1
+        ):
+            raise ConfigurationError("max_steps must be a positive integer")
         self.client = client
         self.allow_sensitive = allow_sensitive
         self.operation_wait_timeout = operation_wait_timeout
+        self.max_steps = max_steps
         self._evidence_capabilities: tuple[str, ...] = ()
+        self._entitlements: Mapping[str, Any] | None = None
+
+    def _configure_entitlements(self, value: Mapping[str, Any]) -> None:
+        """Reuse one entitlement response for capability and limit checks.
+
+        Args:
+            value: Public entitlement mapping already fetched by ``create_run``.
+
+        Postconditions:
+            A later fresh Case request validates ``max_steps`` against this exact
+            response instead of issuing a duplicate GET. Pending-operation resume
+            still skips the preflight entirely.
+
+        Side Effects:
+            Replaces only this provider's in-memory entitlement snapshot; no
+            filesystem or network operation occurs.
+        """
+        self._entitlements = value
 
     def _configure_evidence_capabilities(self, values: tuple[str, ...]) -> None:
+        """Store canonical capabilities only when claim plus observable facts are available."""
         declared = set(values)
         ordered = tuple(
             item for item in CASEGEN_EVIDENCE_CAPABILITY_ORDER if item in declared
@@ -347,18 +540,95 @@ class OfficialCaseProvider:
             raise ConfigurationError("Runtime Evidence capabilities are invalid")
         self._evidence_capabilities = values
 
-    def generate_case(self, context: CaseGenerationContext) -> Mapping[str, Any]:
-        """Return a public Case shape after strategy and integrity validation."""
+    def _max_steps_request(
+        self, context: CaseGenerationContext
+    ) -> tuple[int | None, int | None]:
+        """Resolve wire omission and preflight without weakening the context cap.
 
+        Args:
+            context: Public Provider request whose ``max_steps`` is the
+                authoritative result upper bound.
+
+        Returns:
+            ``(wire_value, preflight_value)``. The wire value is omitted for the
+            frozen default of 10 so omission and explicit 10 share identity. A
+            preflight value is present whenever the caller explicitly configured
+            this provider or the context requests a non-default ceiling.
+
+        Raises:
+            ConfigurationError: If the constructor's explicit value differs from
+                ``context.max_steps``. Rejection occurs before network or local
+                pending-state effects.
+
+        Postconditions:
+            The returned values can control transport behavior, but result
+            validation continues to use ``context.max_steps`` unchanged.
+
+        Side Effects:
+            None.
+        """
+        if self.max_steps is not None and self.max_steps != context.max_steps:
+            raise ConfigurationError(
+                "OfficialCaseProvider max_steps must match context.max_steps"
+            )
+        wire_value = (
+            None if context.max_steps == DEFAULT_CASE_MAX_STEPS else context.max_steps
+        )
+        preflight_value = (
+            context.max_steps
+            if self.max_steps is not None or wire_value is not None
+            else None
+        )
+        return wire_value, preflight_value
+
+    def generate_case(self, context: CaseGenerationContext) -> Mapping[str, Any]:
+        """Generate or resume one official Case and return validated public data.
+
+        Args:
+            context: Immutable requirement, repository metadata, strategy, and
+                maximum-step inputs prepared by ``create_run``.
+
+        Returns:
+            Mapping accepted by ``normalize_case`` with public inputs and opaque
+            validated official provenance. Private rubric content is absent.
+
+        Raises:
+            SensitiveDataError: If uploadable public inputs violate privacy policy.
+            ProviderError: If operation wire, Case integrity, strategy selection,
+                or public result is invalid.
+            KumaError: For authenticated transport, limits, service failure, or
+                bounded wait timeout.
+
+        Preconditions:
+            Requirement is present and ``context.max_steps`` is positive.
+
+        Postconditions:
+            Success has one through ``max_steps`` complete inputs. A terminal
+            validated result clears pending state; timeout/transport interruption
+            retains it so retry resumes the same operation and key.
+
+        Side Effects:
+            May persist non-secret pending metadata and perform public Backend
+            POST/GET requests. It never truncates a valid Case.
+
+        Security/Privacy:
+            Only allowlisted public requirement/repository metadata is sent. No
+            private rubric, hidden answer, provider key, MCP address, or model
+            configuration enters the SDK result.
+        """
+
+        wire_max_steps, preflight_max_steps = self._max_steps_request(context)
         payload, repo_fingerprint = _safe_case_payload(
             context,
             allow_sensitive=self.allow_sensitive,
             evidence_capabilities=self._evidence_capabilities,
+            max_steps=wire_max_steps,
         )
         return self._run_operation(
             context,
             payload,
             repo_fingerprint=repo_fingerprint,
+            preflight_max_steps=preflight_max_steps,
         )
 
     def _run_operation(
@@ -367,14 +637,60 @@ class OfficialCaseProvider:
         payload: Mapping[str, Any],
         *,
         repo_fingerprint: str,
+        preflight_max_steps: int | None,
     ) -> Mapping[str, Any]:
+        """Run or resume v2 Case generation and validate before clearing state.
+
+        Args:
+            context: Current Run's immutable Case-generation correlation data.
+            payload: Privacy-checked public request whose canonical bytes define
+                pending-state identity and Backend idempotency semantics.
+            repo_fingerprint: Digest that the returned public Case must repeat.
+            preflight_max_steps: Explicit/non-default ceiling to validate against
+                entitlements before a fresh POST, or ``None`` for service-default
+                omission.
+
+        Returns:
+            Normalized official Case mapping accepted by ``normalize_case``.
+
+        Raises:
+            LimitExceededError: A new explicit request exceeds the entitlement
+                ceiling; no Case POST has occurred.
+            ProviderError: Entitlements, operation envelopes, or Case result are
+                malformed or fail integrity validation.
+            KumaError: Public transport, service, or bounded-wait failure.
+
+        Preconditions:
+            ``payload`` was produced by ``_safe_case_payload`` for ``context``.
+
+        Postconditions:
+            Success clears pending metadata only after Case acceptance. Existing
+            pending state bypasses the entitlement preflight and resumes the same
+            operation/key, so later service-limit changes cannot cause a repost.
+
+        Side Effects:
+            May GET entitlements, atomically write/delete safe pending metadata,
+            POST one idempotent Case operation, poll it, and sleep within the
+            configured deadline.
+
+        Security/Privacy:
+            Pending files contain only operation metadata; neither request
+            content nor credentials are persisted.
+        """
         store = _case_operation_store(
             context,
             payload=payload,
             base_url=self.client.base_url,
         )
 
+        if preflight_max_steps is not None and store.load() is None:
+            entitlements = self._entitlements
+            if entitlements is None:
+                entitlements = self.client.json("GET", "/sdk/entitlements/")
+            _validate_requested_max_steps(entitlements, preflight_max_steps)
+
         def start_operation(key: str, deadline: float) -> Mapping[str, Any]:
+            """POST the Case payload once per stable key within the shared deadline."""
             kwargs: dict[str, Any] = {"idempotency_key": key}
             if isinstance(self.client, BackendClient):
                 kwargs["_deadline"] = deadline
@@ -387,10 +703,12 @@ class OfficialCaseProvider:
             )
 
         def accept_result(response: Mapping[str, Any]) -> Mapping[str, Any]:
+            """Validate and normalize success before resumable state may be cleared."""
             return _normalized_case(
                 response,
                 context=context,
                 repo_fingerprint=repo_fingerprint,
+                max_steps=context.max_steps,
             )
 
         return await_operation(

--- a/src/kuma/providers/official_judge.py
+++ b/src/kuma/providers/official_judge.py
@@ -36,6 +36,17 @@ _MAX_TRACKED_RUNS = 1024
 
 @dataclass(frozen=True, slots=True)
 class _JudgeUpload:
+    """Stage one validated official Judge request and stable identity.
+
+    Attributes:
+        run_id: Public Run identifier being judged.
+        metadata: Safe manifest/history mapping sent as multipart metadata.
+        case_id: Official Case reference, or ``None`` for custom Case upload.
+        case_part: Serialized public custom Case part when required.
+        log_parts: Bounded Evidence parts in deterministic order.
+        idempotency_key: Stable key reused for retries of this exact Run history.
+    """
+
     run_id: str
     metadata: Mapping[str, Any]
     case_id: str | None
@@ -47,6 +58,7 @@ class _JudgeUpload:
 def _custom_case_part(
     context: JudgeContext, config: _JudgeConfig, part_prefix: str
 ) -> tuple[UploadPart, list[Any]]:
+    """Serialize a custom public Case for Judge upload and return privacy findings."""
     custom_case = {
         "schema_version": "defuzex.custom_case.v1",
         "case_id": context.case.case_id,
@@ -87,6 +99,7 @@ def _custom_case_part(
 def _official_case_reference(
     context: JudgeContext,
 ) -> tuple[str, dict[str, str]] | None:
+    """Validate official provenance and return its opaque Backend reference metadata."""
     if "official_case" not in context.case.extensions:
         return None
     official = context.case.extensions["official_case"]
@@ -101,6 +114,7 @@ def _official_case_reference(
 def _validate_batch_contexts(
     contexts: Sequence[JudgeContext], *, max_batch_items: int | None = None
 ) -> None:
+    """Require a non-empty bounded sequence of typed Judge contexts."""
     if not isinstance(contexts, Sequence) or isinstance(
         contexts, (str, bytes, bytearray)
     ):
@@ -119,6 +133,7 @@ def _validate_batch_contexts(
 
 
 def _batch_item(upload: _JudgeUpload) -> tuple[dict[str, Any], list[UploadPart]]:
+    """Project one prepared upload into batch metadata and uniquely named parts."""
     item = {
         "client_item_id": upload.run_id,
         "idempotency_key": upload.idempotency_key,
@@ -136,6 +151,7 @@ def _batch_item(upload: _JudgeUpload) -> tuple[dict[str, Any], list[UploadPart]]
 
 
 def _batch_result(upload: _JudgeUpload, raw: Any) -> JudgeBatchResult:
+    """Validate one ordered batch item as either a Judgment or safe public error."""
     if (
         not isinstance(raw, Mapping)
         or raw.get("client_item_id") != upload.run_id
@@ -173,7 +189,12 @@ def _batch_result(upload: _JudgeUpload, raw: Any) -> JudgeBatchResult:
 
 
 class OfficialJudgeProvider:
-    """Upload public Run Evidence and wait on the Website Backend v2 operation."""
+    """Upload bounded public Run Evidence and resume one official Judge operation.
+
+    Per-Run locks, stable idempotency keys, and pending metadata prevent concurrent
+    or restarted calls from creating duplicate Judge operations. Private rubric
+    lookup and model execution remain entirely server-owned.
+    """
 
     def __init__(
         self,
@@ -183,6 +204,7 @@ class OfficialJudgeProvider:
         operation_wait_timeout: float = 600.0,
         state_root: Path | None = None,
     ) -> None:
+        """Configure bounded public Judge uploads and per-Run resumable state."""
         self.client = client
         self.allow_sensitive = allow_sensitive
         self.operation_wait_timeout = operation_wait_timeout
@@ -193,6 +215,7 @@ class OfficialJudgeProvider:
         self._idempotency_lock = threading.Lock()
 
     def _run_lock(self, run_id: str) -> threading.Lock:
+        """Return a stable per-Run lock so concurrent Judge calls submit only once."""
         with self._idempotency_lock:
             lock = self._run_locks.get(run_id)
             if lock is None:
@@ -206,6 +229,7 @@ class OfficialJudgeProvider:
             return lock
 
     def _operation_store(self, run_id: str) -> PendingOperationStore:
+        """Return the bounded pending-operation store owned by one Run."""
         with self._idempotency_lock:
             store = self._operation_stores.get(run_id)
             if store is not None:
@@ -224,6 +248,7 @@ class OfficialJudgeProvider:
             return store
 
     def _idempotency_key(self, run_id: str) -> str:
+        """Reuse one Judge key per tracked Run while bounding in-memory entries."""
         with self._idempotency_lock:
             key = self._idempotency_keys.get(run_id)
             if key is None:
@@ -244,6 +269,7 @@ class OfficialJudgeProvider:
         part_prefix: str = "",
         idempotency_key: str | None = None,
     ) -> _JudgeUpload:
+        """Build and privacy-check an official or custom Case Judge upload."""
         run_id = self._run_id(context)
         log_parts, manifest, findings = _evidence_upload(context, config, part_prefix)
         metadata: dict[str, Any] = {
@@ -272,13 +298,46 @@ class OfficialJudgeProvider:
         )
 
     def judge(self, context: JudgeContext) -> Mapping[str, Any]:
-        """Judge one completed Run using a stable per-Run idempotency key."""
+        """Judge one completed Run through a serialized per-Run operation.
+
+        Args:
+            context: Immutable completed Case/history/Evidence context.
+
+        Returns:
+            Validated public Judgment mapping ready for report normalization.
+
+        Raises:
+            SensitiveDataError: If selected upload content violates policy.
+            LimitExceededError: If local/dynamic upload or tracked-Run limits are
+                exceeded before an unsafe request.
+            ProviderError: If public configuration, operation state, or response
+                is malformed.
+            KumaError: For authenticated transport, terminal service failure, or
+                bounded operation timeout.
+
+        Preconditions:
+            History is complete, internally correlated, and belongs to one Run.
+
+        Postconditions:
+            Concurrent calls for the same Run execute one critical section.
+            Success clears pending operation state only after Judgment validation;
+            retryable failure preserves identity for safe resume.
+
+        Side Effects:
+            Reads public Judge limits, may persist non-secret pending metadata,
+            uploads bounded multipart Evidence, and polls the public Backend.
+
+        Security/Privacy:
+            No private rubric is read or uploaded by the SDK. Raw remote/internal
+            error text is not exposed.
+        """
 
         run_id = self._run_id(context)
         with self._run_lock(run_id):
             return self._judge_locked(context, run_id)
 
     def _judge_locked(self, context: JudgeContext, run_id: str) -> Mapping[str, Any]:
+        """Resume an accepted Judge operation or prepare and submit one new operation."""
         store = self._operation_store(run_id)
         pending = store.load()
         if pending is not None and pending.operation_id is not None:
@@ -295,6 +354,7 @@ class OfficialJudgeProvider:
     def _resume_judgment(
         self, store: PendingOperationStore, idempotency_key: str
     ) -> Mapping[str, Any]:
+        """Poll the stored Judge operation without issuing a replacement POST."""
         response = await_operation(
             self.client,
             store,
@@ -307,6 +367,7 @@ class OfficialJudgeProvider:
     def _submit_judgment(
         self, store: PendingOperationStore, upload: _JudgeUpload
     ) -> Mapping[str, Any]:
+        """Submit one multipart Judge operation and retain its key for safe replay."""
         fields = {"metadata": json.dumps(upload.metadata, separators=(",", ":"))}
         parts = list(upload.log_parts)
         if upload.case_id is not None:
@@ -315,6 +376,7 @@ class OfficialJudgeProvider:
             parts.insert(0, upload.case_part)
 
         def start_operation(key: str, deadline: float) -> Mapping[str, Any]:
+            """POST the prepared Judge upload once per stable key and deadline."""
             kwargs: dict[str, Any] = {"idempotency_key": key}
             if isinstance(self.client, BackendClient):
                 kwargs["_deadline"] = deadline
@@ -338,7 +400,30 @@ class OfficialJudgeProvider:
     def judge_batch(
         self, contexts: Sequence[JudgeContext]
     ) -> tuple[JudgeBatchResult, ...]:
-        """Judge completed Runs synchronously, preserving order and item errors."""
+        """Judge a bounded sequence through the legacy synchronous batch endpoint.
+
+        Args:
+            contexts: Non-empty unique-Run completed contexts, no larger than the
+                Backend-advertised ``max_batch_items``.
+
+        Returns:
+            Tuple in request order. Each :class:`JudgeBatchResult` contains
+            exactly one normalized report or stable public item error.
+
+        Raises:
+            ConfigurationError: If contexts are empty, duplicated, or invalid.
+            LimitExceededError: If batch/upload limits are exceeded.
+            SensitiveDataError: If an upload violates privacy policy.
+            KumaError: If the batch transport or outer response fails.
+
+        Postconditions:
+            Item failures remain item failures and are never fabricated as
+            reports; ordering is stable.
+
+        Side Effects:
+            Performs public config GET and one idempotent multipart POST. Unlike
+            single Judge, batch remains synchronous v1 and stores no operation ID.
+        """
 
         _validate_batch_contexts(contexts)
         config = _judge_config(self.client.json("GET", "/sdk/judge/config/"))
@@ -374,6 +459,7 @@ class OfficialJudgeProvider:
 
     @staticmethod
     def _run_id(context: JudgeContext) -> str:
+        """Require non-empty history belonging to exactly one Run identifier."""
         if not context.history:
             raise ProviderError("Judge requires at least one submitted Input")
         run_id = context.history[0].submission.run_id
@@ -383,6 +469,7 @@ class OfficialJudgeProvider:
 
     @staticmethod
     def _submission_status(context: JudgeContext) -> str:
+        """Return the latest non-completed Submission status or overall Run status."""
         for item in reversed(context.history):
             if item.submission.status != "completed":
                 return item.submission.status

--- a/src/kuma/repository/metadata.py
+++ b/src/kuma/repository/metadata.py
@@ -40,11 +40,20 @@ _EXCLUDED_DIRECTORIES = frozenset(
 
 @dataclass(frozen=True, slots=True)
 class RepoTreeEntry:
+    """Describe one public metadata-only repository tree entry.
+
+    Attributes:
+        path: Validated relative POSIX path; absolute and traversal paths fail.
+        type: ``file`` or ``directory``.
+        size_bytes: Non-negative file size, or ``None`` for directories.
+    """
+
     path: str
     type: str
     size_bytes: int | None = None
 
     def __post_init__(self) -> None:
+        """Validate one metadata-only repository entry and freeze its fields."""
         _validate_relative_path(self.path)
         if self.type not in {"file", "directory"}:
             raise ValidationError("Repo Meta entry type must be file or directory")
@@ -63,6 +72,7 @@ class RepoTreeEntry:
             )
 
     def to_dict(self) -> dict[str, Any]:
+        """Return the validated metadata as a detached public-wire mapping."""
         result: dict[str, Any] = {"path": self.path, "type": self.type}
         if self.size_bytes is not None:
             result["size_bytes"] = self.size_bytes
@@ -71,7 +81,20 @@ class RepoTreeEntry:
 
 @dataclass(frozen=True, slots=True)
 class RepoMeta:
-    """Backend-compatible metadata with no source, README, Git, or host paths."""
+    """Carry bounded Backend-compatible repository metadata without file content.
+
+    Attributes:
+        repo_fingerprint: Stable ``sha256:<hex>`` digest of the canonical tree.
+        tree: Ordered immutable public file/directory metadata entries.
+        truncated: Whether the entry cap omitted additional paths.
+        omitted_sensitive_paths: Count of credential/private-looking paths that
+            were intentionally excluded.
+        schema_version: Exact public metadata schema version.
+
+    Security/Privacy:
+        The object contains no source, README contents, Git history, absolute
+        host paths, environment values, or credentials.
+    """
 
     repo_fingerprint: str
     tree: tuple[RepoTreeEntry, ...]
@@ -80,6 +103,7 @@ class RepoMeta:
     schema_version: str = REPO_META_SCHEMA_VERSION
 
     def __post_init__(self) -> None:
+        """Validate fingerprint and freeze the bounded metadata tree."""
         if self.schema_version != REPO_META_SCHEMA_VERSION:
             raise ValidationError("Unsupported Repo Meta schema version")
         _normalize_fingerprint(self.repo_fingerprint)
@@ -104,6 +128,7 @@ class RepoMeta:
         return f"{_SHA256_PREFIX}{_normalize_fingerprint(self.repo_fingerprint)}"
 
     def to_dict(self) -> dict[str, Any]:
+        """Return the validated metadata as a detached public-wire mapping."""
         extension: dict[str, Any] = {}
         if self.truncated:
             extension["truncated"] = True
@@ -120,6 +145,7 @@ class RepoMeta:
 
 
 def _normalize_fingerprint(value: Any) -> str:
+    """Normalize and validate a canonical SHA-256 repository fingerprint."""
     if not isinstance(value, str):
         raise ValidationError("repo_fingerprint must be a SHA-256 digest")
     normalized = value.removeprefix(_SHA256_PREFIX).lower()
@@ -131,6 +157,7 @@ def _normalize_fingerprint(value: Any) -> str:
 
 
 def _validate_relative_path(value: Any) -> str:
+    """Reject absolute, traversing, backslash, control-character, or oversized paths."""
     if (
         not isinstance(value, str)
         or not value
@@ -146,6 +173,7 @@ def _validate_relative_path(value: Any) -> str:
 
 
 def _entry_from_mapping(value: Any) -> RepoTreeEntry:
+    """Validate one public tree-entry mapping and normalize its relative path."""
     if not isinstance(value, Mapping):
         raise ValidationError("Repo Meta tree entries must be mappings")
     if set(value) - {"path", "type", "size_bytes"}:
@@ -158,7 +186,36 @@ def _entry_from_mapping(value: Any) -> RepoTreeEntry:
 
 
 def prepare_repo_meta_upload(value: Mapping[str, Any] | RepoMeta) -> dict[str, Any]:
-    """Validate and reduce arbitrary Repo Meta to the public Backend allowlist."""
+    """Validate and reduce repository metadata to the public Backend allowlist.
+
+    Official Case generation calls this boundary before network I/O. It retains
+    only the canonical fingerprint and bounded metadata-only tree; paths are
+    normalized and privacy-scanned, while file contents and unknown fields are
+    never projected to transport.
+
+    Args:
+        value: Untrusted metadata mapping or validated :class:`RepoMeta`.
+
+    Returns:
+        Detached closed-schema public mapping safe for official Case transport.
+
+    Raises:
+        ValidationError: If schema, fingerprint, tree entries, types, counts,
+            limits, or extension fields are invalid.
+        SensitiveDataError: If a path is classified as sensitive.
+
+    Preconditions:
+        The network request has not started; this is the final repository
+        metadata serialization boundary.
+
+    Postconditions:
+        Output contains only schema, fingerprint, bounded relative tree metadata,
+        and allowlisted truncation counters.
+
+    Security/Privacy:
+        Source/README content, Git data, absolute paths, environment values,
+        credentials, and arbitrary fields cannot pass the allowlist.
+    """
 
     raw = value.to_dict() if isinstance(value, RepoMeta) else dict(value)
     if raw.get("schema_version") != REPO_META_SCHEMA_VERSION:
@@ -215,10 +272,24 @@ def prepare_repo_meta_upload(value: Mapping[str, Any] | RepoMeta) -> dict[str, A
 def _scan_entry(
     entry: os.DirEntry[str], repo_path: Path
 ) -> tuple[RepoTreeEntry | None, Path | None, bool]:
-    relative = Path(entry.path).relative_to(repo_path).as_posix()
-    if scan_sensitive_path(relative, location="repo_meta_path"):
-        return None, None, True
+    """Privacy-scan one metadata entry without reading its file content.
+
+    Args:
+        entry: Directory entry obtained beneath the canonical repository root.
+        repo_path: Root used to derive a non-sensitive relative POSIX path.
+
+    Returns:
+        Public tree entry, optional child directory, and sensitive-omission flag.
+
+    Raises:
+        ValidationError: If entry metadata cannot be inspected safely; the raw
+            filesystem failure and absolute path are detached.
+    """
+    inspection_failed = False
     try:
+        relative = Path(entry.path).relative_to(repo_path).as_posix()
+        if scan_sensitive_path(relative, location="repo_meta_path"):
+            return None, None, True
         if entry.is_symlink():
             return None, None, False
         if entry.is_dir(follow_symlinks=False):
@@ -227,30 +298,48 @@ def _scan_entry(
             return RepoTreeEntry(relative, "directory"), Path(entry.path), False
         if entry.is_file(follow_symlinks=False):
             return RepoTreeEntry(relative, "file", entry.stat().st_size), None, False
-    except OSError as exc:
+    except (TypeError, ValueError, OSError):
+        inspection_failed = True
+    if inspection_failed:
         raise ValidationError(
             "Repository metadata could not inspect an entry", code="config_invalid"
-        ) from exc
+        ) from None
     return None, None, False
 
 
 def _scan_tree(
     repo_path: Path, max_entries: int
 ) -> tuple[list[RepoTreeEntry], bool, int]:
+    """Privacy-scan the bounded tree and return safe detached entries.
+
+    Args:
+        repo_path: Canonical repository root; files are never opened for content.
+        max_entries: Positive upper bound on retained metadata entries.
+
+    Returns:
+        Ordered entries, truncation flag, and sensitive-path omission count.
+
+    Raises:
+        ValidationError: If a directory or entry cannot be inspected without
+            exposing host filesystem diagnostics.
+    """
     tree: list[RepoTreeEntry] = []
     pending = [repo_path]
     omitted_sensitive_paths = 0
     while pending and len(tree) < max_entries:
         current = pending.pop()
+        directory_failed = False
         try:
             entries = sorted(
                 os.scandir(current), key=lambda entry: entry.name.casefold()
             )
-        except OSError as exc:
+        except OSError:
+            directory_failed = True
+        if directory_failed:
             raise ValidationError(
                 "Repository metadata could not read a directory",
                 code="config_invalid",
-            ) from exc
+            ) from None
         child_directories: list[Path] = []
         for entry in entries:
             if len(tree) >= max_entries:
@@ -273,11 +362,21 @@ def collect_repo_meta(
 ) -> RepoMeta:
     """Collect names, entry types, and file sizes without reading file contents."""
 
-    root = Path(repo_path).expanduser().resolve()
-    if not root.is_dir():
+    root_failed = False
+    try:
+        root = Path(repo_path).expanduser().resolve()
+        if not root.is_dir():
+            raise ValidationError(
+                "repo_path must be a readable directory", code="config_invalid"
+            )
+    except ValidationError:
+        raise
+    except (TypeError, ValueError, OSError, RuntimeError):
+        root_failed = True
+    if root_failed:
         raise ValidationError(
             "repo_path must be a readable directory", code="config_invalid"
-        )
+        ) from None
     if (
         isinstance(max_entries, bool)
         or not isinstance(max_entries, int)
@@ -286,12 +385,15 @@ def collect_repo_meta(
         raise ValidationError(
             "Repo Meta limits must be positive", code="config_invalid"
         )
+    readability_failed = False
     try:
         next(root.iterdir(), None)
-    except OSError as exc:
+    except OSError:
+        readability_failed = True
+    if readability_failed:
         raise ValidationError(
             "repo_path must be readable", code="config_invalid"
-        ) from exc
+        ) from None
 
     tree, truncated, omitted_sensitive_paths = _scan_tree(root, max_entries)
     fingerprint_source = {

--- a/src/kuma/repository/privacy.py
+++ b/src/kuma/repository/privacy.py
@@ -55,6 +55,7 @@ PRIVATE_DATA_FIELDS = frozenset(
         "answer_key",
         "deepseek_key",
         "expected_answer",
+        "expected_output",
         "hidden_answer",
         "hidden_inputs",
         "internal_labels",
@@ -71,17 +72,26 @@ PRIVATE_DATA_FIELDS = frozenset(
 
 @dataclass(frozen=True, slots=True)
 class SensitiveFinding:
+    """Identify a sensitive-data category without retaining the matched value.
+
+    Attributes:
+        kind: Stable category such as credential file, API token, or private field.
+        location: Caller-supplied safe component/path label, not secret content.
+    """
+
     kind: str
     location: str
 
     @property
     def reason(self) -> str:
+        """Return the stable public reason code for this sensitive-data finding."""
         return f"sensitive_{self.kind}:{self.location}"
 
 
 def scan_sensitive_path(
     path: str | Path, *, location: str = "file"
 ) -> tuple[SensitiveFinding, ...]:
+    """Return a finding when a path suggests credentials or private data."""
     candidate = Path(path)
     basename = candidate.name.casefold()
     if (
@@ -94,6 +104,7 @@ def scan_sensitive_path(
 
 
 def scan_sensitive_text(text: str, *, location: str) -> tuple[SensitiveFinding, ...]:
+    """Scan bounded text for credential and private-data signatures."""
     findings = [
         SensitiveFinding(kind, location)
         for kind, pattern in _TEXT_PATTERNS
@@ -103,9 +114,11 @@ def scan_sensitive_text(text: str, *, location: str) -> tuple[SensitiveFinding, 
 
 
 def scan_sensitive_json(value: Any, *, location: str) -> tuple[SensitiveFinding, ...]:
+    """Recursively scan JSON keys and scalar values for sensitive data."""
     findings: list[SensitiveFinding] = []
 
     def visit(item: Any) -> None:
+        """Visit nested JSON values while applying the sensitive-data scanner."""
         if isinstance(item, Mapping):
             for key, child in item.items():
                 if (
@@ -136,6 +149,7 @@ def contains_private_data(value: Any, *, extra_fields: Sequence[str] = ()) -> bo
     prohibited = PRIVATE_DATA_FIELDS | {field.casefold() for field in extra_fields}
 
     def visit(item: Any) -> bool:
+        """Visit nested JSON values while applying the sensitive-data scanner."""
         if isinstance(item, Mapping):
             if {str(key).casefold() for key in item} & prohibited:
                 return True
@@ -152,6 +166,7 @@ def enforce_sensitive_policy(
     *,
     allow_sensitive: bool,
 ) -> None:
+    """Raise before transport when findings are not explicitly allowed."""
     if not findings or allow_sensitive:
         return
     reasons = tuple(dict.fromkeys(item.reason for item in findings))

--- a/src/kuma/repository/requirements.py
+++ b/src/kuma/repository/requirements.py
@@ -34,7 +34,24 @@ _FENCE_PATTERN = re.compile(r"```(?:json)?\s*\n(.*?)\n```", re.DOTALL | re.IGNOR
 
 @dataclass(frozen=True, slots=True)
 class RequirementSpec:
-    """Validated requirement content ready for Case Provider context creation."""
+    """Hold a parsed public requirement for Case Provider context creation.
+
+    Attributes:
+        path: Absolute path of the explicitly selected UTF-8 requirement file.
+        content: Complete validated public requirement text.
+        agent_description: Pure front-matter Agent description, kept separate
+            from the requirement body for official auto-strategy selection.
+        input_type: Required Case input kind, ``text`` or ``structured``.
+        body: Requirement body after front matter removal.
+        sections: Read-only named Markdown sections parsed from ``body``.
+        input_schema: Read-only validated JSON Schema for structured inputs.
+        input_schema_path: Absolute path of an explicitly referenced schema file,
+            or ``None`` when schema is inline/absent.
+
+    Security/Privacy:
+        Parsing does not make content safe to upload automatically. Official
+        providers apply their own public allowlist and sensitive scan.
+    """
 
     path: Path
     content: str
@@ -46,6 +63,7 @@ class RequirementSpec:
     input_schema_path: Path | None = None
 
     def __post_init__(self) -> None:
+        """Freeze parsed requirement metadata while retaining its explicit source path."""
         object.__setattr__(self, "path", self.path.resolve())
         object.__setattr__(self, "sections", MappingProxyType(dict(self.sections)))
         if self.input_schema is not None:
@@ -57,7 +75,10 @@ class RequirementSpec:
 
 
 def _freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Recursively freeze parsed requirement mappings and sequences."""
+
     def freeze(item: Any) -> Any:
+        """Return an immutable copy of the parsed requirement metadata."""
         if isinstance(item, Mapping):
             return MappingProxyType(
                 {str(key): freeze(child) for key, child in item.items()}
@@ -70,6 +91,7 @@ def _freeze_mapping(value: Mapping[str, Any]) -> Mapping[str, Any]:
 
 
 def _split_front_matter(content: str) -> tuple[str, str]:
+    """Separate optional YAML front matter from the Markdown requirement body."""
     lines = content.splitlines()
     if not lines or lines[0].strip() != _FRONT_MATTER_BOUNDARY:
         raise ValidationError(
@@ -93,6 +115,7 @@ def _split_front_matter(content: str) -> tuple[str, str]:
 
 
 def _parse_front_matter(source: str) -> Mapping[str, Any]:
+    """Parse bounded YAML metadata and require a string-keyed mapping."""
     try:
         parsed = yaml.safe_load(source)
     except yaml.YAMLError as exc:
@@ -115,6 +138,7 @@ def _parse_front_matter(source: str) -> Mapping[str, Any]:
 
 
 def _extract_sections(body: str) -> dict[str, str]:
+    """Extract uniquely named level-two Markdown sections as immutable text."""
     matches = list(_HEADING_PATTERN.finditer(body))
     sections_by_heading: dict[str, str] = {}
     for index, match in enumerate(matches):
@@ -148,6 +172,7 @@ def _extract_sections(body: str) -> dict[str, str]:
 
 
 def _load_schema_from_section(section: str) -> Mapping[str, Any]:
+    """Parse an inline fenced JSON Schema without external reference retrieval."""
     match = _FENCE_PATTERN.search(section)
     if match is None:
         raise ValidationError(
@@ -168,6 +193,7 @@ def _load_schema_from_section(section: str) -> Mapping[str, Any]:
 
 
 def _load_schema_file(path: Path) -> Mapping[str, Any]:
+    """Read a bounded local JSON Schema file selected by the requirement."""
     if not path.is_file():
         raise ValidationError(
             f"Input schema file does not exist: {path}",
@@ -187,6 +213,7 @@ def _load_schema_file(path: Path) -> Mapping[str, Any]:
 
 
 def _reject_undeclared_schema_references(value: Any) -> None:
+    """Reject external JSON Schema references so validation performs no network I/O."""
     if isinstance(value, Mapping):
         reference = value.get("$ref")
         if isinstance(reference, str) and not reference.startswith("#"):
@@ -228,7 +255,43 @@ def validate_structured_input(payload: Any, schema: Mapping[str, Any]) -> None:
 
 
 def parse_requirement(path: str | Path) -> RequirementSpec:
-    """Parse an explicitly selected requirement file and fail entirely offline."""
+    """Parse one explicitly selected requirement and its local Input schema.
+
+    Run construction invokes this offline boundary before Case Provider I/O. It
+    validates front matter, required behavior sections, and text/structured Input
+    declarations; schema files must be local and external references are rejected.
+    Read or validation failures raise stable ``ValidationError`` values.
+
+    Args:
+        path: Explicit UTF-8 Markdown requirement file selected by the caller.
+            A leading UTF-8 byte-order mark is accepted and removed before
+            front-matter parsing; other encodings remain invalid.
+
+    Returns:
+        Immutable :class:`RequirementSpec` containing front matter, body,
+        sections, and a validated optional structured-input schema.
+
+    Raises:
+        ValidationError: If file existence/encoding, front matter, Agent
+            description, input type, schema path, or JSON Schema is invalid.
+
+    Preconditions:
+        The caller authorizes reading this file and any relative schema path it
+        explicitly declares.
+
+    Postconditions:
+        Success returns detached immutable mappings and absolute source paths;
+        no Run or process configuration state changes.
+
+    Side Effects:
+        Reads the requirement and, when declared, one local schema file only.
+        Decoding uses ``utf-8-sig`` so an optional leading UTF-8 BOM is treated
+        as transport metadata rather than requirement content.
+
+    Security/Privacy:
+        Parsing does not transmit content. Official-provider allowlisting and
+        sensitive scanning remain mandatory before network use.
+    """
 
     requirement_path = Path(path).expanduser().resolve()
     if not requirement_path.is_file():
@@ -237,7 +300,7 @@ def parse_requirement(path: str | Path) -> RequirementSpec:
             code="requirement_required",
         )
     try:
-        content = requirement_path.read_text(encoding="utf-8")
+        content = requirement_path.read_text(encoding="utf-8-sig")
     except (OSError, UnicodeError) as exc:
         raise ValidationError(
             "Requirement file must be readable UTF-8 text",

--- a/src/kuma/run.py
+++ b/src/kuma/run.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import json
+import os
 import threading
-from collections.abc import Mapping
-from pathlib import Path
+from collections.abc import Sequence
 from typing import Any, Literal
 
+from ._json_values import detach_json
 from .contracts import (
     CaptureStatus,
     Case,
@@ -43,28 +43,145 @@ _OUTPUT_UNSET = object()
 
 
 def _plain_json(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {str(key): _plain_json(child) for key, child in value.items()}
-    if isinstance(value, tuple):
-        return [_plain_json(child) for child in value]
-    if isinstance(value, list):
-        return [_plain_json(child) for child in value]
-    return value
+    """Return one detached bounded JSON graph for internal Run callers.
+
+    Args:
+        value: Candidate Input or Submission value.
+
+    Returns:
+        A mutable built-in JSON graph detached from caller-owned containers.
+
+    Raises:
+        JsonStructureError: Through :func:`detach_json` when the graph is
+            unsupported, cyclic, non-finite, or deeper than 256 containers.
+
+    Postconditions:
+        Success is safe for later immutable contract construction.
+
+    Side Effects:
+        Traverses custom Mapping values locally and performs no external I/O.
+    """
+    return detach_json(value)
 
 
 def _validate_json(value: Any, description: str) -> Any:
-    plain = _plain_json(value)
+    """Validate Agent output before Evidence, persistence, Judge, or billing.
+
+    Args:
+        value: Explicit or OTel-derived Agent result to detach. Cyclic graphs and
+            values deeper than 256 nested containers are invalid.
+        description: Safe field label used in the stable public error message;
+            callers pass a constant rather than user-controlled text.
+
+    Returns:
+        A detached finite JSON value made of built-in dictionaries/lists and
+        scalars. Shared aliases are copied and remain valid.
+
+    Raises:
+        ValidationError: If traversal, a custom Mapping, or JSON encoding fails.
+            The stable code is ``output_invalid`` and the original exception or
+            caller value is never included in display text.
+
+    Preconditions:
+        Run state has not entered Evidence preparation or submission commit.
+
+    Postconditions:
+        Success is safe to freeze into Submission history. Failure leaves the
+        current Input delivered and performs no persistence or network action.
+
+    Side Effects:
+        Iterates custom Mapping output locally; performs no external I/O.
+
+    Security/Privacy:
+        Arbitrary Mapping errors, recursion details, keys, values, and object
+        representations are replaced with one stable SDK message.
+    """
     try:
-        json.dumps(plain, allow_nan=False)
-    except (TypeError, ValueError) as exc:
+        return _plain_json(value)
+    except Exception:
         raise ValidationError(
             f"{description} must be JSON serializable", code="output_invalid"
-        ) from exc
-    return plain
+        ) from None
+
+
+def _validate_log_paths(
+    logs: Sequence[str | os.PathLike[str]] | None,
+) -> tuple[str, ...] | None:
+    """Validate explicit log-path syntax before Run state or Evidence I/O.
+
+    Args:
+        logs: ``None`` or an ordered sequence whose elements are text or
+            ``os.PathLike`` values resolving to text. A bare string and all
+            bytes-like containers are values, not path sequences, and are
+            rejected.
+
+    Returns:
+        ``None`` when capture was not requested; otherwise an immutable tuple
+        of detached path spellings for repository-root resolution.
+
+    Raises:
+        ValidationError: If the top-level value is not an ordered sequence or
+            any element is not a text path-like value.
+
+    Preconditions:
+        None. Validation deliberately runs before checking Run state so invalid
+        path containers cannot reach Evidence preparation or Judge transport.
+
+    Postconditions:
+        Success has not read a path, changed Run state, or performed network I/O.
+
+    Security/Privacy:
+        Conversion failures use one stable message and never include the
+        supplied object, path spelling, or underlying exception text.
+    """
+    if logs is None:
+        return None
+    if isinstance(logs, (str, bytes, bytearray)) or not isinstance(logs, Sequence):
+        raise ValidationError(
+            "logs must be None or an ordered sequence of text paths",
+            code="logs_invalid",
+        )
+    normalized: list[str] = []
+    for item in logs:
+        if isinstance(item, (bytes, bytearray)) or not isinstance(
+            item, (str, os.PathLike)
+        ):
+            raise ValidationError(
+                "logs must be None or an ordered sequence of text paths",
+                code="logs_invalid",
+            )
+        try:
+            value = os.fspath(item)
+        except Exception:
+            raise ValidationError(
+                "logs must be None or an ordered sequence of text paths",
+                code="logs_invalid",
+            ) from None
+        if not isinstance(value, str):
+            raise ValidationError(
+                "logs must be None or an ordered sequence of text paths",
+                code="logs_invalid",
+            )
+        normalized.append(value)
+    return tuple(normalized)
 
 
 class Run:
-    """Synchronous delivery, submission, and Judge lifecycle for one Case."""
+    """Coordinate the synchronous Input → Submission → Judge lifecycle.
+
+    A Run is created by :func:`kuma.create_run`; callers do not instantiate it
+    directly. It owns exactly one immutable Case, one active runtime lease, the
+    ordered committed history, transactional Evidence state, and at most one
+    final report. Public methods are protected by a re-entrant lock so concurrent
+    calls cannot commit the same input twice.
+
+    Attributes:
+        run_id: Public identifier for this execution.
+        case_id: Public Case identifier used by official Judge requests.
+        strategy: Requested/selected public Case strategy identifier.
+        max_steps: Actual number of inputs in this validated Case. This is not
+            the configured upper bound when the provider returned fewer steps.
+    """
 
     def __init__(
         self,
@@ -78,10 +195,36 @@ class Run:
         strategy: str,
         evidence: EvidenceCollector | None = None,
     ) -> None:
+        """Initialize one validated Run and take ownership of its runtime lease.
+
+        Args:
+            run_id: Newly generated public Run identifier.
+            case: Fully normalized immutable Case owned by this Run.
+            runtime: Open runtime session whose lock/resources this Run closes.
+            judge_provider: Configured Judge provider, or ``None`` when judging
+                is disabled or deliberately unavailable.
+            judge_enabled: Whether the last Submission should invoke Judge.
+            on_failure: ``continue`` or ``stop`` behavior after a non-completed
+                Submission.
+            strategy: Public Case strategy recorded for introspection.
+            evidence: Step Evidence collector, or ``None`` when capture is not
+                configured.
+
+        Preconditions:
+            ``case`` has at least one correlated input and ``runtime`` is open
+            with the active-Run lease already acquired.
+
+        Postconditions:
+            The Run is ``ready`` at input index zero and owns the supplied
+            runtime and Evidence lifecycle until completion or cancellation.
+
+        Side Effects:
+            None beyond taking ownership of already-created objects.
+        """
         self.run_id = run_id
         self.case_id = case.case_id or ""
         self.strategy = strategy
-        self.max_inputs = len(case.inputs)
+        self.max_steps = len(case.inputs)
         self._case = case
         self._runtime = runtime
         self._judge_provider = judge_provider
@@ -134,13 +277,30 @@ class Run:
                 only its JSON-compatible payload when ``False``.
 
         Returns:
-            The current payload or ``KumaInput``. Returns ``None`` after all
-            Inputs are committed. Repeated calls before :meth:`submit` return
-            the same Input and do not advance the Run.
+            Current payload or ``KumaInput``. Returns ``None`` after all inputs
+            are committed. Repeated calls before :meth:`submit` return the same
+            input and do not advance the Run.
 
         Raises:
-            InputProtocolError: The Run cannot currently deliver an Input.
-            EvidenceCaptureError: Step-level Evidence initialization fails.
+            InputProtocolError: If the Run cannot currently deliver an input.
+            EvidenceCaptureError: If step Evidence initialization fails.
+
+        Preconditions:
+            The Run is ``ready`` or already ``input_delivered``. The caller must
+            submit the delivered input before requesting the next one.
+
+        Postconditions:
+            First delivery changes ``ready`` to ``input_delivered`` and starts
+            that input's Evidence transaction. Repeated delivery changes
+            nothing. Returning ``None`` means no uncommitted inputs remain.
+
+        Side Effects:
+            May initialize bounded file, log, and Trace capture. It never calls
+            Judge or appends history.
+
+        Security/Privacy:
+            Only the public Case input is returned; private Rubrics and private
+            evaluation metadata are never exposed.
         """
 
         with self._mutex:
@@ -170,7 +330,7 @@ class Run:
         *,
         status: str = "completed",
         error: str | None = None,
-        logs: list[str | Path] | None = None,
+        logs: Sequence[str | os.PathLike[str]] | None = None,
         wait: bool = True,
     ) -> TestReport | None:
         """Validate and commit one result, then advance or judge synchronously.
@@ -180,32 +340,55 @@ class Run:
                 completed Submission, KUMA uses a supported OTel
                 ``invoke_agent``/``invoke_workflow`` output. Explicit output has
                 priority; ``None`` is invalid for ``status="completed"``.
-            status: ``"completed"``, ``"failed"``, ``"timeout"``, or
-                ``"aborted"``.
-            error: Optional caller-safe error summary for a non-completed
-                Submission. Do not pass secrets or raw tracebacks.
-            logs: Optional log-file paths whose bounded increments are captured.
-                Evidence must be enabled; scope and sensitive checks still apply.
-            wait: Must remain ``True`` when the final Submission triggers Judge;
-                the public Run API does not expose background polling.
+                Containers may nest up to 256 levels (root container is level
+                one). Cycles are invalid; shared acyclic children are allowed.
+            status: ``completed``, ``failed``, ``timeout``, or ``aborted``.
+            error: Optional caller-safe summary for a non-completed Submission.
+                Do not pass secrets or raw tracebacks.
+            logs: ``None`` or an ordered sequence of text/path-like log-file
+                paths. Relative paths resolve from this Run's repository, never
+                the process working directory. Bare ``str``/bytes-like values
+                are invalid. Accepted files remain subject to count/size,
+                repository-scope, suffix, symlink, and sensitive-data checks.
+            wait: Must remain ``True`` when the last Submission triggers Judge;
+                the public Run API exposes synchronous completion only.
 
         Returns:
-            Final :class:`TestReport` only when this is the last Input and Judge
-            completes; otherwise ``None``. The committed Submission is available
-            through :attr:`history`.
+            Final :class:`TestReport` only when this is the last input and Judge
+            completes; otherwise ``None``. The committed result is always
+            available through :attr:`history`.
 
         Raises:
-            InputProtocolError: No Input is currently delivered.
-            ValidationError: Output, status, error, or serialization is invalid.
-            EvidenceCaptureError: Requested Evidence cannot be captured safely.
-            KumaError: The final official or custom Judge fails.
+            InputProtocolError: If no input is currently delivered.
+            ValidationError: If output, status, error, or serialization is invalid.
+            EvidenceCaptureError: If requested Evidence cannot be captured safely.
+            KumaError: If the final official or custom Judge fails.
 
-        Evidence offsets, local files, and Trace byte budgets advance only after
-        the immutable Submission is appended successfully.
+        Preconditions:
+            Exactly one input has been delivered and not yet submitted. A
+            completed Submission needs explicit output or a supported OTel final
+            output. Log paths must be in the allowed Evidence scope.
+
+        Postconditions:
+            Success appends exactly one immutable history item and commits
+            Evidence offsets, local records, and Trace budgets together. The Run
+            becomes ``ready``, ``completed``, or ``report_ready``. Validation or
+            preparation failure leaves the input delivered. Judge failure leaves
+            completed history available for retry.
+
+        Side Effects:
+            Reads bounded log/file state, may atomically write local Evidence,
+            and may synchronously poll the configured Judge after the final input.
+
+        Security/Privacy:
+            Output, error, logs, diffs, and Evidence may cross the public Judge
+            boundary. Do not pass credentials, raw tracebacks, prompts, private
+            rubrics, or unauthorized repository content.
         """
 
+        log_paths = _validate_log_paths(logs)
         with self._mutex:
-            current = self._submission_input(logs)
+            current = self._submission_input(log_paths)
             plain_output = self._validated_output(
                 output,
                 current=current,
@@ -217,7 +400,7 @@ class Run:
                 output=plain_output,
                 status=status,
                 error=error,
-                logs=logs,
+                logs=log_paths,
             )
             submission = self._submission(
                 current=current,
@@ -229,7 +412,8 @@ class Run:
             self._record_submission(current, submission, prepared)
             return self._advance_after_submission(status=status, wait=wait)
 
-    def _submission_input(self, logs: list[str | Path] | None) -> KumaInput:
+    def _submission_input(self, logs: Sequence[str] | None) -> KumaInput:
+        """Require one delivered Input and an Evidence collector when logs are supplied."""
         if self._state != "input_delivered" or self._current is None:
             raise InputProtocolError(
                 f"submit() requires a delivered Input; Run is {self._state}"
@@ -249,6 +433,7 @@ class Run:
         status: str,
         error: str | None,
     ) -> Any:
+        """Validate status/output and fall back to actual OTel Agent output when omitted."""
         if error is not None and not isinstance(error, str):
             raise ValidationError("error must be text or None", code="output_invalid")
         if status not in {"completed", "failed", "timeout", "aborted"}:
@@ -273,8 +458,9 @@ class Run:
         output: Any,
         status: str,
         error: str | None,
-        logs: list[str | Path] | None,
+        logs: Sequence[str] | None,
     ) -> PreparedEvidence | None:
+        """Prepare transactional Evidence without advancing collector offsets."""
         if self._evidence is None:
             return None
         return self._evidence.prepare(
@@ -294,6 +480,7 @@ class Run:
         error: str | None,
         prepared: PreparedEvidence | None,
     ) -> Submission:
+        """Build the immutable Submission and abort prepared Evidence on validation failure."""
         try:
             return Submission(
                 run_id=self.run_id,
@@ -322,6 +509,7 @@ class Run:
         submission: Submission,
         prepared: PreparedEvidence | None,
     ) -> None:
+        """Append history then commit Evidence, restoring deliverable state on append failure."""
         self._state = "submitting"
         try:
             self._history.append(HistoryItem(test_input=current, submission=submission))
@@ -338,6 +526,7 @@ class Run:
     def _advance_after_submission(
         self, *, status: str, wait: bool
     ) -> TestReport | None:
+        """Advance to the next Input, stop early, or enter the configured Judge."""
         if status != "completed" and self._on_failure == "stop":
             self._stopped_early = True
             self._finish_runtime()
@@ -351,11 +540,26 @@ class Run:
         return None
 
     def cancel(self) -> None:
-        """Cancel an unfinished Run and release Evidence, files, and its lock.
+        """Cancel an unfinished Run and release Evidence and its runtime lease.
 
-        The operation is idempotent for already-cancelled or report-ready Runs.
-        It raises :class:`InputProtocolError` when cancellation would hide a
-        failed or actively committing state.
+        Returns:
+            ``None``.
+
+        Raises:
+            InputProtocolError: If the Run is failed or is in an intermediate
+                state whose work must not be hidden by cancellation.
+
+        Preconditions:
+            The Run is in a cancellable public lifecycle state.
+
+        Postconditions:
+            An unfinished Run becomes ``cancelled``; active Evidence is discarded
+            and runtime resources are released. Calls on ``cancelled`` or
+            ``report_ready`` Runs are idempotent.
+
+        Side Effects:
+            Closes runtime resources and removes validated temporary runtime
+            files. It does not create a Submission or invoke Judge.
         """
 
         with self._mutex:
@@ -380,26 +584,42 @@ class Run:
 
         Args:
             wait: Must be ``True``. Official operation polling remains internal
-                and bounded by ``operation_wait_timeout`` from :func:`create_run`.
+                and is bounded by ``operation_wait_timeout`` from ``create_run``.
 
         Returns:
             Validated final :class:`TestReport`. Repeated calls after success
-            return the same report.
+            return the same report object.
 
         Raises:
-            ConfigurationError: ``wait=False`` is requested.
-            InputProtocolError: The Run is not completed and ready for Judge.
-            ProviderError: No Judge is configured or a custom Judge fails.
-            KumaError: The official Judge operation fails or times out.
+            ConfigurationError: If ``wait=False`` is requested.
+            InputProtocolError: If the Run is not completed and ready for Judge.
+            ProviderError: If no Judge is configured or a custom Judge fails.
+            KumaError: If an official Judge operation fails or times out.
 
-        A failure restores the ``completed`` state so retry reuses truthful
-        History and pending-operation metadata rather than creating a new result.
+        Preconditions:
+            Every delivered input has a committed Submission, state is
+            ``completed``, and a Judge Provider is configured.
+
+        Postconditions:
+            Success stores the report and changes state to ``report_ready``.
+            Failure restores ``completed`` so retry reuses the same immutable
+            history, idempotency identity, and pending operation.
+
+        Side Effects:
+            Calls the configured Judge for an unresolved report. Official Judge
+            uses bounded synchronous HTTP polling.
+
+        Security/Privacy:
+            Only validated public provenance, committed Submission Evidence, and
+            bounded public metadata cross the official Backend boundary. The SDK
+            never retrieves a private rubric.
         """
 
         with self._mutex:
             return self._judge_locked(wait=wait)
 
     def _judge_locked(self, *, wait: bool) -> TestReport:
+        """Judge completed history once and restore ``completed`` after Provider failure."""
         if not wait:
             raise ConfigurationError(
                 "SDK v4 Judge requests are synchronous; wait must remain True"
@@ -439,6 +659,7 @@ class Run:
         return report
 
     def _finish_runtime(self) -> None:
+        """Seal Evidence and release the active-Run lease, marking cleanup failure."""
         self._state = "completed"
         try:
             if self._evidence is not None:

--- a/src/kuma/runtime.py
+++ b/src/kuma/runtime.py
@@ -6,14 +6,18 @@ import json
 import os
 import re
 import shutil
-import stat
-import tempfile
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from types import TracebackType
 from typing import BinaryIO, Literal
 
+from ._runtime_filesystem import (
+    default_lock_path,
+    default_runtime_root,
+    ensure_repo_runtime_directory,
+)
 from .errors import ConfigurationError, DockerRequiredError, RunAlreadyActiveError
 
 RuntimeMode = Literal["docker", "local"]
@@ -27,7 +31,21 @@ def is_running_in_docker(
     marker_paths: tuple[Path, ...] = _DOCKER_MARKERS,
     cgroup_path: Path = Path("/proc/1/cgroup"),
 ) -> bool:
-    """Detect the Docker container that must contain both SDK and Agent."""
+    """Detect whether SDK and Agent appear to share a Docker container.
+
+    Args:
+        marker_paths: Container marker files to inspect; defaults to
+            ``/.dockerenv``. Tests may provide isolated paths.
+        cgroup_path: Linux cgroup file checked for Docker/containerd markers when
+            no marker file exists.
+
+    Returns:
+        ``True`` when a marker or cgroup token identifies Docker, otherwise
+        ``False``. Unreadable cgroup metadata is treated as not detected.
+
+    Side Effects:
+        Reads only the supplied marker existence and cgroup text.
+    """
 
     if any(path.exists() for path in marker_paths):
         return True
@@ -39,6 +57,22 @@ def is_running_in_docker(
 
 
 def resolve_runtime_mode(*, allow_local: bool) -> RuntimeMode:
+    """Choose the supported Docker mode or an explicit trusted local mode.
+
+    Args:
+        allow_local: Explicit development opt-in when Docker is not detected.
+
+    Returns:
+        ``"docker"`` when detected, otherwise ``"local"`` only when opted in.
+
+    Raises:
+        DockerRequiredError: If Docker is absent and local execution was not
+            explicitly permitted.
+
+    Security/Privacy:
+        ``allow_local=True`` does not create isolation or relax Evidence/path
+        validation; it only acknowledges that the caller trusts local execution.
+    """
     if is_running_in_docker():
         return "docker"
     if allow_local:
@@ -49,25 +83,8 @@ def resolve_runtime_mode(*, allow_local: bool) -> RuntimeMode:
     )
 
 
-def default_lock_path() -> Path:
-    runtime_root = os.environ.get("XDG_RUNTIME_DIR")
-    if runtime_root:
-        return Path(runtime_root).expanduser() / "kuma" / "active-run.lock"
-    if os.name == "posix":
-        # Without XDG_RUNTIME_DIR, POSIX processes must resolve one fallback lock
-        # to preserve the single-active-Run invariant.
-        return Path("/tmp/kuma-active-run.lock")  # nosec B108
-    return Path(tempfile.gettempdir()) / "kuma-active-run.lock"
-
-
-def default_runtime_root(mode: RuntimeMode) -> Path:
-    if mode == "docker":
-        # Runs use random child names; cleanup validates each child's parent/name.
-        return Path("/tmp/kuma")  # nosec B108
-    return Path(tempfile.gettempdir()) / "kuma"
-
-
 def _lock_file(handle: BinaryIO) -> None:
+    """Acquire the platform file lock without blocking another active Run."""
     handle.seek(0)
     if os.name == "nt":
         import msvcrt
@@ -80,6 +97,7 @@ def _lock_file(handle: BinaryIO) -> None:
 
 
 def _unlock_file(handle: BinaryIO) -> None:
+    """Release a previously acquired platform file lock."""
     handle.seek(0)
     if os.name == "nt":
         import msvcrt
@@ -91,65 +109,212 @@ def _unlock_file(handle: BinaryIO) -> None:
         fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
+def _resolve_lock_path(path: Path | None) -> Path:
+    """Resolve the shared lock location without retaining raw path failures.
+
+    Args:
+        path: Explicit lock path, or ``None`` for the platform-wide default.
+
+    Returns:
+        Canonical absolute lock path used by :class:`ContainerRunLock`.
+
+    Raises:
+        ConfigurationError: If the path cannot be converted or resolved. The
+            original filesystem exception is detached from the public chain.
+    """
+    failed = False
+    try:
+        resolved = (path or default_lock_path()).expanduser().resolve()
+    except (AttributeError, TypeError, ValueError, OSError, RuntimeError):
+        failed = True
+    if failed:
+        raise ConfigurationError("KUMA runtime lock is unavailable") from None
+    return resolved
+
+
+def _open_lock_handle(path: Path) -> BinaryIO:
+    """Open and initialize the lock byte, closing partial ownership on failure.
+
+    Args:
+        path: Canonical lock-file path owned by the runtime boundary.
+
+    Returns:
+        Open binary handle ready for a non-blocking OS lock.
+
+    Raises:
+        ConfigurationError: If parent creation, opening, seeking, or initial
+            writing fails. Any opened handle is closed before the safe error.
+
+    Side Effects:
+        May create the parent and lock file; never leaves a caller-owned handle
+        after failure.
+    """
+    handle: BinaryIO | None = None
+    failed = False
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        handle = path.open("a+b")
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"\0")
+            handle.flush()
+    except OSError:
+        if handle is not None:
+            with suppress(OSError):
+                handle.close()
+        failed = True
+    if failed:
+        raise ConfigurationError("KUMA runtime lock is unavailable") from None
+    assert handle is not None
+    return handle
+
+
+def _claim_lock_handle(handle: BinaryIO) -> None:
+    """Claim one opened lock handle or close it and report stable contention.
+
+    Args:
+        handle: Open initialized handle returned by :func:`_open_lock_handle`.
+
+    Raises:
+        RunAlreadyActiveError: If the platform refuses the non-blocking lock.
+            The raw OSError and lock path are detached from the public chain.
+
+    Postconditions:
+        Success leaves the handle locked; failure closes it.
+    """
+    failed = False
+    try:
+        _lock_file(handle)
+    except OSError:
+        with suppress(OSError):
+            handle.close()
+        failed = True
+    if failed:
+        raise RunAlreadyActiveError(
+            "Another KUMA Run is already active in this container"
+        ) from None
+
+
+def _write_lock_metadata(handle: BinaryIO, run_id: str) -> None:
+    """Durably write public lease metadata and release ownership on failure.
+
+    Args:
+        handle: Currently locked runtime handle.
+        run_id: Validated public identifier written with PID and start time.
+
+    Raises:
+        ConfigurationError: If metadata cannot be written and fsynced; the lock
+            is released, the handle closed, and the raw failure detached.
+        BaseException: Non-filesystem control-flow failures after releasing the
+            same resources.
+
+    Postconditions:
+        Success leaves the lock owned for :class:`ContainerRunLock`; failure
+        transfers no handle ownership to its caller.
+    """
+    failed = False
+    try:
+        metadata = json.dumps(
+            {
+                "run_id": run_id,
+                "pid": os.getpid(),
+                "started_at": datetime.now(timezone.utc).isoformat(),
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        handle.seek(1)
+        handle.truncate()
+        handle.write(metadata)
+        handle.flush()
+        os.fsync(handle.fileno())
+    except BaseException as exc:
+        with suppress(OSError):
+            _unlock_file(handle)
+        with suppress(OSError):
+            handle.close()
+        if isinstance(exc, OSError):
+            failed = True
+        else:
+            raise
+    if failed:
+        raise ConfigurationError("KUMA runtime lock is unavailable") from None
+
+
 class ContainerRunLock:
     """One active Run per container, enforced by the operating system."""
 
     def __init__(self, path: Path | None = None) -> None:
-        self.path = (path or default_lock_path()).expanduser().resolve()
+        """Bind the single-Run lease to a validated local lock location.
+
+        Raises:
+            ConfigurationError: If the selected path is invalid or cannot be
+                resolved. The fixed error does not expose host path details.
+        """
+        self.path = _resolve_lock_path(path)
         self._handle: BinaryIO | None = None
 
     @property
     def acquired(self) -> bool:
+        """Return whether this lock currently owns the process-wide Run lease."""
         return self._handle is not None
 
     def acquire(self, run_id: str) -> None:
+        """Acquire the single-active-Run lease without waiting.
+
+        Args:
+            run_id: Safe public identifier recorded as non-secret lock metadata.
+
+        Raises:
+            ConfigurationError: If ``run_id`` is unsafe for local state.
+            RunAlreadyActiveError: If this object or another process/container
+                already owns the shared lock.
+            ConfigurationError: If the lock file or its public metadata cannot
+                be created and written safely.
+
+        Preconditions:
+            No Run has been acquired through this lock instance.
+
+        Postconditions:
+            Success retains an open OS-locked handle until :meth:`release` and
+            writes run ID, PID, and UTC start time. Metadata-write failure unlocks
+            and closes the handle before re-raising.
+
+        Side Effects:
+            Creates the lock parent/file when needed and fsyncs public lock
+            metadata. It never stores credentials or Case/Evidence content.
+        """
         _validate_run_id(run_id)
         if self._handle is not None:
             raise RunAlreadyActiveError("This lock instance already owns an active Run")
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        handle = self.path.open("a+b")
-        try:
-            handle.seek(0, os.SEEK_END)
-            if handle.tell() == 0:
-                handle.write(b"\0")
-                handle.flush()
-            _lock_file(handle)
-        except OSError as exc:
-            handle.close()
-            raise RunAlreadyActiveError(
-                "Another KUMA Run is already active in this container"
-            ) from exc
-        try:
-            metadata = json.dumps(
-                {
-                    "run_id": run_id,
-                    "pid": os.getpid(),
-                    "started_at": datetime.now(timezone.utc).isoformat(),
-                },
-                sort_keys=True,
-            ).encode("utf-8")
-            handle.seek(1)
-            handle.truncate()
-            handle.write(metadata)
-            handle.flush()
-            os.fsync(handle.fileno())
-        except BaseException:
-            _unlock_file(handle)
-            handle.close()
-            raise
+        handle = _open_lock_handle(self.path)
+        _claim_lock_handle(handle)
+        _write_lock_metadata(handle, run_id)
         self._handle = handle
 
     def release(self) -> None:
+        """Release the Run lease idempotently and close its lock handle.
+
+        Raises:
+            ConfigurationError: If the operating system cannot release or close
+                the lock. Internal path and OS diagnostics are never exposed.
+        """
         handle = self._handle
         if handle is None:
             return
         self._handle = None
+        release_failed = False
         try:
             _unlock_file(handle)
-        finally:
             handle.close()
+        except OSError:
+            with suppress(OSError):
+                handle.close()
+            release_failed = True
+        if release_failed:
+            raise ConfigurationError("KUMA runtime lock is unavailable") from None
 
     def __enter__(self) -> ContainerRunLock:
+        """Acquire or expose the managed resource for a context block."""
         if not self.acquired:
             raise RuntimeError("Call acquire() before entering ContainerRunLock")
         return self
@@ -160,60 +325,127 @@ class ContainerRunLock:
         exc: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        """Release the managed resource when leaving a context block."""
         self.release()
 
 
 def _validate_run_id(run_id: str) -> None:
+    """Reject Run identifiers unsafe for lock names or owned directory paths."""
     if not isinstance(run_id, str) or _RUN_ID_PATTERN.fullmatch(run_id) is None:
         raise ConfigurationError("run_id contains unsupported path characters")
 
 
-def ensure_repo_runtime_directory(repo_path: Path) -> Path:
-    """Create the excluded .kuma directory and idempotent Git ignore rule."""
+def _resolve_workspace_roots(
+    repo_path: Path, mode: RuntimeMode, runtime_root: Path | None
+) -> tuple[Path, Path]:
+    """Resolve repository/runtime roots and create only the controlled parent.
 
-    root = repo_path.expanduser().resolve()
-    if not root.is_dir():
-        raise ConfigurationError("repo_path must be an existing directory")
-    runtime_directory = root / ".kuma"
-    runtime_directory.mkdir(exist_ok=True)
+    Args:
+        repo_path: Existing repository authorized for this Run.
+        mode: Runtime mode used only to select the default temporary root.
+        runtime_root: Explicit controlled parent, or ``None`` for the default.
 
-    gitignore = root / ".gitignore"
+    Returns:
+        Canonical repository root and canonical temporary-runtime root.
+
+    Raises:
+        ConfigurationError: If either path is invalid/unavailable or the runtime
+            parent cannot be created, without retaining raw filesystem details.
+    """
+    failed = False
     try:
-        existing = gitignore.read_text(encoding="utf-8") if gitignore.exists() else ""
-    except (OSError, UnicodeError) as exc:
-        raise ConfigurationError(
-            "Repository .gitignore must be readable UTF-8 text"
-        ) from exc
-    normalized_rules = {line.strip() for line in existing.splitlines()}
-    if ".kuma/" in normalized_rules or "/.kuma/" in normalized_rules:
-        return runtime_directory
-
-    separator = "\r\n" if "\r\n" in existing else "\n"
-    updated = existing
-    if updated and not updated.endswith(("\n", "\r")):
-        updated += separator
-    updated += f"/.kuma/{separator}"
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=".gitignore.kuma-",
-        suffix=".tmp",
-        dir=root,
-        text=True,
-    )
-    temporary = Path(temporary_name)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
-            handle.write(updated)
-        if gitignore.exists():
-            temporary.chmod(stat.S_IMODE(gitignore.stat().st_mode))
-        temporary.replace(gitignore)
-    except BaseException:
-        temporary.unlink(missing_ok=True)
+        root = repo_path.expanduser().resolve()
+        if not root.is_dir():
+            raise ConfigurationError("repo_path must be an existing directory")
+        resolved_runtime_root = (
+            (runtime_root or default_runtime_root(mode)).expanduser().resolve()
+        )
+        resolved_runtime_root.mkdir(parents=True, exist_ok=True)
+    except ConfigurationError:
         raise
-    return runtime_directory
+    except (AttributeError, TypeError, ValueError, OSError):
+        failed = True
+    if failed:
+        raise ConfigurationError("KUMA runtime workspace is unavailable") from None
+    return root, resolved_runtime_root
+
+
+def _create_temporary_workspace(runtime_root: Path, run_id: str) -> Path:
+    """Create the exclusive Run child and hide collision path diagnostics.
+
+    Args:
+        runtime_root: Canonical SDK-controlled temporary parent.
+        run_id: Validated public Run identifier used as the child name.
+
+    Returns:
+        Newly created exclusive Run directory.
+
+    Raises:
+        ConfigurationError: On a collision or local creation failure. Neither
+            the absolute root nor the original OSError remains in the chain.
+    """
+    temporary_path = runtime_root / run_id
+    failure_message: str | None = None
+    try:
+        temporary_path.mkdir()
+    except FileExistsError:
+        failure_message = f"Runtime directory already exists for {run_id}"
+    except OSError:
+        failure_message = "KUMA runtime workspace is unavailable"
+    if failure_message is not None:
+        raise ConfigurationError(failure_message) from None
+    return temporary_path
+
+
+def _create_persistent_workspace(
+    persistent_path: Path | None, temporary_path: Path, run_id: str
+) -> None:
+    """Create optional local Evidence storage or roll back the temporary Run.
+
+    Args:
+        persistent_path: Run-owned output directory, or ``None`` when disabled.
+        temporary_path: Temporary directory to remove if persistence fails.
+        run_id: Validated public identifier used for a stable collision message.
+
+    Raises:
+        ConfigurationError: If persistent storage collides or cannot be created;
+            raw host diagnostics are detached.
+
+    Postconditions:
+        Success creates the requested directory. Failure best-effort removes the
+        temporary workspace before returning the stable error.
+    """
+    if persistent_path is None:
+        return
+    failure_message: str | None = None
+    try:
+        persistent_path.mkdir(parents=True, exist_ok=False)
+    except OSError as exc:
+        with suppress(OSError):
+            shutil.rmtree(temporary_path)
+        failure_message = (
+            f"Runtime directory already exists for {run_id}"
+            if isinstance(exc, FileExistsError)
+            else "KUMA runtime workspace is unavailable"
+        )
+    if failure_message is not None:
+        raise ConfigurationError(failure_message) from None
 
 
 @dataclass(slots=True)
 class RuntimeWorkspace:
+    """Own temporary and optional persistent directories for one Run.
+
+    Attributes:
+        run_id: Validated public Run identifier used in directory names.
+        repo_path: Canonical authorized repository root.
+        temporary_path: Random Run-owned directory removed on close.
+        persistent_path: Stable ``.kuma/runs/<run_id>`` directory when local
+            persistence is enabled, otherwise ``None``.
+        runtime_root: Canonical parent allowed to contain temporary directories.
+        _closed: Whether cleanup already ran; makes ``close`` idempotent.
+    """
+
     run_id: str
     repo_path: Path
     temporary_path: Path
@@ -231,27 +463,42 @@ class RuntimeWorkspace:
         save_local: bool,
         runtime_root: Path | None = None,
     ) -> RuntimeWorkspace:
+        """Create temporary and optional persistent directories for one Run.
+
+        Args:
+            run_id: Safe identifier used as the exact child directory name.
+            repo_path: Existing authorized repository root.
+            mode: Resolved ``docker`` or ``local`` mode.
+            save_local: Create persistent ``.kuma/runs/<run_id>`` output when true.
+            runtime_root: Optional controlled temporary parent for tests/embedding.
+
+        Returns:
+            Open workspace whose temporary directory is uniquely owned by this Run.
+
+        Raises:
+            ConfigurationError: If identifiers/paths are invalid or a same-name
+                runtime directory already exists, or directory creation fails.
+
+        Postconditions:
+            Failure after temporary creation removes that temporary directory.
+            Success leaves cleanup ownership with the returned workspace.
+
+        Side Effects:
+            Creates runtime directories and may update repository ``.gitignore``.
+        """
         _validate_run_id(run_id)
-        root = repo_path.expanduser().resolve()
-        repo_runtime = ensure_repo_runtime_directory(root)
-        resolved_runtime_root = (
-            (runtime_root or default_runtime_root(mode)).expanduser().resolve()
+        root, resolved_runtime_root = _resolve_workspace_roots(
+            repo_path, mode, runtime_root
         )
-        resolved_runtime_root.mkdir(parents=True, exist_ok=True)
-        temporary_path = resolved_runtime_root / run_id
+        temporary_path = _create_temporary_workspace(resolved_runtime_root, run_id)
         try:
-            temporary_path.mkdir()
-        except FileExistsError as exc:
-            raise ConfigurationError(
-                f"Runtime directory already exists for {run_id}"
-            ) from exc
-        persistent_path = repo_runtime / "runs" / run_id if save_local else None
-        try:
-            if persistent_path is not None:
-                persistent_path.mkdir(parents=True, exist_ok=False)
+            repo_runtime = ensure_repo_runtime_directory(root)
         except BaseException:
-            shutil.rmtree(temporary_path)
+            with suppress(OSError):
+                shutil.rmtree(temporary_path)
             raise
+        persistent_path = repo_runtime / "runs" / run_id if save_local else None
+        _create_persistent_workspace(persistent_path, temporary_path, run_id)
         return cls(
             run_id=run_id,
             repo_path=root,
@@ -261,21 +508,55 @@ class RuntimeWorkspace:
         )
 
     def close(self) -> None:
+        """Remove only this Run's validated temporary workspace, idempotently.
+
+        Raises:
+            ConfigurationError: If the cleanup target is not the exact expected
+                child of ``runtime_root`` or safe deletion fails.
+
+        Postconditions:
+            On success the temporary path no longer exists. Persistent local
+            Evidence remains available. Repeated successful calls do nothing.
+            A failed deletion remains retryable instead of being marked closed.
+
+        Side Effects:
+            Recursively removes the exact Run-owned temporary directory only.
+        """
         if self._closed:
             return
+        cleanup_failed = False
+        try:
+            resolved = self.temporary_path.resolve()
+            if (
+                resolved.parent != self.runtime_root.resolve()
+                or resolved.name != self.run_id
+            ):
+                raise ConfigurationError(
+                    "Refusing to clean an unexpected runtime directory"
+                )
+            if resolved.exists():
+                shutil.rmtree(resolved)
+        except ConfigurationError:
+            raise
+        except OSError:
+            cleanup_failed = True
+        if cleanup_failed:
+            raise ConfigurationError("KUMA runtime workspace is unavailable") from None
         self._closed = True
-        resolved = self.temporary_path.resolve()
-        if (
-            resolved.parent != self.runtime_root.resolve()
-            or resolved.name != self.run_id
-        ):
-            raise RuntimeError("Refusing to clean an unexpected runtime directory")
-        if resolved.exists():
-            shutil.rmtree(resolved)
 
 
 @dataclass(slots=True)
 class RuntimeSession:
+    """Own the active-Run lease and workspace as one rollback-safe resource.
+
+    Attributes:
+        run_id: Public Run identifier associated with both resources.
+        mode: ``docker`` or explicitly permitted ``local`` runtime mode.
+        lock: Process/container-wide active-Run lease.
+        workspace: Run-owned temporary/persistent filesystem paths.
+        _closed: Whether both resources have already been released.
+    """
+
     run_id: str
     mode: RuntimeMode
     lock: ContainerRunLock
@@ -293,6 +574,32 @@ class RuntimeSession:
         lock_path: Path | None = None,
         runtime_root: Path | None = None,
     ) -> RuntimeSession:
+        """Acquire the active-Run lease and create its workspace atomically.
+
+        Args:
+            run_id: Safe public Run identifier.
+            repo_path: Existing authorized repository root.
+            allow_local: Explicit permission to use trusted local mode.
+            save_local: Whether committed Evidence receives a persistent directory.
+            lock_path: Optional isolated lock path for tests/embedding.
+            runtime_root: Optional isolated temporary root.
+
+        Returns:
+            Open session owning both lock and workspace.
+
+        Raises:
+            DockerRequiredError: Docker is absent without local opt-in.
+            RunAlreadyActiveError: Another Run owns the lease.
+            ConfigurationError: Identifier or repository/runtime path is invalid,
+                unavailable, or cannot be created safely.
+
+        Postconditions:
+            Success owns both resources. Workspace failure releases the acquired
+            lock before re-raising, so no leaked active-Run state remains.
+
+        Side Effects:
+            Acquires an OS lock and creates the Run directories.
+        """
         mode = resolve_runtime_mode(allow_local=allow_local)
         lock = ContainerRunLock(lock_path)
         lock.acquire(run_id)
@@ -310,15 +617,25 @@ class RuntimeSession:
         return cls(run_id=run_id, mode=mode, lock=lock, workspace=workspace)
 
     def close(self) -> None:
+        """Close workspace and release the active-Run lease exactly once.
+
+        Postconditions:
+            The lock is released even if workspace cleanup raises. Repeated calls
+            after success are no-ops; a cleanup failure may be retried safely.
+
+        Side Effects:
+            Removes validated temporary files and closes the shared lock handle.
+        """
         if self._closed:
             return
-        self._closed = True
         try:
             self.workspace.close()
         finally:
             self.lock.release()
+        self._closed = True
 
     def __enter__(self) -> RuntimeSession:
+        """Acquire or expose the managed resource for a context block."""
         return self
 
     def __exit__(
@@ -327,6 +644,7 @@ class RuntimeSession:
         exc: BaseException | None,
         traceback: TracebackType | None,
     ) -> None:
+        """Release the managed resource when leaving a context block."""
         self.close()
 
 

--- a/src/kuma/transport/backend.py
+++ b/src/kuma/transport/backend.py
@@ -15,7 +15,7 @@ from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
 from .._version import __version__
-from ..config import resolve_api_key, validate_max_retries
+from ..config import DEFAULT_CASE_MAX_STEPS, resolve_api_key, validate_max_retries
 from ..errors import (
     AuthenticationError,
     CaseIntegrityError,
@@ -24,6 +24,7 @@ from ..errors import (
     KumaTimeoutError,
     LimitExceededError,
     PermissionDeniedError,
+    ProviderError,
     RepoStateMismatchError,
     SensitiveDataError,
     ServiceBusyError,
@@ -52,13 +53,61 @@ _InternalWireTransport = Callable[
 
 
 class _RemoteError(Exception):
+    """Hold a bounded remote failure until it is mapped to a public SDK error."""
+
     def __init__(self, status: int, payload: Mapping[str, Any] | None = None) -> None:
+        """Retain an HTTP failure for later conversion to a public SDK error.
+
+        Args:
+            status: HTTP status code returned by the public Backend.
+            payload: Parsed public JSON error object. ``None`` means no usable
+                response object was available.
+
+        Preconditions:
+            ``status`` comes from the HTTP boundary; ``payload`` has already
+            passed the bounded response reader when supplied.
+
+        Postconditions:
+            The payload is detached into a mutable private copy. The exception
+            message contains only the status code and never response text.
+
+        Side Effects:
+            None beyond initializing the exception.
+
+        Security/Privacy:
+            Callers must map this internal exception through
+            :func:`_mapped_remote_error` before exposing it to SDK users.
+        """
         self.status = status
         self.payload = dict(payload or {})
         super().__init__(f"HTTP {status}")
 
 
 def _decode(raw: bytes, status: int) -> Mapping[str, Any]:
+    """Decode a bounded response as the required top-level JSON object.
+
+    Args:
+        raw: Complete response bytes already limited by :func:`_read_response`.
+        status: HTTP status associated with those bytes.
+
+    Returns:
+        Parsed JSON mapping. Arrays, scalars, and ``null`` are rejected because
+        every public Backend response must be an object.
+
+    Raises:
+        _RemoteError: UTF-8 decoding, JSON parsing, or top-level shape fails. Its
+            replacement payload uses only stable ``invalid_response`` fields.
+
+    Preconditions:
+        ``raw`` is no larger than ``_MAX_RESPONSE_BYTES``.
+
+    Postconditions:
+        Success returns the decoded mapping without changing it. Failure retains
+        no raw response text in the public error envelope.
+
+    Security/Privacy:
+        Malformed server content is deliberately replaced rather than echoed.
+    """
     try:
         value = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
@@ -75,6 +124,32 @@ def _decode(raw: bytes, status: int) -> Mapping[str, Any]:
 
 
 def _read_response(response: Any, status: int) -> Mapping[str, Any]:
+    """Read and decode one HTTP response without permitting unbounded memory use.
+
+    Args:
+        response: File-like HTTP response exposing ``read(size)``.
+        status: HTTP status used if JSON decoding must raise ``_RemoteError``.
+
+    Returns:
+        Parsed top-level JSON mapping from the bounded response body.
+
+    Raises:
+        ServiceError: The body exceeds the 8 MiB SDK response limit.
+        _RemoteError: The bounded body is not a valid UTF-8 JSON object.
+
+    Preconditions:
+        The caller owns the response lifecycle and will close it.
+
+    Postconditions:
+        Reads at most ``_MAX_RESPONSE_BYTES + 1`` bytes, which is sufficient to
+        distinguish an allowed body from an oversized one.
+
+    Side Effects:
+        Advances the response stream to the consumed position.
+
+    Security/Privacy:
+        Raw response bytes never appear in raised SDK messages.
+    """
     raw = response.read(_MAX_RESPONSE_BYTES + 1)
     if len(raw) > _MAX_RESPONSE_BYTES:
         raise ServiceError(
@@ -91,12 +166,45 @@ def _wire_transport(
     body: bytes | None,
     timeout: float,
 ) -> WireResponse:
-    # Revalidate the final URL at the I/O boundary even when a custom caller
-    # bypasses BackendClient's validated base_url invariant.
-    _validate_base_url(url)
+    """Perform exactly one HTTP attempt against the validated public Backend URL.
+
+    Args:
+        method: Uppercase HTTP method already accepted by ``validate_request``.
+        url: Final absolute Backend URL, including the validated SDK path.
+        headers: Complete HTTP headers, including authentication and optional
+            idempotency key. Values must already be header-safe.
+        body: Exact serialized request bytes, or ``None`` for a bodyless request.
+        timeout: Positive per-attempt timeout in seconds.
+
+    Returns:
+        ``WireResponse`` containing the status and parsed JSON object for a 2xx
+        response. Status interpretation remains the caller's responsibility.
+
+    Raises:
+        _RemoteError: The server returns an HTTP error response.
+        KumaTimeoutError: The socket or URL layer reaches ``timeout``.
+        ServiceError: The service is unreachable or its response is oversized.
+
+    Preconditions:
+        ``BackendClient`` has validated the base URL, method, SDK path, body
+        size, timeout, API key, and idempotency key. This low-level function must
+        not be called with an arbitrary user URL.
+
+    Postconditions:
+        Exactly one network attempt has occurred. Every opened response or
+        ``HTTPError`` stream is closed before return or raise. No retry occurs
+        here; retry ownership remains in ``BackendClient._send``.
+
+    Side Effects:
+        Sends one HTTPS request, or approved loopback/Docker-gateway HTTP request.
+
+    Security/Privacy:
+        Response text, provider details, and tracebacks are never interpolated
+        into user-visible messages. The Authorization header is not logged.
+    """
     request = Request(url, data=body, headers=dict(headers), method=method)
     try:
-        with urlopen(request, timeout=timeout) as response:  # nosec B310
+        with urlopen(request, timeout=timeout) as response:
             return WireResponse(
                 status=response.status,
                 payload=_read_response(response, response.status),
@@ -131,6 +239,31 @@ def _wire_transport(
 
 
 def new_idempotency_key(operation: str) -> str:
+    """Create one unpredictable HTTP idempotency key for a logical operation.
+
+    Args:
+        operation: Short ASCII operation label such as ``"case"`` or
+            ``"judge"``. Letters, digits, and hyphens are accepted.
+
+    Returns:
+        Header-safe key beginning with ``sdk-v4-<operation>-`` and containing a
+        cryptographically random suffix.
+
+    Raises:
+        ConfigurationError: ``operation`` is empty, non-ASCII, or contains a
+            character other than a letter, digit, or hyphen.
+
+    Preconditions:
+        Call once when creating a new logical operation, then persist/reuse the
+        returned value for retries and resume.
+
+    Postconditions:
+        Produces a new opaque value; it contains no API key or request payload.
+
+    Security/Privacy:
+        The key is correlation metadata, not a credential, but applications
+        should still avoid exposing it unnecessarily.
+    """
     if (
         not operation
         or not operation.isascii()
@@ -141,6 +274,26 @@ def new_idempotency_key(operation: str) -> str:
 
 
 def _validate_idempotency_key(value: str) -> str:
+    """Validate a caller-stable idempotency key before header construction.
+
+    Args:
+        value: Candidate key supplied by the operation/resume layer.
+
+    Returns:
+        The unchanged key after validating 1-255 printable, non-space ASCII
+        characters.
+
+    Raises:
+        ConfigurationError: The value is not text or is empty, oversized,
+            non-ASCII, whitespace-containing, or control-character-containing.
+
+    Preconditions:
+        The caller intends to place this value in ``Idempotency-Key``.
+
+    Postconditions:
+        Success guarantees direct HTTP header representation without newline or
+        delimiter injection.
+    """
     if (
         not isinstance(value, str)
         or not value
@@ -154,6 +307,33 @@ def _validate_idempotency_key(value: str) -> str:
 
 
 def _validate_base_url(value: str) -> str:
+    """Validate the public Backend origin and normalize only its trailing slash.
+
+    Args:
+        value: Absolute public API base URL. Remote services require HTTPS;
+            loopback HTTP is allowed for local integration, and the Docker host
+            gateway is allowed only from a detected container.
+
+    Returns:
+        The same URL with trailing slashes removed. Path spelling and routing are
+        otherwise preserved.
+
+    Raises:
+        ConfigurationError: The URL is non-text, lacks scheme/host, embeds
+            credentials, query, or fragment, uses another scheme, or requests
+            remote insecure HTTP.
+
+    Preconditions:
+        ``value`` identifies the public Website Backend, never MCP or a provider.
+
+    Postconditions:
+        Concatenating a validated ``/sdk/...`` path produces an HTTP(S) URL that
+        satisfies the SDK transport policy.
+
+    Security/Privacy:
+        Embedded username/password data and arbitrary local-file schemes are
+        rejected before any request occurs.
+    """
     if not isinstance(value, str):
         raise ConfigurationError("base_url must be an HTTPS URL")
     parsed_url = urlsplit(value)
@@ -183,6 +363,21 @@ def _validate_base_url(value: str) -> str:
 
 
 def _validate_timeout(value: float) -> float:
+    """Normalize a per-request timeout without accepting booleans or infinity.
+
+    Args:
+        value: Integer or floating-point duration in seconds.
+
+    Returns:
+        Equivalent positive finite ``float``.
+
+    Raises:
+        ConfigurationError: The value is boolean, non-numeric, non-finite, zero,
+            or negative.
+
+    Postconditions:
+        The result is safe to pass to the HTTP transport as a blocking timeout.
+    """
     if (
         isinstance(value, bool)
         or not isinstance(value, int | float)
@@ -193,16 +388,82 @@ def _validate_timeout(value: float) -> float:
     return float(value)
 
 
-def _error_envelope(error: _RemoteError) -> tuple[str, bool, Mapping[str, Any]]:
+def _error_envelope(
+    error: _RemoteError,
+) -> tuple[str, bool, str | None, Mapping[str, Any]]:
+    """Project a remote failure onto the closed SDK-safe error envelope.
+
+    Args:
+        error: Internal HTTP failure containing a parsed response object.
+
+    Returns:
+        ``(code, retryable, message, details)`` where arbitrary details are
+        discarded and only the closed Case step-limit field may survive.
+
+    Preconditions:
+        ``error`` has not yet crossed the public SDK exception boundary.
+
+    Postconditions:
+        Only typed ``code``, ``retryable``, optional text ``message``, and the
+        integer ``max_allowed_steps`` for ``case_step_limit_exceeded`` remain.
+
+    Security/Privacy:
+        Backend/Core/provider diagnostics cannot flow through ``details``.
+    """
     raw = error.payload.get("error")
     envelope = raw if isinstance(raw, Mapping) else {}
     raw_code = envelope.get("code")
     code = raw_code if isinstance(raw_code, str) and raw_code else "service_error"
     raw_retryable = envelope.get("retryable", False)
     retryable = raw_retryable if isinstance(raw_retryable, bool) else False
-    # Backend details are deliberately not propagated: their shape is not part of
-    # the public SDK contract and could accidentally contain internal context.
-    return code, retryable, {}
+    raw_message = envelope.get("message")
+    message = raw_message if isinstance(raw_message, str) else None
+    return code, retryable, message, _case_step_limit_details(code, envelope)
+
+
+def _case_step_limit_details(
+    code: str, envelope: Mapping[str, Any]
+) -> Mapping[str, int]:
+    """Validate the sole public error-detail shape allowed through the SDK.
+
+    Arbitrary Backend details remain discarded for every other error code. The
+    Case limit code fails closed when its required details object is absent,
+    malformed, or contains an unknown field.
+
+    Args:
+        code: Stable public error code already reduced to a string.
+        envelope: Parsed Backend error mapping at the HTTP boundary.
+
+    Returns:
+        Immutable-by-convention mapping containing only ``max_allowed_steps``,
+        or an empty mapping for all unrelated codes.
+
+    Raises:
+        ProviderError: If the Case-limit details are absent, out of range,
+            incorrectly typed, or contain any additional field.
+
+    Security/Privacy:
+        No arbitrary Backend/Core/provider diagnostic field crosses this helper.
+    """
+    if code != "case_step_limit_exceeded":
+        return {}
+    details = envelope.get("details")
+    if not isinstance(details, Mapping) or set(details) != {"max_allowed_steps"}:
+        raise ProviderError(
+            "The Backend returned invalid Case step-limit details",
+            code="invalid_response",
+        )
+    maximum = details["max_allowed_steps"]
+    if (
+        isinstance(maximum, bool)
+        or not isinstance(maximum, int)
+        or not 1 <= maximum <= DEFAULT_CASE_MAX_STEPS
+    ):
+        raise ProviderError(
+            "The Backend returned invalid Case step-limit details",
+            code="invalid_response",
+        )
+    return {"max_allowed_steps": maximum}
 
 
 _ERROR_CLASSES: dict[str, type[KumaError]] = {
@@ -219,6 +480,7 @@ _ERROR_CLASSES: dict[str, type[KumaError]] = {
     "log_size_exceeded": LimitExceededError,
     "payload_too_large": LimitExceededError,
     "quota_exhausted": LimitExceededError,
+    "case_step_limit_exceeded": LimitExceededError,
     "sensitive_content_detected": SensitiveDataError,
 }
 _VALIDATION_CODES = {
@@ -260,10 +522,87 @@ _ERROR_MESSAGES = {
     ValidationError: "The KUMA request was rejected as invalid.",
     ServiceError: "The KUMA service request failed.",
 }
+_CODE_ERROR_MESSAGES = {
+    "forbidden": "此密钥没有权限使用该功能。",
+    "idempotency_conflict": "这个请求已经提交过了，请不要重复提交。",  # noqa: RUF001
+    "invalid_api_key": "密钥无效。",
+    "invalid_request": "提交的内容有问题，请检查后重试。",  # noqa: RUF001
+}
+_NOT_FOUND_MESSAGE = "你要找的内容不存在，或者已经被删除。"  # noqa: RUF001
+_READ_ONLY_FORBIDDEN_MESSAGE = "此密钥为只读密钥，无法生成 Case 或运行 Judge。"  # noqa: RUF001
+
+
+def _public_error_message(
+    code: str,
+    error_type: type[KumaError],
+    remote_message: str | None = None,
+    details: Mapping[str, Any] | None = None,
+) -> str:
+    """Select a frozen user-facing message without trusting arbitrary server text.
+
+    Args:
+        code: Stable public error code used by program logic.
+        error_type: SDK exception class selected for the code/status.
+        remote_message: Optional Backend message from the closed error envelope.
+        details: Closed safe details for codes that define them.
+
+    Returns:
+        Canonical SDK wording, except for an exact match to an approved frozen
+        Backend message (including the read-only ``forbidden`` specialization).
+
+    Preconditions:
+        ``error_type`` exists in ``_ERROR_MESSAGES`` and ``code`` has already
+        been reduced to a non-empty string.
+
+    Postconditions:
+        The returned message is always from the SDK allowlist; unrecognized
+        remote wording cannot become user-visible.
+
+    Security/Privacy:
+        Prevents provider, database, path, traceback, or balance details from
+        leaking through an otherwise valid error object.
+    """
+
+    if code == "case_step_limit_exceeded" and details:
+        return (
+            "max_steps exceeds the Case service limit; maximum allowed is "
+            f"{details['max_allowed_steps']}."
+        )
+    if code == "resource_not_found" or code.endswith("_not_found"):
+        canonical = _NOT_FOUND_MESSAGE
+    else:
+        canonical = _CODE_ERROR_MESSAGES.get(code, _ERROR_MESSAGES[error_type])
+    # Backend may send the same frozen public wording so async and synchronous
+    # errors retain it exactly. Any other text falls back to the SDK mapping;
+    # this prevents an upstream detail or traceback from becoming user-visible.
+    if remote_message == canonical or (
+        code == "forbidden" and remote_message == _READ_ONLY_FORBIDDEN_MESSAGE
+    ):
+        return remote_message
+    return canonical
 
 
 def _mapped_remote_error(error: _RemoteError) -> KumaError:
-    code, retryable, details = _error_envelope(error)
+    """Convert one internal HTTP failure into the stable public exception model.
+
+    Args:
+        error: Internal response failure with status and parsed public envelope.
+
+    Returns:
+        Unraised ``KumaError`` subclass carrying safe message, stable code,
+        retryability, and an empty detached details mapping.
+
+    Preconditions:
+        The response has already passed size and top-level JSON validation.
+
+    Postconditions:
+        Authentication, permission, timeout, limit, validation, integrity,
+        service-busy, and generic service failures use deterministic classes.
+
+    Security/Privacy:
+        Raw response content and unapproved remote messages are absent.
+    """
+    code, retryable, message, details = _error_envelope(error)
     error_type = _ERROR_CLASSES.get(code) or _STATUS_CLASSES.get(error.status)
     if error_type is None:
         error_type = (
@@ -272,7 +611,7 @@ def _mapped_remote_error(error: _RemoteError) -> KumaError:
             else ServiceError
         )
     return error_type(
-        _ERROR_MESSAGES[error_type],
+        _public_error_message(code, error_type, message, details),
         code=code,
         retryable=retryable,
         details=details,
@@ -284,30 +623,88 @@ def mapped_error(
     *,
     retryable: bool = False,
     status: int = 400,
+    message: str | None = None,
+    details: Mapping[str, Any] | None = None,
 ) -> KumaError:
-    """Map a safe public error envelope, including per-item batch failures."""
+    """Map already separated public error fields through the HTTP error policy.
 
+    Args:
+        code: Stable public error code.
+        retryable: Whether repeating the same logical operation may succeed.
+        status: HTTP-equivalent status used for class fallback; defaults to 400.
+        message: Optional frozen public wording. Arbitrary text is ignored by
+            :func:`_public_error_message`.
+        details: Optional closed public error details. Only the Case step-limit
+            code may carry ``max_allowed_steps``.
+
+    Returns:
+        Unraised public ``KumaError`` suitable for a batch item or asynchronous
+        failed-operation result.
+
+    Preconditions:
+        Callers have validated the closed error schema and field types.
+
+    Postconditions:
+        Produces the same class/message policy as a synchronous HTTP failure.
+
+    Security/Privacy:
+        Discards all details except the validated integer Case service ceiling.
+    """
+
+    envelope: dict[str, Any] = {
+        "code": code,
+        "retryable": retryable,
+    }
+    if message is not None:
+        envelope["message"] = message
+    if details is not None:
+        envelope["details"] = dict(details)
     return _mapped_remote_error(
         _RemoteError(
             status,
-            {
-                "error": {
-                    "code": code,
-                    "retryable": retryable,
-                }
-            },
+            {"error": envelope},
         )
     )
 
 
 @dataclass(frozen=True, slots=True)
 class UploadPart:
+    """Describe one validated immutable multipart Evidence part.
+
+    Attributes:
+        name: Safe multipart form field name.
+        filename: Safe display filename without CR/LF or quote injection.
+        content_type: Declared MIME type used by the public Judge contract.
+        data: Already bounded and privacy-checked bytes to serialize.
+
+    Security/Privacy:
+        Construction validates framing but does not itself authorize ``data``;
+        callers must complete size and sensitive-data checks first.
+    """
+
     name: str
     filename: str
     content_type: str
     data: bytes
 
     def __post_init__(self) -> None:
+        """Validate one immutable multipart upload part before serialization.
+
+        Raises:
+            ValidationError: Name, filename, or content type is empty or permits
+                header injection, or ``data`` is not bytes.
+
+        Preconditions:
+            The caller has already bounded and privacy-checked the part content.
+
+        Postconditions:
+            Success guarantees that ``encode_multipart`` can insert metadata into
+            MIME headers without quote or CR/LF injection.
+
+        Security/Privacy:
+            This validates framing only; it does not authorize the bytes for
+            upload or scan their content.
+        """
         for label, value in (("name", self.name), ("filename", self.filename)):
             if not value or any(character in value for character in ('"', "\r", "\n")):
                 raise ValidationError(f"multipart {label} is invalid")
@@ -322,6 +719,31 @@ class UploadPart:
 def encode_multipart(
     fields: Mapping[str, str], parts: Sequence[UploadPart]
 ) -> tuple[str, bytes]:
+    """Serialize public fields and upload parts as one multipart/form-data body.
+
+    Args:
+        fields: Text form fields keyed by header-safe field names.
+        parts: Ordered, validated ``UploadPart`` objects.
+
+    Returns:
+        ``(content_type, body)`` using a fresh random MIME boundary. Part order
+        matches the input sequence.
+
+    Raises:
+        ValidationError: A field name is empty or permits quote/CR/LF injection.
+            ``UploadPart`` metadata errors are rejected at construction time.
+
+    Preconditions:
+        Field values and part bytes have already passed size, schema, and
+        sensitive-data policy for the target public endpoint.
+
+    Postconditions:
+        Returns a complete closing-boundary-terminated body; inputs are unchanged.
+
+    Security/Privacy:
+        Random boundaries prevent caller-controlled delimiter collisions. This
+        function performs no network request and no content redaction.
+    """
     boundary = "kuma-" + secrets.token_hex(18)
     chunks: list[bytes] = []
     for name, value in fields.items():
@@ -371,6 +793,37 @@ class BackendClient:
         transport: WireTransport | None = None,
         max_retries: int = 2,
     ) -> None:
+        """Create a validated, authenticated client for public SDK endpoints.
+
+        Args:
+            api_key: Per-client ``dfx_`` credential. ``None`` resolves
+                ``KUMA_API_KEY`` and then the user credential file.
+            base_url: Public Backend API base URL; remote addresses require HTTPS.
+            timeout: Positive finite timeout in seconds for each HTTP attempt.
+            transport: Optional controlled/test transport. ``None`` uses the
+                standard-library HTTP implementation.
+            max_retries: Additional retries for eligible transient failures,
+                from 0 through the configured SDK maximum.
+
+        Raises:
+            ConfigurationError: URL, timeout, retry count, or credential format
+                is invalid.
+            AuthenticationError: No credential can be resolved.
+
+        Preconditions:
+            ``base_url`` points to the public Website Backend, never private MCP.
+
+        Postconditions:
+            The client stores only validated configuration and performs no
+            network request until ``json`` or ``multipart`` is called.
+
+        Side Effects:
+            May read the environment or user credential file.
+
+        Security/Privacy:
+            The API key remains private client state and is omitted from repr and
+            public exceptions.
+        """
         self.base_url = _validate_base_url(base_url)
         self.timeout = _validate_timeout(timeout)
         self.max_retries = validate_max_retries(max_retries)
@@ -378,11 +831,45 @@ class BackendClient:
         self._transport: _InternalWireTransport = transport or _wire_transport
 
     def __repr__(self) -> str:
+        """Return a diagnostic representation containing no credential value.
+
+        Returns:
+            Text containing only the validated base URL and authenticated flag.
+
+        Postconditions:
+            The API key, request bodies, and idempotency keys are absent.
+        """
         return f"BackendClient(base_url={self.base_url!r}, authenticated=True)"
 
     def _headers(
         self, *, content_type: str, idempotency_key: str | None
     ) -> dict[str, str]:
+        """Build the complete header set for one public SDK request.
+
+        Args:
+            content_type: MIME type matching the already serialized body.
+            idempotency_key: Stable logical-operation key, or ``None`` for a read
+                or other request that does not require replay protection.
+
+        Returns:
+            New header dictionary containing Accept, Authorization, Content-Type,
+            User-Agent, and optional Idempotency-Key.
+
+        Raises:
+            ConfigurationError: The idempotency key is not header-safe.
+
+        Preconditions:
+            The client contains a validated API key and ``content_type`` is owned
+            by the JSON or multipart serializer.
+
+        Postconditions:
+            Each call returns a fresh mapping; modifying it cannot mutate client
+            configuration.
+
+        Security/Privacy:
+            The returned mapping contains a live Bearer credential and must not
+            be logged or persisted.
+        """
         headers = {
             "Accept": "application/json",
             "Authorization": f"Bearer {self._api_key}",
@@ -404,6 +891,42 @@ class BackendClient:
         deadline: float | None = None,
         expected_status: int | None = None,
     ) -> Mapping[str, Any]:
+        """Execute a bounded public request under the SDK retry/deadline policy.
+
+        Args:
+            method: HTTP method accepted by the public transport validator.
+            path: Relative ``/sdk/...`` endpoint; absolute or private paths fail.
+            content_type: MIME type corresponding to ``body``.
+            body: Exact serialized bytes, or ``None``.
+            idempotency_key: Stable key reused byte-for-byte across every retry.
+            deadline: Optional monotonic absolute deadline shared by operation
+                polling; ``None`` uses only the per-attempt timeout.
+            expected_status: Optional exact successful status required by the
+                asynchronous operation contract.
+
+        Returns:
+            Validated public JSON mapping from the first successful attempt.
+
+        Raises:
+            KumaError: Validation, authentication, permission, timeout, limit,
+                service, malformed-response, or deadline handling fails.
+
+        Preconditions:
+            Body serialization and privacy checks are complete. Mutating requests
+            carry the same idempotency key for the same logical operation.
+
+        Postconditions:
+            At most ``max_retries + 1`` attempts occur. Every retry uses identical
+            method, URL, headers, body, and idempotency key. ``ServiceBusyError``
+            is returned immediately to avoid amplifying server load.
+
+        Side Effects:
+            Performs network I/O and sleeps for bounded transient backoff.
+
+        Security/Privacy:
+            Sends only to the validated public base URL plus validated SDK path;
+            mapped exceptions never include the credential or raw response.
+        """
         method = validate_request(method, path, idempotency_key)
         headers = self._headers(
             content_type=content_type,
@@ -446,6 +969,34 @@ class BackendClient:
         _deadline: float | None = None,
         _expected_status: int | None = None,
     ) -> Mapping[str, Any]:
+        """Serialize and send one deterministic public JSON request.
+
+        Args:
+            method: Public HTTP method; normalized to uppercase.
+            path: Relative ``/sdk/...`` endpoint.
+            payload: JSON-compatible mapping, or ``None`` for no body.
+            idempotency_key: Stable replay key for a mutating logical operation.
+            _deadline: Internal monotonic operation deadline propagated to
+                transport retries.
+            _expected_status: Internal exact-success status requirement.
+
+        Returns:
+            Validated public JSON response mapping.
+
+        Raises:
+            ValidationError: ``payload`` is not finite JSON serializable.
+            KumaError: Request validation, transport, status, or response fails.
+
+        Preconditions:
+            Payload fields satisfy the endpoint's public schema and privacy rules.
+
+        Postconditions:
+            A non-``None`` payload is encoded as compact UTF-8 JSON with stable
+            insertion order and no NaN/Infinity. Retries reuse those exact bytes.
+
+        Side Effects:
+            Delegates network I/O and bounded retries to :meth:`_send`.
+        """
         try:
             body = (
                 None
@@ -479,6 +1030,38 @@ class BackendClient:
         _deadline: float | None = None,
         _expected_status: int | None = None,
     ) -> Mapping[str, Any]:
+        """Serialize and upload bounded public Evidence as multipart form data.
+
+        Args:
+            path: Relative public Judge endpoint.
+            fields: Validated text form fields.
+            parts: Ordered, bounded Evidence parts approved for upload.
+            idempotency_key: Required stable key for the logical Judge request.
+            _deadline: Internal monotonic operation deadline.
+            _expected_status: Internal exact-success status requirement.
+
+        Returns:
+            Validated public JSON response mapping.
+
+        Raises:
+            ValidationError: Multipart metadata cannot be serialized safely.
+            KumaError: Request validation, transport, status, or response fails.
+
+        Preconditions:
+            Evidence projection has enforced the dynamic file/byte limits,
+            association contract, and sensitive-data policy.
+
+        Postconditions:
+            The multipart body is generated once; every retry reuses the exact
+            body, boundary, and idempotency key.
+
+        Side Effects:
+            Performs bounded public Backend upload through :meth:`_send`.
+
+        Security/Privacy:
+            This boundary never contacts Core directly and must receive only the
+            already allowlisted public Evidence representation.
+        """
         content_type, body = encode_multipart(fields, parts)
         return self._send(
             "POST",

--- a/src/kuma/transport/http.py
+++ b/src/kuma/transport/http.py
@@ -15,11 +15,19 @@ _RETRY_BACKOFF_MAX_SECONDS = 2.0
 
 @dataclass(frozen=True, slots=True)
 class WireResponse:
+    """Return a decoded public HTTP status and JSON object from a transport.
+
+    Attributes:
+        status: Integer HTTP status code.
+        payload: Decoded JSON object; scalar/list bodies are rejected earlier.
+    """
+
     status: int
     payload: Mapping[str, Any]
 
 
 def validate_request(method: str, path: str, idempotency_key: str | None) -> str:
+    """Reject an oversized serialized request before network I/O."""
     normalized_method = method.upper()
     if (
         not path.startswith("/sdk/")
@@ -37,6 +45,7 @@ def validate_request(method: str, path: str, idempotency_key: str | None) -> str
 
 
 def request_timeout(default: float, deadline: float | None) -> float:
+    """Clamp one HTTP attempt to both its timeout and remaining deadline."""
     if deadline is None:
         return default
     remaining = deadline - time.monotonic()
@@ -50,6 +59,7 @@ def request_timeout(default: float, deadline: float | None) -> float:
 
 
 def retry_delay(attempts: int, deadline: float | None) -> float:
+    """Return bounded exponential backoff for a transient HTTP attempt."""
     delay = min(
         _RETRY_BACKOFF_BASE_SECONDS * (2**attempts),
         _RETRY_BACKOFF_MAX_SECONDS,
@@ -63,6 +73,7 @@ def validated_response(
     response: Mapping[str, Any] | WireResponse,
     expected_status: int | None,
 ) -> Mapping[str, Any]:
+    """Validate response status, body size, JSON shape, and expected status."""
     if isinstance(response, WireResponse):
         if expected_status is not None and response.status != expected_status:
             raise ServiceError(

--- a/src/kuma/transport/operations.py
+++ b/src/kuma/transport/operations.py
@@ -15,7 +15,11 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
-from ..config import DEFAULT_OPERATION_WAIT_TIMEOUT, validate_operation_wait_timeout
+from ..config import (
+    DEFAULT_CASE_MAX_STEPS,
+    DEFAULT_OPERATION_WAIT_TIMEOUT,
+    validate_operation_wait_timeout,
+)
 from ..errors import (
     KumaError,
     KumaTimeoutError,
@@ -56,11 +60,28 @@ def request_identity(payload: Mapping[str, Any], *, base_url: str) -> str:
 
 
 def _base_url_identity(base_url: str) -> str:
+    """Hash the normalized Backend origin without persisting credentials."""
     return hashlib.sha256(base_url.encode("utf-8")).hexdigest()
 
 
 @dataclass(frozen=True, slots=True)
 class PendingOperation:
+    """Persist only safe metadata required to resume an asynchronous operation.
+
+    Attributes:
+        operation_type: Closed local type, currently Case generation or Judge.
+        idempotency_key: Stable public request key reused after response loss.
+        base_url_identity: Hash of the public Backend identity, never its key.
+        created_at: Local wall-clock seconds when this request identity began.
+        updated_at: Local wall-clock seconds of the last metadata change.
+        operation_id: Opaque Backend operation reference after acceptance, or
+            ``None`` while retrying a lost POST response.
+
+    Security/Privacy:
+        No API key, request payload, Case, Evidence, model output, or remote error
+        body is stored in this object.
+    """
+
     operation_type: str
     idempotency_key: str
     base_url_identity: str
@@ -79,27 +100,66 @@ class PendingOperationStore:
         operation_type: str,
         base_url: str,
     ) -> None:
-        self.path = None if path is None else path.expanduser().resolve()
+        """Bind resumable metadata to one operation type and Backend identity.
+
+        Args:
+            path: Run-owned state file, or ``None`` for process-local state.
+            operation_type: Closed Case/Judge operation label validated on load.
+            base_url: Public Backend identity; only its hash is persisted.
+
+        Raises:
+            ProviderError: If the selected state path cannot be resolved safely.
+
+        Security/Privacy:
+            Construction stores no API key, request payload, or raw Backend URL
+            in the persisted state.
+        """
+        path_failed = False
+        try:
+            self.path = None if path is None else path.expanduser().resolve()
+        except (AttributeError, TypeError, ValueError, OSError, RuntimeError):
+            path_failed = True
+        if path_failed:
+            raise ProviderError(
+                "The pending operation state is unavailable",
+                code="operation_state_unavailable",
+            ) from None
         self.operation_type = operation_type
         self.base_url_identity = _base_url_identity(base_url)
         self._memory_state: PendingOperation | None = None
 
     def load(self) -> PendingOperation | None:
+        """Load and validate pending state without exposing request content.
+
+        Returns:
+            Valid pending metadata, or ``None`` when no operation is stored.
+
+        Raises:
+            ProviderError: With ``operation_state_invalid`` when metadata cannot
+                be inspected, decoded, or validated; raw local errors are detached.
+
+        Side Effects:
+            Reads at most the configured local state file and performs no network
+            request or operation replay.
+        """
         with _STATE_LOCK:
             if self.path is None:
                 return self._memory_state
-            if not self.path.exists():
-                return None
             try:
+                if not self.path.exists():
+                    return None
                 raw = json.loads(self.path.read_text(encoding="utf-8"))
-            except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-                raise ProviderError(
-                    "The pending operation state is unreadable",
-                    code="operation_state_invalid",
-                ) from exc
-            return self._validate(raw)
+            except (OSError, UnicodeError, json.JSONDecodeError):
+                pass
+            else:
+                return self._validate(raw)
+            raise ProviderError(
+                "The pending operation state is unreadable",
+                code="operation_state_invalid",
+            ) from None
 
     def load_or_create(self, key_factory: Callable[[], str]) -> PendingOperation:
+        """Load pending state or atomically create it with one stable key."""
         with _STATE_LOCK:
             existing = self.load()
             if existing is not None:
@@ -118,6 +178,7 @@ class PendingOperationStore:
     def set_operation_id(
         self, state: PendingOperation, operation_id: str
     ) -> PendingOperation:
+        """Persist the accepted operation ID without changing its stable key."""
         with _STATE_LOCK:
             validated_id = _operation_id(operation_id)
             current = self.load()
@@ -142,6 +203,16 @@ class PendingOperationStore:
             return updated
 
     def clear(self) -> None:
+        """Remove terminal operation state while tolerating prior absence.
+
+        Raises:
+            ProviderError: If the state file cannot be removed; raw path and OS
+                diagnostics are detached from the public exception chain.
+
+        Postconditions:
+            Memory state is cleared first. Successful file removal may also prune
+            its now-empty Run directory without touching committed Evidence.
+        """
         with _STATE_LOCK:
             self._memory_state = None
             if self.path is None:
@@ -150,16 +221,35 @@ class PendingOperationStore:
                 self.path.unlink(missing_ok=True)
             except FileNotFoundError:
                 return
-            except OSError as exc:
-                raise ProviderError(
-                    "The completed operation state could not be cleared",
-                    code="operation_state_unavailable",
-                ) from exc
-            # A non-empty Run directory can also contain committed Evidence.
-            with suppress(OSError):
-                self.path.parent.rmdir()
+            except OSError:
+                pass
+            else:
+                # A non-empty Run directory can also contain committed Evidence.
+                with suppress(OSError):
+                    self.path.parent.rmdir()
+                return
+            raise ProviderError(
+                "The completed operation state could not be cleared",
+                code="operation_state_unavailable",
+            ) from None
 
     def _write(self, state: PendingOperation) -> None:
+        """Atomically persist non-secret resume metadata with owner-only permissions.
+
+        Args:
+            state: Validated operation ID/key/timestamp metadata; never payload or
+                credential content.
+
+        Raises:
+            ProviderError: If a local filesystem operation fails. Its public code
+                is ``operation_state_unavailable`` with no raw exception chain.
+            BaseException: Non-filesystem serialization/control-flow errors after
+                descriptor and temporary-file cleanup.
+
+        Postconditions:
+            Success atomically replaces the state file. Failure closes any raw
+            descriptor still owned here and removes the temporary file.
+        """
         if self.path is None:
             self._memory_state = state
             return
@@ -172,6 +262,8 @@ class PendingOperationStore:
             "created_at": state.created_at,
             "updated_at": state.updated_at,
         }
+        descriptor: int | None = None
+        temporary: Path | None = None
         try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
             descriptor, temporary_name = tempfile.mkstemp(
@@ -180,28 +272,30 @@ class PendingOperationStore:
                 dir=self.path.parent,
                 text=True,
             )
-        except OSError as exc:
-            raise ProviderError(
-                "The pending operation state could not be saved",
-                code="operation_state_unavailable",
-            ) from exc
-        temporary = Path(temporary_name)
-        try:
+            temporary = Path(temporary_name)
             with os.fdopen(descriptor, "w", encoding="utf-8", newline="") as handle:
+                descriptor = None
                 json.dump(payload, handle, separators=(",", ":"), allow_nan=False)
                 handle.write("\n")
             temporary.chmod(0o600)
             temporary.replace(self.path)
+            return
         except BaseException as exc:
-            temporary.unlink(missing_ok=True)
-            if isinstance(exc, OSError):
-                raise ProviderError(
-                    "The pending operation state could not be saved",
-                    code="operation_state_unavailable",
-                ) from exc
-            raise
+            if descriptor is not None:
+                with suppress(OSError):
+                    os.close(descriptor)
+            if temporary is not None:
+                with suppress(OSError):
+                    temporary.unlink(missing_ok=True)
+            if not isinstance(exc, OSError):
+                raise
+        raise ProviderError(
+            "The pending operation state could not be saved",
+            code="operation_state_unavailable",
+        ) from None
 
     def _validate(self, raw: Any) -> PendingOperation:
+        """Validate closed-schema state against the expected operation and Backend."""
         if not isinstance(raw, Mapping) or set(raw) != {
             "schema_version",
             "operation_type",
@@ -250,6 +344,7 @@ class PendingOperationStore:
 
 
 def _valid_timestamp(value: Any) -> bool:
+    """Return whether timestamp satisfies the resumable asynchronous operations contract."""
     return (
         not isinstance(value, bool)
         and isinstance(value, int | float)
@@ -259,6 +354,7 @@ def _valid_timestamp(value: Any) -> bool:
 
 
 def _operation_id(value: Any) -> str:
+    """Validate and return a bounded opaque Backend operation identifier."""
     if not isinstance(value, str) or not 1 <= len(value) <= _MAX_OPERATION_ID_CHARS:
         raise ProviderError(
             "The Backend returned an invalid operation_id",
@@ -268,6 +364,7 @@ def _operation_id(value: Any) -> str:
 
 
 def _start_response(response: Mapping[str, Any]) -> tuple[str, int]:
+    """Validate the closed 202 operation envelope and bounded poll interval."""
     if set(response) != {"operation_id", "status", "poll_after_ms"}:
         raise ProviderError(
             "The Backend returned an invalid operation start response",
@@ -289,7 +386,34 @@ def _start_response(response: Mapping[str, Any]) -> tuple[str, int]:
 
 def _poll_response(
     response: Mapping[str, Any], expected_operation_id: str
-) -> tuple[str, Mapping[str, Any] | None, tuple[str, bool] | None]:
+) -> tuple[
+    str,
+    Mapping[str, Any] | None,
+    tuple[str, bool, str | None, Mapping[str, Any] | None] | None,
+]:
+    """Validate a poll envelope and separate active, success, and failure data.
+
+    Args:
+        response: Untrusted JSON mapping returned by the public operation GET.
+        expected_operation_id: Opaque ID stored for the current resumable request.
+
+    Returns:
+        Status plus either a succeeded result mapping or a closed failed-error
+        tuple. Case step-limit errors may additionally carry the sole safe detail
+        ``max_allowed_steps``.
+
+    Raises:
+        ProviderError: If IDs differ, status/fields violate the closed union, or
+            a field has the wrong type, range, or nested shape.
+
+    Postconditions:
+        Returned values contain no unknown response fields. This function does
+        not clear pending state; ``await_operation`` commits that transition.
+
+    Security/Privacy:
+        Arbitrary remote details and malformed messages cannot enter public SDK
+        exceptions through the asynchronous polling path.
+    """
     operation_id = _operation_id(response.get("operation_id"))
     status = response.get("status")
     if operation_id != expected_operation_id:
@@ -316,15 +440,32 @@ def _poll_response(
         "error",
     }:
         error = response["error"]
-        if isinstance(error, Mapping) and set(error) == {"code", "retryable"}:
+        if isinstance(error, Mapping) and set(error) in (
+            {"code", "retryable"},
+            {"code", "message", "retryable"},
+            {"code", "retryable", "details"},
+            {"code", "message", "retryable", "details"},
+        ):
             code = error["code"]
             retryable = error["retryable"]
+            message = error.get("message")
+            details = error.get("details")
+            details_valid = "details" not in error or (
+                code == "case_step_limit_exceeded"
+                and isinstance(details, Mapping)
+                and set(details) == {"max_allowed_steps"}
+                and not isinstance(details.get("max_allowed_steps"), bool)
+                and isinstance(details.get("max_allowed_steps"), int)
+                and 1 <= details["max_allowed_steps"] <= DEFAULT_CASE_MAX_STEPS
+            )
             if (
                 isinstance(code, str)
                 and 1 <= len(code) <= 64
                 and isinstance(retryable, bool)
+                and ("message" not in error or isinstance(message, str))
+                and details_valid
             ):
-                return status, None, (code, retryable)
+                return status, None, (code, retryable, message, details)
     raise ProviderError(
         "The Backend returned an invalid operation status response",
         code="invalid_response",
@@ -343,7 +484,49 @@ def await_operation(
     wait_timeout: float,
     accept_result: Callable[[Mapping[str, Any]], Mapping[str, Any]] | None = None,
 ) -> Mapping[str, Any]:
-    """Return one accepted public result while preserving resumable state."""
+    """Start or resume one operation until a validated terminal result arrives.
+
+    The stable key and operation ID survive retryable transport failures and
+    wait timeouts. State is cleared only after result acceptance or a terminal
+    public failure, preventing a retry from creating a second paid operation.
+
+    Args:
+        client: Public Backend client used for operation-status GET requests.
+        store: Resume store scoped to the exact request identity and Backend.
+        key_factory: Called only when no pending state exists to create one stable
+            idempotency key.
+        start: POST callback receiving the stable key and absolute monotonic
+            deadline. Retries must reuse its key.
+        wait_timeout: Total positive seconds for start and all polling attempts.
+        accept_result: Optional boundary validator/normalizer called on succeeded
+            ``result`` before pending state is cleared.
+
+    Returns:
+        Terminal succeeded result, or ``accept_result(result)`` when supplied.
+
+    Raises:
+        KumaTimeoutError: Deadline expires; pending metadata remains for retry.
+        KumaError: Public transport or terminal operation failure. Retryable
+            interruptions preserve state except stable operation-not-found.
+        ProviderError: Start/poll/result schema or local state is invalid.
+
+    Preconditions:
+        ``store`` is bound to this operation type/request identity; ``start`` is
+        idempotent for the provided key.
+
+    Postconditions:
+        Success clears state only after accepted result validation. Terminal
+        failed operation clears state after mapping. Timeout/transient failure
+        keeps the same key and operation ID for GET-only resume where possible.
+
+    Side Effects:
+        May atomically write/delete pending metadata, issue one idempotent POST,
+        sleep according to bounded server polling guidance, and issue status GETs.
+
+    Security/Privacy:
+        The store contains no credential, request payload, Evidence, or response
+        body; errors expose only stable safe public fields.
+    """
 
     deadline = time.monotonic() + validate_operation_wait_timeout(wait_timeout)
     state = store.load_or_create(key_factory)
@@ -382,11 +565,17 @@ def await_operation(
             return accepted
         if status == "failed" and error is not None:
             store.clear()
-            raise mapped_error(error[0], retryable=error[1])
+            raise mapped_error(
+                error[0],
+                retryable=error[1],
+                message=error[2],
+                details=error[3],
+            )
         _sleep_bounded(poll_after_ms, deadline)
 
 
 def _ensure_time_remaining(deadline: float) -> None:
+    """Raise a retryable wait timeout without clearing resumable operation state."""
     if time.monotonic() >= deadline:
         raise KumaTimeoutError(
             "The KUMA operation did not finish before the wait timeout.",
@@ -396,6 +585,7 @@ def _ensure_time_remaining(deadline: float) -> None:
 
 
 def _sleep_bounded(poll_after_ms: int, deadline: float) -> None:
+    """Sleep for the server interval without crossing the operation deadline."""
     remaining = deadline - time.monotonic()
     if remaining <= 0:
         _ensure_time_remaining(deadline)

--- a/tools/verify_public_api_docs.py
+++ b/tools/verify_public_api_docs.py
@@ -25,6 +25,15 @@ class PublicApi:
     source: str
     qualified_name: str
     dataclass_fields: bool = False
+    required_docstring_sections: tuple[str, ...] = (
+        "Args",
+        "Returns",
+        "Raises",
+        "Preconditions",
+        "Postconditions",
+        "Side Effects",
+        "Security/Privacy",
+    )
 
 
 PUBLIC_APIS = (
@@ -33,7 +42,19 @@ PUBLIC_APIS = (
     PublicApi("get_input", "src/kuma/run.py", "Run.get_input"),
     PublicApi("submit", "src/kuma/run.py", "Run.submit"),
     PublicApi("judge", "src/kuma/run.py", "Run.judge"),
-    PublicApi("KumaClient", "src/kuma/client.py", "KumaClient.__init__"),
+    PublicApi(
+        "KumaClient",
+        "src/kuma/client.py",
+        "KumaClient.__init__",
+        required_docstring_sections=(
+            "Args",
+            "Raises",
+            "Preconditions",
+            "Postconditions",
+            "Side Effects",
+            "Security/Privacy",
+        ),
+    ),
     PublicApi(
         "configure_trace_evidence",
         "src/kuma/otel.py",
@@ -44,6 +65,13 @@ PUBLIC_APIS = (
         "src/kuma/evidence/trace.py",
         "TraceEvidenceLimits",
         dataclass_fields=True,
+        required_docstring_sections=(
+            "Args",
+            "Raises",
+            "Preconditions",
+            "Postconditions",
+            "Security/Privacy",
+        ),
     ),
 )
 
@@ -191,8 +219,9 @@ def _validate_document(
 def _validate_source_docstrings(
     source_contracts: dict[str, tuple[tuple[str, ...], str]],
 ) -> list[str]:
-    """Require source docstrings to mention every public parameter by name."""
+    """Require public parameters and applicable contract sections in source docs."""
     errors: list[str] = []
+    api_by_name = {api.name: api for api in PUBLIC_APIS}
     for name, (parameters, docstring) in source_contracts.items():
         if not docstring:
             errors.append(f"source docstring missing for {name}")
@@ -201,6 +230,16 @@ def _validate_source_docstrings(
             f"source docstring for {name} omits {parameter}"
             for parameter in parameters
             if parameter not in docstring
+        )
+        headings = {
+            line.strip()[:-1]
+            for line in docstring.splitlines()
+            if line.strip().endswith(":")
+        }
+        errors.extend(
+            f"source docstring for {name} omits {section} section"
+            for section in api_by_name[name].required_docstring_sections
+            if section not in headings
         )
     return errors
 


### PR DESCRIPTION
## Summary

This clean public sync brings the accepted private KUMA SDK production tree forward without exporting private tests, acceptance assets, or internal services.

- replace the ambiguous public `max_inputs` option with `max_steps`, enforce the advertised service limit before Case generation, and never clamp or truncate a returned Case
- fail closed on private custom-Case fields, cyclic/deep JSON, missing required requirements, unsafe log paths/TOCTOU, and sanitized filesystem failures
- make OTel loss accounting accurate, add bounded native OTel log metadata, and accept UTF-8 BOM requirement files
- negotiate Runtime Evidence v2 only when advertised, adding the bounded/scanned completed Agent output while preserving byte-compatible v1 hash-only behavior
- accept the frozen optional async error message without accepting unknown error fields
- keep bilingual API documentation, examples, pre/postconditions, limits, and privacy behavior aligned with the source

## Verification

- private canonical suite bound to this public source: 399 passed, 7 skipped
- Ruff format/check: pass
- public API documentation verifier: pass (8 APIs, English and Chinese)
- compileall and deterministic `examples/minimal_local.py`: pass
- DEF-122 public projection tests: 13 passed
- wheel/sdist build, Twine, clean wheel/sdist install, version/import/CLI smoke: pass
- Markdown relative links: pass
- detect-secrets 1.5.0: zero findings

No production service, model, paid flow, PyPI publication, release, or deployment was used.

Fixes #14
Fixes #16
Fixes #17
Fixes #18
Fixes #19
Fixes #20
Fixes #21
Fixes #22
Fixes #23
Fixes #26