### PR TITLE
docs: clarify Strategy Group coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,33 +37,13 @@ Run the deterministic local check without an account, API key, Docker, or networ
 kuma quickstart
 ```
 
-## Choose a Strategy Group
-
-For official runs, configure `KUMA_API_KEY`, then fetch the current public catalog:
-
-```bash
-kuma strategies list
-kuma strategies list --output strategy-groups.json
-```
-
-KUMA validates the catalog before showing or saving its group `id`/`version`, `display_name`, `description`, `available`, `required_capabilities`, `limits.max_steps`, `limits.supported_difficulties`, and exact `default` coordinate. Copy a selected coordinate into the Requirement front matter:
-
-```yaml
-strategy_group:
-  schema_version: kuma.strategy_group_selection.v1
-  id: <catalog group id>
-  version: "<catalog version>"
-```
-
-Only these three fields are user-owned; KUMA fills `selection_source` and `catalog_release`. An unknown, unavailable, or capability-incompatible explicit selection fails closed. Omitting `strategy_group` uses the catalog's `default.id` and `default.version`; “general” is its meaning, not a fixed ID. `scan_strategy_group=True` is an explicit opt-in to conservative local suggestion. See [Strategy Groups](docs/strategy-groups.md).
-
 ## Full-stack user-flow example
 
 Follow the [full-stack user-flow guide](examples/full_stack/README.md) to run KUMA with mini-SWE-agent in Docker. This path calls external services and may use service credit and model budget.
 
 ## Detailed documentation
 
-[English SDK guide](docs/sdk-guide.md) · [Python API reference](docs/api-reference.md) · [简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [中文 API 参考](docs/api-reference.zh-CN.md) · [Runtime Evidence contract](docs/runtime-evidence.md)
+[English SDK guide](docs/sdk-guide.md) · [Strategy Groups](docs/strategy-groups.md) · [Python API reference](docs/api-reference.md) · [简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [中文 API 参考](docs/api-reference.zh-CN.md) · [Runtime Evidence contract](docs/runtime-evidence.md)
 
 ## Project
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,33 +37,13 @@ python -m pip install "kuma-defuzex==0.1.0"
 kuma quickstart
 ```
 
-## 选择策略组
-
-使用官方服务时，请先配置 `KUMA_API_KEY`，再查询当前公共目录：
-
-```bash
-kuma strategies list
-kuma strategies list --output strategy-groups.json
-```
-
-KUMA 会先校验目录，再显示或保存策略组的 `id`/`version`、`display_name`、`description`、`available`、`required_capabilities`、`limits.max_steps`、`limits.supported_difficulties` 以及精确的 `default` 坐标。把选中的坐标写入 Requirement front matter：
-
-```yaml
-strategy_group:
-  schema_version: kuma.strategy_group_selection.v1
-  id: <目录中的策略组 ID>
-  version: "<目录中的版本>"
-```
-
-用户只能填写这三个字段；`selection_source` 和 `catalog_release` 由 KUMA 补充。显式选择未知、不可用或能力不满足的策略组时会直接拒绝，不会静默回退。省略 `strategy_group` 时使用目录中的 `default.id` 与 `default.version`；“general”只是语义，不是固定 ID。`scan_strategy_group=True` 只是明确启用本地保守建议。详见[策略组](docs/strategy-groups.zh-CN.md)。
-
 ## 全栈用户流程示例
 
 按照[全栈用户流程指南](examples/full_stack/README.zh-CN.md)，可在 Docker 中组合运行 KUMA 与 mini-SWE-agent。该流程会调用外部服务，可能消耗服务 Credit 和模型预算。
 
 ## 详细文档
 
