### PR TITLE
fix(otel): support declared SDK version range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,26 @@ jobs:
       - run: python -m kuma --help
       - run: python examples/minimal_local.py
 
+  otel-compatibility:
+    name: OTel ${{ matrix.otel-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        otel-version: ["1.30.0", "1.38.0", "1.39.0"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: >-
+          python -m pip install -e .
+          "opentelemetry-api==${{ matrix.otel-version }}"
+          "opentelemetry-sdk==${{ matrix.otel-version }}"
+      - run: python tools/verify_otel_compat.py
+
   package:
     name: Package
     runs-on: ubuntu-latest

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -230,6 +230,11 @@ Install OTel support only when trace capture is needed; the core package does no
 python -m pip install "kuma-defuzex[otel]"
 ```
 
+The declared `opentelemetry-sdk>=1.30,<2` range is supported across the Logs
+exporter rename: KUMA uses the matching old API pair on 1.30–1.38 and the new
+pair from 1.39 onward. If an installed release exposes neither complete pair,
+the import error reports the installed version and the supported range.
+
 `create_run()` now follows this precedence:
 
 | Environment | Run behavior | Trace behavior | Warning |

--- a/docs/sdk-guide.zh-CN.md
+++ b/docs/sdk-guide.zh-CN.md
@@ -224,6 +224,10 @@ OpenTelemetry（OTel）是 Agent 框架和 instrumentation 用来产生 span 的
 python -m pip install "kuma-defuzex[otel]"
 ```
 
+声明的 `opentelemetry-sdk>=1.30,<2` 范围完整支持 Logs exporter 改名：
+KUMA 在 1.30–1.38 使用配套的旧 API 名称，从 1.39 起使用配套的新名称，
+不会混用两代符号。若安装版本不提供任一完整组合，导入错误会说明当前版本和支持范围。
+
 `create_run()` 现在按以下优先级工作：
 
 | 当前环境 | Run 行为 | Trace 行为 | 提示 |

--- a/src/kuma/otel.py
+++ b/src/kuma/otel.py
@@ -7,28 +7,83 @@ import weakref
 from collections.abc import Sequence
 from contextlib import suppress
 from dataclasses import dataclass, field
+from importlib import metadata
 from typing import Any
 
 from .errors import ConfigurationError
 from .evidence.trace import TraceEvidenceCapture, TraceEvidenceLimits
 
+
+def _resolve_log_export_api(
+    export_module: Any,
+) -> tuple[type[Any], type[Any], type[Any]]:
+    """Resolve the OTel Logs exporter rename across supported SDK releases.
+
+    OpenTelemetry Logs remains a development signal and renamed ``LogExporter``
+    and ``LogExportResult`` in 1.39 while retaining the same processor extension
+    point. KUMA supports the declared 1.30--1.x range by preferring the new names
+    and falling back to the old pair as one indivisible API generation.
+
+    Args:
+        export_module: Imported ``opentelemetry.sdk._logs.export`` module.
+
+    Returns:
+        Exporter base, result enum, and simple processor classes from one
+        supported OTel Logs API generation.
+
+    Raises:
+        ImportError: If neither complete API generation is available or the
+            processor extension point is missing.
+
+    Postconditions:
+        New and old exporter/result names are never mixed, so KUMA returns the
+        result enum expected by the installed processor implementation.
+    """
+    processor = getattr(export_module, "SimpleLogRecordProcessor", None)
+    generations = (
+        ("LogRecordExporter", "LogRecordExportResult"),
+        ("LogExporter", "LogExportResult"),
+    )
+    for exporter_name, result_name in generations:
+        exporter = getattr(export_module, exporter_name, None)
+        result = getattr(export_module, result_name, None)
+        if isinstance(exporter, type) and isinstance(result, type):
+            if not isinstance(processor, type):
+                break
+            return exporter, result, processor
+    raise ImportError("unsupported OpenTelemetry Logs exporter API")
+
+
+def _otel_import_error_message() -> str:
+    """Return an actionable optional-dependency error without internal details."""
+    try:
+        installed = metadata.version("opentelemetry-sdk")
+    except metadata.PackageNotFoundError:
+        return 'OpenTelemetry Trace Evidence requires: pip install "kuma-defuzex[otel]"'
+    return (
+        "OpenTelemetry Trace Evidence is incompatible with installed "
+        f"opentelemetry-sdk {installed}; install a supported >=1.30,<2 release "
+        'with: pip install --upgrade "kuma-defuzex[otel]"'
+    )
+
+
 try:
     from opentelemetry import trace
     from opentelemetry._logs import get_logger_provider
-    from opentelemetry.sdk._logs.export import (
-        LogRecordExporter,
-        LogRecordExportResult,
-        SimpleLogRecordProcessor,
-    )
+    from opentelemetry.sdk._logs import export as _otel_log_export
     from opentelemetry.sdk.trace import SpanProcessor
     from opentelemetry.sdk.trace.export import (
         SpanExporter,
         SpanExportResult,
     )
+
+    (
+        LogRecordExporter,
+        LogRecordExportResult,
+        SimpleLogRecordProcessor,
+    ) = _resolve_log_export_api(_otel_log_export)
 except ImportError as exc:  # pragma: no cover - exercised without the optional extra
-    raise ImportError(
-        'OpenTelemetry Trace Evidence requires: pip install "kuma-defuzex[otel]"'
-    ) from exc
+    raise ImportError(_otel_import_error_message()) from exc
 
 
 _ATTACH_LOCK = threading.RLock()

--- a/tools/verify_otel_compat.py
+++ b/tools/verify_otel_compat.py
@@ -1,0 +1,68 @@
+"""Run a network-free OTel Logs capture smoke in the installed environment."""
+
+from __future__ import annotations
+
+import logging
+from importlib import metadata
+
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk.trace import TracerProvider
+
+from kuma.otel import configure_trace_evidence
+
+
+def main() -> int:
+    """Verify that the installed supported OTel release captures one log record.
+
+    Preconditions:
+        KUMA and one declared-compatible ``opentelemetry-api``/``-sdk`` pair are
+        installed. The caller selects the version; this verifier makes no
+        package or network changes itself.
+
+    Returns:
+        Process exit code zero after one in-process LogRecord is captured.
+
+    Side Effects:
+        Temporarily attaches a private Python logger handler and KUMA processors
+        to providers owned by this process, then shuts them down before return.
+
+    Security/Privacy:
+        Emits only a fixed non-sensitive message and prints only the installed
+        SDK version plus a pass marker.
+    """
+    tracer_provider = TracerProvider()
+    logger_provider = LoggerProvider()
+    capture = configure_trace_evidence(
+        tracer_provider,
+        logger_provider=logger_provider,
+    )
+    handler = LoggingHandler(logger_provider=logger_provider)
+    logger = logging.getLogger("kuma.otel.compatibility")
+    logger.propagate = False
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    try:
+        capture.begin_step("compat-run", "compat-case", "compat-input")
+        logger.info("bounded compatibility record")
+        prepared = capture.prepare_step(
+            "compat-run",
+            "compat-case",
+            "compat-input",
+        )
+        if prepared.otel_logs.observed_count != 1:
+            raise AssertionError("expected one observed OTel log record")
+        if prepared.otel_logs.retained_count != 1:
+            raise AssertionError("expected one retained OTel log record")
+        prepared.commit()
+        capture.finish_run("compat-run", "compat-case")
+    finally:
+        logger.removeHandler(handler)
+        handler.close()
+        logger_provider.shutdown()
+        tracer_provider.shutdown()
+    print(f"OpenTelemetry SDK {metadata.version('opentelemetry-sdk')}: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #34.

- support the complete OTel Logs exporter API pair on 1.30-1.38 and the renamed pair from 1.39 onward
- never mix exporter/result generations
- add actionable installed-version errors
- gate 1.30.0, 1.38.0, and 1.39.0 in CI
- document the supported range in English and Chinese

Independent local checks: all three pinned OTel versions PASS; Ruff, public documentation gates, compileall, minimal local run, wheel/sdist build and Twine PASS. No Backend/Core/model/paid/deploy action.