### PR TITLE
docs: align full-stack example guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 
 KUMA is the public Python SDK for testing Agent behavior through a strict `Run` protocol and bounded Evidence capture. Official services are reached only through public HTTPS; the SDK does not run Agents, execute models, or expose private evaluation logic.
 
+## Core capabilities
+
+- Synchronous, framework-neutral Case and Judge workflow.
+- Official or custom Providers, including fully local runs.
+- Bounded file, log, and optional trace Evidence.
+
 ## Install
 
 Python 3.10 or newer is required:
@@ -31,30 +37,9 @@ Run the deterministic local check without an account, API key, Docker, or networ
 kuma quickstart
 ```
 
-## Real end-to-end example
+## Full-stack user-flow example
 
-The runnable [Docker example](examples/full_stack/docker_user_flow.py) performs the real flow: obtain an official Case, run each step with mini-SWE-agent, submit Evidence, receive the official Judgment, and save it as `.kuma/mini-swe-agent/judge-report.json`.
-
-Prepare a disposable Agent workspace using the [short guide](examples/full_stack/USER_GUIDE.md), set `KUMA_BASE_URL`, `KUMA_API_KEY`, and `DEEPSEEK_API_KEY`, then run from this repository:
-
-```bash
-docker build -f examples/full_stack/Dockerfile.user-flow -t kuma-user-flow .
-workspace=/absolute/path/to/prepared-workspace
-docker run --rm \
-  --env KUMA_BASE_URL \
-  --env KUMA_API_KEY \
-  --env DEEPSEEK_API_KEY \
-  --mount "type=bind,source=$workspace,target=/workspace" \
-  kuma-user-flow
-```
-
-This calls real services and may use service credit and model budget. KUMA needs only the public Backend URL and user keys—never a private Core address.
-
-## Core capabilities
-
-- Synchronous, framework-neutral Case and Judge workflow.
-- Official or custom Providers, including fully local runs.
-- Bounded file, log, and optional trace Evidence. Runtime Evidence v1 remains hash-only; when the official service explicitly advertises v2, the completed step may include the final Agent output after strict JSON, size, and sensitive-data checks.
+Follow the [full-stack user-flow guide](examples/full_stack/README.md) to run KUMA with mini-SWE-agent in Docker. This path calls external services and may use service credit and model budget.
 
 ## Detailed documentation
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,6 +15,12 @@
 
 KUMA 是公开 Python SDK，通过严格的 `Run` 协议和有界 Evidence 采集测试 Agent 行为。官方服务仅通过公开 HTTPS 访问；SDK 不运行 Agent、不执行模型，也不暴露私有评估逻辑。
 
+## 核心能力
+
+- 同步且不绑定框架的 Case 与 Judge 流程。
+- 支持官方或自定义 Provider，也可完全本地运行。
+- 有界采集文件、日志和可选 Trace Evidence。
+
 ## 安装
 
 需要 Python 3.10 或更高版本：
@@ -31,30 +37,9 @@ python -m pip install "kuma-defuzex==0.1.0"
 kuma quickstart
 ```
 
-## 真实全流程示例
+## 全栈用户流程示例
 