-[简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [中文 API 参考](docs/api-reference.zh-CN.md) · [English SDK guide](docs/sdk-guide.md) · [Python API reference](docs/api-reference.md) · [Runtime Evidence 合同](docs/runtime-evidence.md)
+[简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [策略组](docs/strategy-groups.zh-CN.md) · [中文 API 参考](docs/api-reference.zh-CN.md) · [English SDK guide](docs/sdk-guide.md) · [Python API reference](docs/api-reference.md) · [Runtime Evidence 合同](docs/runtime-evidence.md)
 
 ## 项目链接
 

--- a/docs/strategy-groups.md
+++ b/docs/strategy-groups.md
@@ -12,13 +12,19 @@ Configure the official key through `KUMA_API_KEY`, then run:
 kuma strategies list
 ```
 
-The command performs an authenticated catalog read, validates the complete response, and prints canonical JSON. Each group contains:
+The command performs an authenticated catalog read, validates the complete response, and prints canonical JSON. Each `groups[]` entry is one exact selectable coordinate and contains:
 
 - `id` and `version`: the exact coordinate used in a Requirement;
 - `display_name` and `description`: its public name and purpose;
 - `available`: whether it accepts new selections;
 - `required_capabilities`: Runtime Evidence capabilities the Run must support;
 - `limits.max_steps` and `limits.supported_difficulties`: public execution bounds.
+
+Versions are not grouped into a nested list. If one group ID has multiple
+selectable versions, the response contains multiple `groups[]` entries with the
+same `id` and different `version` values. Always choose an entry whose
+`available` value is `true`. In the current catalog, for example, `BASE-01` is
+available at version `"1"`.
 
 The top-level `default.id` and `default.version` identify the exact default group. Save the same validated JSON atomically when you need a reviewable local copy:
 
@@ -30,7 +36,9 @@ kuma strategies list --output strategy-groups.json
 
 ## Select a group in a Requirement
 
-Copy one available catalog coordinate into the YAML front matter:
+Choose one available `groups[]` entry and copy its machine-readable `id` and
+`version` exactly into the YAML front matter. For example, the current Security
+group is `CAND-007@1`:
 
 ```yaml
 ---
@@ -38,12 +46,17 @@ agent_description: A repository maintenance agent
 input_type: text
 strategy_group:
   schema_version: kuma.strategy_group_selection.v1
-  id: <catalog group id>
-  version: "<catalog version>"
+  id: CAND-007
+  version: "1"
 ---
 ```
 
-The object is closed: only `schema_version`, `id`, and `version` are accepted. `selection_source` and `catalog_release` describe validated runtime facts, so KUMA fills them after resolving the current catalog; they must not be placed in the Requirement.
+Here `id` means the exact `groups[].id` value. Do not use `display_name`, a
+numbered list position, or the member strategy that the group runs internally,
+and never leave placeholder text in a real Requirement. The object is closed:
+only `schema_version`, `id`, and `version` are accepted. `selection_source` and
+`catalog_release` describe validated runtime facts, so KUMA fills them after
+resolving the current catalog; they must not be placed in the Requirement.
 
 An explicit coordinate has priority. An unknown or unavailable group fails closed with `strategy_group_invalid`; a group whose `required_capabilities` are not available fails with `strategy_capability_mismatch` and lists the missing capabilities. KUMA never silently substitutes another group for an explicit choice.
 

--- a/docs/strategy-groups.zh-CN.md
+++ b/docs/strategy-groups.zh-CN.md
@@ -12,13 +12,17 @@
 kuma strategies list
 ```
 
-该命令执行带鉴权的目录读取，校验完整响应后输出规范 JSON。每个策略组包含：
+该命令执行带鉴权的目录读取，校验完整响应后输出规范 JSON。每个 `groups[]` 条目代表一个可以精确选择的坐标，包含：
 
 - `id` 与 `version`：写入 Requirement 的精确坐标；
 - `display_name` 与 `description`：公开名称和用途；
 - `available`：是否允许新选择；
 - `required_capabilities`：Run 必须支持的 Runtime Evidence 能力；
 - `limits.max_steps` 与 `limits.supported_difficulties`：公开执行边界。
+
+版本不会嵌套为单独列表。如果同一个策略组 ID 有多个可选版本，响应会
+用多条 `groups[]` 记录表示：它们的 `id` 相同、`version` 不同。只能选择
+`available: true` 的条目。例如当前目录中的 `BASE-01` 可用版本为 `"1"`。
 
 顶层 `default.id` 与 `default.version` 指向精确默认组。需要可审查的本地副本时，可原子保存同一份已校验 JSON：
 
@@ -30,7 +34,9 @@ kuma strategies list --output strategy-groups.json
 
 ## 在 Requirement 中选择策略组
 
-把一个可用的目录坐标写入 YAML front matter：
+从一个 `available: true` 的 `groups[]` 条目中，原样复制机器可读的 `id`
+和 `version` 到 YAML front matter。例如当前 Security 策略组是
+`CAND-007@1`：
 
 ```yaml
 ---
@@ -38,12 +44,16 @@ agent_description: A repository maintenance agent
 input_type: text
 strategy_group:
   schema_version: kuma.strategy_group_selection.v1
-  id: <目录中的策略组 ID>
-  version: "<目录中的版本>"
+  id: CAND-007
+  version: "1"
 ---
 ```
 
-该对象是 closed schema，只接受 `schema_version`、`id` 和 `version`。`selection_source` 与 `catalog_release` 描述校验后的运行时事实，由 KUMA 在解析当前目录后填充；不要把它们写入 Requirement。
+这里的 `id` 必须是 `groups[].id` 的精确值，不能填写 `display_name`、列表
+序号或策略组内部实际执行的 member strategy；真实 Requirement 中也不能
+保留占位符。该对象是 closed schema，只接受 `schema_version`、`id` 和
+`version`。`selection_source` 与 `catalog_release` 描述校验后的运行时事实，
+由 KUMA 在解析当前目录后填充；不要把它们写入 Requirement。
 
 显式坐标优先。未知或不可用的策略组会以 `strategy_group_invalid` 直接拒绝；如果 Run 缺少该组 `required_capabilities` 所需能力，则以 `strategy_capability_mismatch` 拒绝并列出缺失项。KUMA 不会为显式选择静默替换其他组。
 


### PR DESCRIPTION
## Summary
- keep the README landing pages concise and link to the full Strategy Group guide
- explain that each groups[] entry is one exact id/ersion coordinate
- show real CAND-007@1 Requirement examples and warn against display names, list positions, member strategies, or placeholders
- explain how multiple versions of one ID appear

## Verification
- public API documentation verifier: PASS
- Ruff format/check: PASS
- diff check: PASS

Documentation-only; no runtime, wire, PyPI, or deployment change.