-可运行的 [Docker 示例](examples/full_stack/docker_user_flow.py)会完成真实流程：获取官方 Case、用 mini-SWE-agent 执行每个步骤、提交 Evidence、取得官方 Judgment，并保存为 `.kuma/mini-swe-agent/judge-report.json`。
-
-按照[简短指南](examples/full_stack/USER_GUIDE.md)准备一次性 Agent 工作区，设置 `KUMA_BASE_URL`、`KUMA_API_KEY` 和 `DEEPSEEK_API_KEY`，然后在本仓库执行：
-
-```bash
-docker build -f examples/full_stack/Dockerfile.user-flow -t kuma-user-flow .
-workspace=/absolute/path/to/prepared-workspace
-docker run --rm \
-  --env KUMA_BASE_URL \
-  --env KUMA_API_KEY \
-  --env DEEPSEEK_API_KEY \
-  --mount "type=bind,source=$workspace,target=/workspace" \
-  kuma-user-flow
-```
-
-该流程会调用真实服务，可能消耗服务 Credit 和模型预算。KUMA 只需要公网 Backend 地址和用户密钥，不需要私有 Core 地址。
-
-## 核心能力
-
-- 同步且不绑定框架的 Case 与 Judge 流程。
-- 支持官方或自定义 Provider，也可完全本地运行。
-- 有界采集文件、日志和可选 Trace Evidence。Runtime Evidence v1 仍仅含哈希；仅当官方服务明确声明支持 v2 时，已完成步骤才可在严格 JSON、大小和敏感数据检查后携带 Agent 最终输出。
+按照[全栈用户流程指南](examples/full_stack/README.zh-CN.md)，可在 Docker 中组合运行 KUMA 与 mini-SWE-agent。该流程会调用外部服务，可能消耗服务 Credit 和模型预算。
 
 ## 详细文档
 

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -273,7 +273,7 @@ Build the supplied user-flow example:
 docker build -f examples/full_stack/Dockerfile.user-flow -t kuma-user-flow .
 ```
 
-See the [full-stack example guide](../examples/full_stack/USER_GUIDE.md) for its exact workspace and runtime requirements.
+See the [full-stack user-flow guide](../examples/full_stack/README.md) for its exact workspace and runtime requirements.
 
 ## Errors, retries, and timeouts
 
@@ -315,6 +315,6 @@ An operation timeout retains bounded recovery metadata without storing credentia
 - [Runtime Evidence contract](runtime-evidence.md)
 - [Minimal local example](../examples/minimal_local.py)
 - [Single Agent template](../examples/single_agent_template/README.md)
-- [Full-stack example](../examples/full_stack/USER_GUIDE.md)
+- [Full-stack user-flow example](../examples/full_stack/README.md)
 - [Security policy](../SECURITY.md)
 - [Contributing](../CONTRIBUTING.md)

--- a/docs/sdk-guide.zh-CN.md
+++ b/docs/sdk-guide.zh-CN.md
@@ -267,7 +267,7 @@ span 数量、属性、事件、文本和整个 Run 的字节数均有上限。�
 docker build -f examples/full_stack/Dockerfile.user-flow -t kuma-user-flow .
 ```
 
-示例所需的工作区和运行参数见[完整流程示例指南](../examples/full_stack/USER_GUIDE.md)。
+示例所需的工作区和运行参数见[全栈用户流程指南](../examples/full_stack/README.zh-CN.md)。
 
 ## 错误、重试与超时
 
@@ -309,6 +309,6 @@ operation 超时只保留有界恢复元数据，不保存凭证、请求正文�
 - [Runtime Evidence 合同](runtime-evidence.md)
 - [最小本地示例](../examples/minimal_local.py)
 - [Single Agent 模板](../examples/single_agent_template/README.md)
-- [完整流程示例](../examples/full_stack/USER_GUIDE.md)
+- [全栈用户流程示例](../examples/full_stack/README.zh-CN.md)
 - [安全策略](../SECURITY.md)
 - [贡献说明](../CONTRIBUTING.md)

--- a/examples/full_stack/README.md
+++ b/examples/full_stack/README.md
@@ -1,6 +1,8 @@
 # KUMA full-stack user-flow example
 
-This file covers only the supplied mini-SWE-agent example. General SDK installation, API key setup, requirement format, Run protocol, Evidence, OpenTelemetry, Docker boundaries, and troubleshooting live in the canonical [English guide](../../docs/sdk-guide.md) and [简体中文指南](../../docs/sdk-guide.zh-CN.md).
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+This guide covers only the supplied mini-SWE-agent example. General SDK installation, API key setup, requirement format, Run protocol, Evidence, OpenTelemetry, Docker boundaries, and troubleshooting live in the canonical [English guide](../../docs/sdk-guide.md) and [简体中文指南](../../docs/sdk-guide.zh-CN.md).
 
 ## What this example runs
 
@@ -28,6 +30,7 @@ Export these values before running the example:
 - `DEEPSEEK_API_KEY`
 
 Do not place populated credentials in the workspace or repository.
+Configure only the public KUMA Backend URL; this example never needs a private Core address.
 
 ## Build the image
 

--- a/examples/full_stack/README.zh-CN.md
+++ b/examples/full_stack/README.zh-CN.md
@@ -1,0 +1,85 @@
+# KUMA 全栈用户流程示例
+
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+本指南只说明仓库提供的 mini-SWE-agent 示例。SDK 的通用安装、API Key 配置、Requirement 格式、Run 协议、Evidence、OpenTelemetry、Docker 边界和故障排查，请查阅规范的[简体中文指南](../../docs/sdk-guide.zh-CN.md)或[英文指南](../../docs/sdk-guide.md)。
+
+## 示例内容
+
+该示例在同一个 Docker 容器中组合 KUMA SDK 与 mini-SWE-agent。它会请求官方 Case 与 Judge，在挂载的工作区内执行每个 Case 步骤，记录有界 Trace 和日志 Evidence，并在本地写入公开 Judge 结果。
+
+示例提供两个入口：
+
+- 使用 [`Dockerfile.user-flow`](Dockerfile.user-flow) 和 [`docker_user_flow.py`](docker_user_flow.py) 直接运行容器。
+- 使用 [`kuma_real_user_flow.ipynb`](kuma_real_user_flow.ipynb)完成 Windows/WSL 引导流程。
+
+两条路径都会调用真实外部服务，可能产生模型或服务费用。
+
+## 准备工作区
+
+请使用一次性 Git 工作区，或确保其中所有既有改动均已提交。直接运行 Docker 示例时，挂载目录必须包含：
+
+- 符合支持格式的 `requirement.md`；
+- `calculator.py`，这是示例唯一允许修改的源码文件；
+- 可通过 `python -m unittest discover -v` 运行的测试。
+
+运行前设置以下环境变量：
+
+- `KUMA_BASE_URL`
+- `KUMA_API_KEY`
+- `DEEPSEEK_API_KEY`
+
+不要将真实凭证写入工作区或仓库。
+只配置公开的 KUMA Backend URL；本示例不需要私有 Core 地址。
+
+## 构建镜像
+
+在 SDK 仓库根目录执行：
+
+```bash
+docker build -f examples/full_stack/Dockerfile.user-flow -t kuma-user-flow .
+```
+
+## 运行容器
+
+Windows PowerShell：
+
+```powershell
+$workspace = (Resolve-Path "C:\path\to\workspace").Path
+docker run --rm `
+  --env KUMA_BASE_URL `
+  --env KUMA_API_KEY `
+  --env DEEPSEEK_API_KEY `
+  --mount "type=bind,source=$workspace,target=/workspace" `
+  kuma-user-flow
+```
+
+Linux 或 macOS：
+
+```bash
+workspace="$(pwd)"
+docker run --rm \
+  --env KUMA_BASE_URL \
+  --env KUMA_API_KEY \
+  --env DEEPSEEK_API_KEY \
+  --mount "type=bind,source=$workspace,target=/workspace" \
+  kuma-user-flow
+```
+
+脚本会拒绝在 Docker 外运行，也会拒绝缺失的环境变量。如果 Agent 修改了范围外源码、Submission 未成功或最终 Judge 报告缺失，运行同样会失败。
+
+## 运行 Notebook
+
+Notebook 需要 Windows、WSL、Jupyter、上述两个 API Key 和已配置的公开 Base URL。启动 Jupyter 前先设置环境变量，再打开 [`kuma_real_user_flow.ipynb`](kuma_real_user_flow.ipynb)，按照单元格提示选择 Agent 工作区。
+
+Notebook 可能修改所选仓库。请仅选择一次性工作区，或确保仓库原有工作均已提交。
+
+## 输出
+
+直接运行流程会在挂载工作区的 `.kuma/mini-swe-agent/` 下写入：
+
+- 精简的 Agent trajectory 与验证 Evidence；
+- 各步骤的 unittest 日志；
+- 最终公开 `judge-report.json`。
+
+脚本还会输出官方 Case Inputs、最终报告、采集的 span 名称、最终 `calculator.py` 和 artifact 路径。这些输出只属于本示例；通用结果处理方式以规范 SDK 指南为准。


### PR DESCRIPTION
## Summary

- move Core capabilities above installation in both project homepages
- keep the homepage full-stack section concise and point to the canonical example guide
- rename the English full-stack guide to the conventional `README.md`, add a matching Simplified Chinese guide, and align SDK-guide references

## Validation

- Markdown: 15 files, 76 local links, 2 anchors, 15 Python fences, 1 notebook parsed; 0 failures
- `ruff check` and `ruff format --check`: passed (50 files)
- `compileall` for `src`, `examples`, and `tools`: passed
- `kuma quickstart`: passed (100/100)
- `examples/minimal_local.py`: passed (`completed`, 1 submission)
- isolated `python -m build`: wheel and sdist built; Twine checks passed
- targeted credential/private-key scan: 0 findings
- `git diff --check`: passed

README reduction:

- English: 65 -> 50 lines; 296 -> 193 whitespace-delimited words
- Chinese: 65 -> 50 lines; 170 -> 120 whitespace-delimited words

Brand scan: 0 legacy product-display names. Retained `DefuzeX`/`defuzex` occurrences are factual technical identifiers only: the `kuma-defuzex` distribution, versioned `defuzex.*` schemas/media types, the existing repository slug, and public API URLs.

No live Docker container or paid external service was invoked. This PR is intentionally Draft for user review and must not be merged automatically.