### PR TITLE
fix(evidence): raise bounded trace and upload capacity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - run: python -m ruff format --check --exclude "*.ipynb" .
       - run: python tools/verify_public_api_docs.py
       - run: python tools/verify_agent_profile_migration.py
+      - run: python tools/verify_evidence_capacity.py
       - run: python -m compileall -q src examples tools
 
   test:
@@ -47,6 +48,7 @@ jobs:
       - run: python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma-defuzex')"
       - run: python -m kuma --help
       - run: python examples/minimal_local.py
+      - run: python tools/verify_evidence_capacity.py
 
   windows:
     name: Windows
@@ -62,6 +64,7 @@ jobs:
       - run: python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma-defuzex')"
       - run: python -m kuma --help
       - run: python examples/minimal_local.py
+      - run: python tools/verify_evidence_capacity.py
 
   macos:
     name: macOS
@@ -77,6 +80,7 @@ jobs:
       - run: python -c "import importlib.metadata, kuma; assert kuma.__version__ == importlib.metadata.version('kuma-defuzex')"
       - run: python -m kuma --help
       - run: python examples/minimal_local.py
+      - run: python tools/verify_evidence_capacity.py
 
   otel-compatibility:
     name: OTel ${{ matrix.otel-version }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ KUMA is the public Python SDK for testing Agent behavior through a strict `Run` 
 - Synchronous, framework-neutral Case and Judge workflow.
 - Official or custom Providers, including fully local runs.
 - Bounded file, log, and optional trace Evidence.
+- Default Trace budget: 8 MiB per Run. Agent output: 4 MiB canonical JSON;
+  Runtime Evidence: 5 MiB; complete multipart upload: 8 MiB. Stricter server
+  limits still apply; output is rejected rather than truncated.
 - Strategy Groups choose the testing method; an Agent Profile supplies only the
   Agent, scenario, expected-behavior, and prohibited-boundary context.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -20,6 +20,9 @@ KUMA 是公开 Python SDK，通过严格的 `Run` 协议和有界 Evidence 采�
 - 同步且不绑定框架的 Case 与 Judge 流程。
 - 支持官方或自定义 Provider，也可完全本地运行。
 - 有界采集文件、日志和可选 Trace Evidence。
+- 默认 Trace 预算为每 Run 8 MiB；Agent 输出 canonical JSON 上限 4 MiB，
+  Runtime Evidence 上限 5 MiB，完整 multipart 上传上限 8 MiB。
+  服务端更小的限制仍有效；输出超限会拒绝，不会截断。
 - Strategy Group 决定测试方法；Agent Profile 只提供被测 Agent、运行场景、
   预期行为和禁止边界的上下文。
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -383,11 +383,11 @@ excluded.
 
 | Argument | Type | Required/default | What happens when the limit is reached |
 | --- | --- | --- | --- |
-| `max_spans` | positive `int` | `200` | After this many ended spans have been retained for a Run, additional spans are dropped and the Evidence reports the drop instead of growing memory without bound. |
+| `max_spans` | positive `int` | `200` | Retains at most this many ended spans per step using deterministic sampling; dropped spans are counted. This per-step cap is independent of the Run-wide byte budget. |
 | `max_attributes` | positive `int` | `32` | Keeps at most this many safe, allowlisted attributes on each span; additional attributes are dropped and counted. Sensitive attributes remain rejected regardless of this number. |
 | `max_events_per_span` | positive `int` | `20` | Keeps at most this many safe OTel events on each span; later events are dropped and reported. |
 | `max_text_length` | positive `int` | `256` characters | Truncates each retained allowlisted text value to this many Unicode characters and records that truncation occurred. |
-| `max_total_bytes` | positive `int` | `512000` bytes | Caps the compact JSON size of all committed Trace envelopes in one Run. KUMA drops or truncates Trace data to stay within this budget; the value must still fit the smallest valid envelope. |
+| `max_total_bytes` | positive `int` | `8388608` bytes (8 MiB) | Caps the compact JSON size of all committed Trace envelopes in one Run. KUMA deterministically drops excess Trace data and reports the loss; the value must still fit the smallest valid envelope. |
 | `max_log_records` | positive `int` | `200` | Keeps at most this many normalized OTel log records per step; excess records are dropped and reported. |
 | `max_log_bytes` | positive `int` | `128000` bytes | Caps structured OTel log artifacts committed across one Run; raw log bodies are not retained. |
 

--- a/docs/api-reference.zh-CN.md
+++ b/docs/api-reference.zh-CN.md
@@ -307,11 +307,11 @@ Rubric、Prompt 或 Provider 响应。已知 operation 只通过 GET 继续轮�
 
 | 参数 | 类型 | 必填/默认值 | 达到上限后会怎样 |
 | --- | --- | --- | --- |
-| `max_spans` | 正 `int` | `200` | 一个 Run 保留到该数量后，后续已结束 span 会被丢弃，并在 Evidence 中记录 dropped，而不是让内存无限增长。 |
+| `max_spans` | 正 `int` | `200` | 每步通过确定性采样最多保留这么多个已结束 span，被丢弃的 span 会计数。此每步上限与 Run 总字节预算独立。 |
 | `max_attributes` | 正 `int` | `32` | 每个 span 最多保留这么多个安全 allowlist 属性；其余属性被丢弃并计数。无论数字多大，敏感属性仍会被拒绝。 |
 | `max_events_per_span` | 正 `int` | `20` | 每个 span 最多保留这么多个安全 OTel event；更晚的 event 会被丢弃并记录。 |
 | `max_text_length` | 正 `int` | `256` 字符 | 每个允许保留的文本值超过该 Unicode 字符数后会被截断，并记录 truncated 状态。 |
-| `max_total_bytes` | 正 `int` | `512000` 字节 | 一个 Run 的全部已提交 Trace envelope 紧凑 JSON 合计不能超过该值；KUMA 会丢弃或截断 Trace 数据来守住预算，但该值本身必须能容纳最小合法 envelope。 |
+| `max_total_bytes` | 正 `int` | `8388608` 字节（8 MiB） | 一个 Run 的全部已提交 Trace envelope 紧凑 JSON 合计不能超过该值；KUMA 会确定性丢弃超额 Trace 并报告损失，但该值本身必须能容纳最小合法 envelope。 |
 | `max_log_records` | 正 `int` | `200` | 每个步骤最多保留的规范化 OTel 日志记录数；超出部分会丢弃并记录。 |
 | `max_log_bytes` | 正 `int` | `128000` 字节 | 一个 Run 中已提交的结构化 OTel 日志 artifact 总字节上限；不会保留原始日志正文。 |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,7 +256,7 @@ Evidence 的完整性不由单个布尔值掩盖。`CaptureStatus` 分组件记�
 typed component union，只传关联 ID、顺序、路径/大小、结果枚举和 SHA-256。
 Official Judge 通过公开 Judge config 的 `evidence_types` 协商传输：明确广告 v2
 时，SDK 从已提交的 frozen output 生成不修改本地历史的 v2 transport projection，
-只给 completed response claim 增加经强制敏感扫描和 32,768-byte 上限约束的
+只给 completed response claim 增加经强制敏感扫描和 4 MiB canonical JSON 上限约束的
 `agent_output` JSON。仅广告 v1 时保持 hash-only v1；未广告 typed schema 的旧
 服务仍收到 `defuzex.run_evidence.v1`。SDK 不把日志、Trace、prompt、completion、
 diff 或 tool/model payload 混为 Agent output，也不从文本、OTel span name 或

--- a/docs/runtime-evidence.md
+++ b/docs/runtime-evidence.md
@@ -45,7 +45,7 @@ metadata. The outer Judge request owns `case_id` correlation.
 
 `components` contains 1–100 items. `component_id` and non-negative `sequence`
 are each unique, and sequence is strictly ascending. Serialization uses stable,
-compact JSON. One encoded EvidenceItem is at most 120,000 characters.
+compact JSON. One encoded EvidenceItem is at most 5 MiB of UTF-8 JSON.
 
 ## Closed component union
 
@@ -113,10 +113,11 @@ trace span, prompt, completion, diff, or repository file. Failed, timed-out,
 aborted, refused, and blocked claims never include it. Explicit `submit(output)`
 still takes precedence over supported semantic OTel output extraction.
 
-The output's canonical JSON is limited to 32,768 UTF-8 bytes. JSON is never
+The output's canonical JSON is limited to 4 MiB (4,194,304 UTF-8 bytes). JSON is never
 truncated because doing so could change its meaning or schema. Exceeding that
-limit, the complete 120,000-character envelope limit, or dynamic Judge file and
-total limits raises a stable `KumaError` before multipart POST. `text_sha256`
+limit, the complete 5 MiB Runtime Evidence limit, the 8 MiB SDK multipart limit,
+or a stricter dynamic Judge limit raises a stable `KumaError` before multipart
+POST. `text_sha256`
 keeps the v1 algorithm: strings hash raw UTF-8 with `surrogatepass`; other values
 hash key-sorted compact JSON with ASCII escapes and `allow_nan=false`.
 

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -1,5 +1,14 @@
 # KUMA Python SDK guide
 
+Evidence capacity: the default Trace budget is 8 MiB across one Run; span,
+attribute and event limits and visible loss counters remain active. Canonical
+Agent-output JSON allows 4 MiB, one Runtime Evidence envelope allows 5 MiB, and
+the complete multipart body (including metadata/framing) allows 8 MiB. Lower
+Backend limits still apply. Output is never truncated. JSON quotes and escapes
+count: an ASCII string may contain at most 4,194,302 characters before its two
+JSON quotes; Unicode escapes can use more bytes. Run the offline capacity check
+with `python tools/verify_evidence_capacity.py` from a source checkout.
+
 [English](sdk-guide.md) | [简体中文](sdk-guide.zh-CN.md)
 
 This is the canonical user guide for KUMA configuration and integration. The package, CLI, and environment variables use `kuma` / `KUMA_*`; versioned `defuzex.*` wire schemas remain unchanged for server compatibility.
@@ -208,7 +217,7 @@ Each `get_input()` to `submit()` interval is one Evidence transaction. Evidence 
 - `save_local=True` writes structured records under `.kuma/runs/<run_id>/submissions/`; local persistence does not replace official submission.
 - `CaptureStatus`, `missing`, `dropped_count`, and `runtime_warnings` expose partial or degraded capture.
 
-Framework-neutral runtime metadata follows the [Runtime Evidence contract](runtime-evidence.md). v1 remains hash-only; only an explicitly negotiated v2 official service receives a bounded, scanned completed Agent output. That page is the authoritative schema and privacy reference.
+Framework-neutral runtime metadata follows the [Runtime Evidence contract](runtime-evidence.md). v1 remains hash-only; only an explicitly negotiated output-capable official service receives a scanned completed Agent output. Canonical Agent output is capped at 4 MiB, one Runtime Evidence item at 5 MiB, and the complete official multipart body at 8 MiB. Nothing is truncated. That page is the authoritative schema and privacy reference.
 
 Before official upload, KUMA scans output, errors, paths, diffs, explicit logs, and custom Cases for sensitive material. The API key is used for authorization and is not added to Evidence. `allow_sensitive=True` is an explicit ordinary-Evidence override, not a substitute for isolation or secret hygiene.
 

--- a/docs/sdk-guide.zh-CN.md
+++ b/docs/sdk-guide.zh-CN.md
@@ -1,5 +1,12 @@
 # KUMA Python SDK 指南
 
+Evidence 容量：默认 Trace 总预算为每 Run 8 MiB；span、attribute、event 上限及
+透明丢弃计数继续生效。Agent 输出 canonical JSON 上限 4 MiB，单份 Runtime
+Evidence 上限 5 MiB，含元数据和分隔符的完整 multipart 上限 8 MiB。
+Backend 更小的限制仍有效，输出不会截断。JSON 引号及转义也计入：ASCII 字符串
+加两个引号前最多 4,194,302 字符，Unicode 转义可能占更多字节。
+在源码目录运行 `python tools/verify_evidence_capacity.py` 可离线验证容量。
+
 [English](sdk-guide.md) | [简体中文](sdk-guide.zh-CN.md)
 
 本文是 KUMA 配置与接入的规范用户指南。Python 包、CLI 和环境变量使用 `kuma` / `KUMA_*`；版本化 `defuzex.*` wire schema 为兼容服务端保持不变。
@@ -202,7 +209,7 @@ print(report)
 - `save_local=True` 将结构化记录写入 `.kuma/runs/<run_id>/submissions/`；本地记录不能替代官方提交。
 - `CaptureStatus`、`missing`、`dropped_count` 和 `runtime_warnings` 用于呈现采集不完整或降级。
 
-框架无关的运行时元数据遵循 [Runtime Evidence 合同](runtime-evidence.md)。v1 仍仅含哈希；只有官方服务明确协商 v2 后，才会接收经过大小和敏感检查的 completed Agent 最终输出。该文档是 schema 与隐私规则的权威说明。
+框架无关的运行时元数据遵循 [Runtime Evidence 合同](runtime-evidence.md)。v1 仍仅含哈希；只有官方服务明确协商支持 Agent output 后，才会接收经过敏感检查的 completed Agent 最终输出。Agent output canonical JSON 上限为 4 MiB，单份 Runtime Evidence 为 5 MiB，整个官方 multipart 请求为 8 MiB；均不截断。该文档是 schema 与隐私规则的权威说明。
 
 上传到官方服务前，KUMA 会扫描 output、error、路径、diff、显式日志和自定义 Case 中的敏感内容。API Key 仅用于鉴权，不会加入 Evidence。`allow_sensitive=True` 只是普通 Evidence 的显式覆盖，不能替代隔离与 secret 管理。
 

--- a/src/kuma/evidence/runtime.py
+++ b/src/kuma/evidence/runtime.py
@@ -16,7 +16,7 @@ from ..repository.privacy import scan_sensitive_path
 from .otel_log_mapping import OTEL_LOG_MEDIA_TYPE
 from .runtime_contract import (
     RUNTIME_AGENT_OUTPUT_MAX_BYTES,
-    RUNTIME_EVIDENCE_MAX_CHARS,
+    RUNTIME_EVIDENCE_MAX_BYTES,
     RUNTIME_EVIDENCE_SCHEMA,
     RUNTIME_EVIDENCE_SCHEMA_V1,
     RUNTIME_EVIDENCE_SCHEMA_V2,
@@ -37,13 +37,14 @@ class RuntimeEvidenceLimits:
             Core v1 contract permits at most 100.
         max_text_length: Maximum characters accepted for a safe relative path or
             other bounded identifier before that observation is dropped.
-        max_content_chars: Maximum characters in the complete canonical JSON
-            content, including identifiers and component envelope overhead.
+        max_content_chars: Maximum UTF-8 bytes in the complete canonical JSON
+            content, including identifiers and component envelope overhead. The
+            historical attribute name remains because canonical JSON is ASCII.
     """
 
     max_components: int = 100
     max_text_length: int = 1024
-    max_content_chars: int = RUNTIME_EVIDENCE_MAX_CHARS
+    max_content_chars: int = RUNTIME_EVIDENCE_MAX_BYTES
 
     def __post_init__(self) -> None:
         """Enforce Core-compatible component, text, and envelope size limits."""
@@ -54,8 +55,8 @@ class RuntimeEvidenceLimits:
             raise ValueError("runtime evidence limits must be integers")
         if not 1 <= self.max_components <= 100 or self.max_text_length <= 0:
             raise ValueError("runtime evidence item limits are invalid")
-        if not 1024 <= self.max_content_chars <= RUNTIME_EVIDENCE_MAX_CHARS:
-            raise ValueError("runtime evidence character limit is invalid")
+        if not 1024 <= self.max_content_chars <= RUNTIME_EVIDENCE_MAX_BYTES:
+            raise ValueError("runtime evidence byte limit is invalid")
 
 
 @dataclass(frozen=True, slots=True)
@@ -220,7 +221,7 @@ def _bounded_plain_agent_output(output: Any) -> tuple[Any, str]:
     """Detach one v2 output and return it with its frozen claim digest.
 
     Structural failures become value-free ``ValueError`` instances. The
-    32,768-byte limit is measured against canonical JSON and raises a public
+    4 MiB limit is measured against canonical JSON and raises a public
     ``LimitExceededError`` instead of truncating the Agent result.
     """
 
@@ -291,8 +292,8 @@ def project_runtime_evidence_v2(
         extension and caller-owned values are never mutated.
 
     Raises:
-        LimitExceededError: If canonical Agent output exceeds 32,768 UTF-8
-            bytes or adding it would exceed the 120,000-character envelope cap.
+        LimitExceededError: If canonical Agent output exceeds 4 MiB or adding it
+            would exceed the 5 MiB Runtime Evidence envelope cap.
         ValueError: If v1 association, claim cardinality/status/hash, output JSON,
             or the resulting v2 envelope is invalid.
 
@@ -316,11 +317,14 @@ def project_runtime_evidence_v2(
     projected = json.loads(runtime_evidence_json(value))
     _project_v2_claim(projected, status=status, output=output)
     projected["schema_version"] = RUNTIME_EVIDENCE_SCHEMA_V2
-    if len(runtime_evidence_json(projected)) > RUNTIME_EVIDENCE_MAX_CHARS:
+    if (
+        len(runtime_evidence_json(projected).encode("utf-8"))
+        > RUNTIME_EVIDENCE_MAX_BYTES
+    ):
         raise LimitExceededError(
             "Runtime Evidence exceeds the canonical envelope limit",
             code="runtime_evidence_too_large",
-            details={"max_characters": RUNTIME_EVIDENCE_MAX_CHARS},
+            details={"max_utf8_bytes": RUNTIME_EVIDENCE_MAX_BYTES},
         )
     validate_runtime_evidence(
         projected,
@@ -369,7 +373,7 @@ def _fit_components(
     identifiers: Mapping[str, str],
     limits: RuntimeEvidenceLimits,
 ) -> tuple[dict[str, Any], int, bool]:
-    """Retain ordered facts and the final claim within component and character caps."""
+    """Retain ordered facts and the final claim within component and byte caps."""
     dropped = max(0, len(components) - limits.max_components)
     retained = components[: limits.max_components]
     if dropped and limits.max_components > 1:
@@ -378,9 +382,11 @@ def _fit_components(
         retained = [components[-1]]
     envelope = _envelope(**identifiers, components=retained)
     char_limited = False
-    while len(runtime_evidence_json(envelope)) > limits.max_content_chars:
+    while (
+        len(runtime_evidence_json(envelope).encode("utf-8")) > limits.max_content_chars
+    ):
         if len(retained) <= 1:
-            raise ValueError("runtime evidence metadata exceeds the character limit")
+            raise ValueError("runtime evidence metadata exceeds the byte limit")
         retained.pop(-2)
         dropped += 1
         char_limited = True

--- a/src/kuma/evidence/runtime_contract.py
+++ b/src/kuma/evidence/runtime_contract.py
@@ -15,8 +15,8 @@ RUNTIME_EVIDENCE_SCHEMA_V2 = "defuzex.runtime_evidence.v2"
 # Preserve the original import as the v1 name used by existing integrations.
 RUNTIME_EVIDENCE_SCHEMA = RUNTIME_EVIDENCE_SCHEMA_V1
 RUNTIME_EVIDENCE_MEDIA_TYPE = "application/vnd.defuzex.runtime-evidence+json"
-RUNTIME_EVIDENCE_MAX_CHARS = 120_000
-RUNTIME_AGENT_OUTPUT_MAX_BYTES = 32_768
+RUNTIME_EVIDENCE_MAX_BYTES = 5 * 1024 * 1024
+RUNTIME_AGENT_OUTPUT_MAX_BYTES = 4 * 1024 * 1024
 CASEGEN_FRAMEWORK_SCHEMA = "defuzex.casegen.ita.v1"
 CASEGEN_EVIDENCE_CAPABILITY_ORDER = (
     "file_change",
@@ -438,15 +438,15 @@ def validate_runtime_evidence(
         schema_version=schema_version,
     )
     _validate_components(value["components"], schema_version=schema_version)
-    if len(runtime_evidence_json(value)) > RUNTIME_EVIDENCE_MAX_CHARS:
-        raise ValueError("runtime evidence exceeds the character limit")
+    if len(runtime_evidence_json(value).encode("utf-8")) > RUNTIME_EVIDENCE_MAX_BYTES:
+        raise ValueError("runtime evidence exceeds the byte limit")
 
 
 __all__ = [
     "CASEGEN_EVIDENCE_CAPABILITY_ORDER",
     "CASEGEN_FRAMEWORK_SCHEMA",
     "RUNTIME_AGENT_OUTPUT_MAX_BYTES",
-    "RUNTIME_EVIDENCE_MAX_CHARS",
+    "RUNTIME_EVIDENCE_MAX_BYTES",
     "RUNTIME_EVIDENCE_MEDIA_TYPE",
     "RUNTIME_EVIDENCE_SCHEMA",
     "RUNTIME_EVIDENCE_SCHEMA_V1",

--- a/src/kuma/evidence/trace.py
+++ b/src/kuma/evidence/trace.py
@@ -120,7 +120,7 @@ class TraceEvidenceLimits:
     max_attributes: int = 32
     max_events_per_span: int = 20
     max_text_length: int = 256
-    max_total_bytes: int = 512_000
+    max_total_bytes: int = 8 * 1024 * 1024
     max_log_records: int = 200
     max_log_bytes: int = 128_000
 

--- a/src/kuma/providers/_official_evidence_upload.py
+++ b/src/kuma/providers/_official_evidence_upload.py
@@ -10,6 +10,7 @@ from typing import Any
 from ..errors import LimitExceededError, ProviderError
 from ..evidence.runtime import project_runtime_evidence_v2, runtime_submission_id
 from ..evidence.runtime_contract import (
+    RUNTIME_EVIDENCE_MAX_BYTES,
     RUNTIME_EVIDENCE_MEDIA_TYPE,
     RUNTIME_EVIDENCE_SCHEMA_V1,
     RUNTIME_EVIDENCE_SCHEMA_V2,
@@ -142,7 +143,7 @@ def _runtime_evidence_part(
             "Runtime Evidence is invalid", code="runtime_evidence_invalid"
         ) from exc
     encoded = runtime_evidence_json(value).encode()
-    if len(encoded) > max_file_bytes:
+    if len(encoded) > min(max_file_bytes, RUNTIME_EVIDENCE_MAX_BYTES):
         raise LimitExceededError(
             "Runtime Evidence exceeds the Judge upload limit",
             code="log_size_exceeded",

--- a/src/kuma/transport/backend.py
+++ b/src/kuma/transport/backend.py
@@ -44,6 +44,7 @@ from .http import (
 
 DEFAULT_BASE_URL = "https://defuzex.ai/api/agentdefuze"
 _MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+_MAX_MULTIPART_BYTES = 8 * 1024 * 1024
 _CLIENT_REQUEST_ID_PATTERN = re.compile(r"kreq_[0-9a-f]{32}\Z")
 WireTransport = Callable[
     [str, str, Mapping[str, str], bytes | None, float],
@@ -763,13 +764,16 @@ def encode_multipart(
     Raises:
         ValidationError: A field name is empty or permits quote/CR/LF injection.
             ``UploadPart`` metadata errors are rejected at construction time.
+        LimitExceededError: The complete encoded body, including MIME framing,
+            exceeds the SDK's 8 MiB official multipart ceiling.
 
     Preconditions:
         Field values and part bytes have already passed size, schema, and
         sensitive-data policy for the target public endpoint.
 
     Postconditions:
-        Returns a complete closing-boundary-terminated body; inputs are unchanged.
+        Returns a complete closing-boundary-terminated body no larger than
+        8 MiB; inputs are unchanged.
 
     Security/Privacy:
         Random boundaries prevent caller-controlled delimiter collisions. This
@@ -804,7 +808,14 @@ def encode_multipart(
             )
         )
     chunks.append(f"--{boundary}--\r\n".encode("ascii"))
-    return f"multipart/form-data; boundary={boundary}", b"".join(chunks)
+    body = b"".join(chunks)
+    if len(body) > _MAX_MULTIPART_BYTES:
+        raise LimitExceededError(
+            "The multipart request exceeds the SDK upload limit.",
+            code="evidence_upload_too_large",
+            details={"max_utf8_bytes": _MAX_MULTIPART_BYTES},
+        )
+    return f"multipart/form-data; boundary={boundary}", body
 
 
 class BackendClient:
@@ -1116,6 +1127,7 @@ class BackendClient:
 
         Raises:
             ValidationError: Multipart metadata cannot be serialized safely.
+            LimitExceededError: The complete body exceeds the 8 MiB SDK ceiling.
             KumaError: Request validation, transport, status, or response fails.
 
         Preconditions:

--- a/tools/verify_evidence_capacity.py
+++ b/tools/verify_evidence_capacity.py
@@ -1,0 +1,260 @@
+"""Verify bounded Evidence capacity with synthetic, offline examples."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from kuma.errors import LimitExceededError
+from kuma.evidence.runtime import (
+    build_runtime_evidence,
+    project_runtime_evidence_v2,
+    runtime_submission_id,
+)
+from kuma.evidence.runtime_contract import (
+    RUNTIME_AGENT_OUTPUT_MAX_BYTES,
+    RUNTIME_EVIDENCE_MAX_BYTES,
+    RUNTIME_EVIDENCE_SCHEMA_V2,
+    runtime_agent_output_bytes,
+    runtime_claim_sha256,
+    runtime_evidence_json,
+    validate_runtime_evidence,
+)
+from kuma.evidence.trace import TraceEvidenceCapture, TraceEvidenceLimits
+from kuma.evidence.trace_mapping import json_size
+from kuma.transport.backend import BackendClient, UploadPart, encode_multipart
+
+_MIB = 1024 * 1024
+_MULTIPART_LIMIT = 8 * _MIB
+
+
+def _span(step: int, index: int) -> SimpleNamespace:
+    """Build one large but allowlisted ended span for deterministic capacity tests."""
+
+    span_id = step * 1_000 + index + 1
+    return SimpleNamespace(
+        context=SimpleNamespace(trace_id=step + 1, span_id=span_id),
+        parent=None,
+        name="s" + "x" * 254,
+        kind=SimpleNamespace(name="INTERNAL"),
+        status=SimpleNamespace(status_code=SimpleNamespace(name="UNSET")),
+        start_time=span_id * 10,
+        end_time=span_id * 10 + 5,
+        attributes={"gen_ai.request.model": "m" * 200},
+        events=[],
+        resource=SimpleNamespace(attributes={}),
+        instrumentation_scope=SimpleNamespace(name="fixture", version="1"),
+    )
+
+
+class EvidenceCapacityTests(unittest.TestCase):
+    def test_typed_envelope_accepts_five_mib_utf8_and_rejects_one_more(self) -> None:
+        first = "x" * (RUNTIME_AGENT_OUTPUT_MAX_BYTES - 2)
+        components = [
+            {
+                "component_id": f"claim-{i}",
+                "sequence": i,
+                "kind": "agent_response_claim",
+                "claim_id": f"claim-{i}",
+                "claim": "completed",
+                "agent_output": output,
+                "text_sha256": runtime_claim_sha256(output),
+            }
+            for i, output in enumerate((first, ""))
+        ]
+        envelope = {
+            "schema_version": RUNTIME_EVIDENCE_SCHEMA_V2,
+            "run_id": "run",
+            "input_id": "step",
+            "step_id": "step",
+            "submission_id": "submission",
+            "components": components,
+        }
+        remaining = RUNTIME_EVIDENCE_MAX_BYTES - len(
+            runtime_evidence_json(envelope).encode("utf-8")
+        )
+        second = "é" * (remaining // 6) + "x" * (remaining % 6)
+        components[1]["agent_output"] = second
+        components[1]["text_sha256"] = runtime_claim_sha256(second)
+        self.assertEqual(
+            len(runtime_evidence_json(envelope).encode("utf-8")),
+            RUNTIME_EVIDENCE_MAX_BYTES,
+        )
+        association = dict(
+            run_id="run",
+            input_id="step",
+            step_id="step",
+            submission_id="submission",
+            schema_version=RUNTIME_EVIDENCE_SCHEMA_V2,
+        )
+        validate_runtime_evidence(envelope, **association)
+        components[1]["agent_output"] += "x"
+        components[1]["text_sha256"] = runtime_claim_sha256(second + "x")
+        with self.assertRaisesRegex(ValueError, "byte limit"):
+            validate_runtime_evidence(envelope, **association)
+
+    def test_default_trace_budget_retains_spans_through_ten_large_steps(self) -> None:
+        capture = TraceEvidenceCapture()
+        encoded_sizes: list[int] = []
+
+        for step in range(10):
+            input_id = f"step-{step + 1}"
+            capture.begin_step("run", "case", input_id)
+            for index in range(200):
+                capture.export_span(_span(step, index))
+            prepared = capture.prepare_step("run", "case", input_id)
+            self.assertIsNotNone(prepared.evidence)
+            self.assertEqual(len(prepared.evidence["spans"]), 200)
+            encoded_sizes.append(json_size(prepared.evidence))
+            prepared.commit()
+
+        self.assertEqual(TraceEvidenceLimits().max_total_bytes, 8 * _MIB)
+        self.assertGreater(sum(encoded_sizes), 512_000)
+        self.assertLessEqual(sum(encoded_sizes), 8 * _MIB)
+        capture.finish_run("run", "case")
+
+    def test_agent_output_accepts_four_mib_and_rejects_one_byte_more(self) -> None:
+        exact = "x" * (RUNTIME_AGENT_OUTPUT_MAX_BYTES - 2)
+        oversized = exact + "x"
+
+        self.assertEqual(
+            len(runtime_agent_output_bytes(exact)), RUNTIME_AGENT_OUTPUT_MAX_BYTES
+        )
+        self.assertEqual(
+            len(runtime_agent_output_bytes(oversized)),
+            RUNTIME_AGENT_OUTPUT_MAX_BYTES + 1,
+        )
+        self.assertEqual(RUNTIME_AGENT_OUTPUT_MAX_BYTES, 4 * _MIB)
+        self.assertEqual(RUNTIME_EVIDENCE_MAX_BYTES, 5 * _MIB)
+        submission_id = runtime_submission_id("run", "step")
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = build_runtime_evidence(
+                run_id="run",
+                input_id="step",
+                step_id="step",
+                submission_id=submission_id,
+                root=Path(directory),
+                status="completed",
+                output=exact,
+                error=None,
+                file_evidence=None,
+                logs=(),
+                trace_evidence=None,
+            ).evidence
+        projected = project_runtime_evidence_v2(
+            evidence,
+            run_id="run",
+            input_id="step",
+            step_id="step",
+            submission_id=submission_id,
+            status="completed",
+            output=exact,
+        )
+        self.assertEqual(projected["components"][-1]["agent_output"], exact)
+        with self.assertRaises(LimitExceededError) as raised:
+            project_runtime_evidence_v2(
+                evidence,
+                run_id="run",
+                input_id="step",
+                step_id="step",
+                submission_id=submission_id,
+                status="completed",
+                output=oversized,
+            )
+        self.assertEqual(raised.exception.code, "agent_output_too_large")
+
+    def test_runtime_evidence_ceiling_fails_before_upload(self) -> None:
+        output = {"answer": "safe"}
+        submission_id = runtime_submission_id("run", "step")
+        with tempfile.TemporaryDirectory() as directory:
+            evidence = build_runtime_evidence(
+                run_id="run",
+                input_id="step",
+                step_id="step",
+                submission_id=submission_id,
+                root=Path(directory),
+                status="completed",
+                output=output,
+                error=None,
+                file_evidence=None,
+                logs=(),
+                trace_evidence=None,
+            ).evidence
+        with (
+            patch("kuma.evidence.runtime.RUNTIME_EVIDENCE_MAX_BYTES", 100),
+            self.assertRaises(LimitExceededError) as raised,
+        ):
+            project_runtime_evidence_v2(
+                evidence,
+                run_id="run",
+                input_id="step",
+                step_id="step",
+                submission_id=submission_id,
+                status="completed",
+                output=output,
+            )
+        self.assertEqual(raised.exception.code, "runtime_evidence_too_large")
+        self.assertEqual(dict(raised.exception.details), {"max_utf8_bytes": 100})
+
+    def test_multipart_total_accepts_eight_mib_and_rejects_one_byte_more(
+        self,
+    ) -> None:
+        empty_part = UploadPart("logs", "run.json", "application/json", b"")
+        _, empty_body = encode_multipart({}, (empty_part,))
+        exact_data = b"x" * (_MULTIPART_LIMIT - len(empty_body))
+
+        _, exact_body = encode_multipart(
+            {},
+            (UploadPart("logs", "run.json", "application/json", exact_data),),
+        )
+        self.assertEqual(len(exact_body), _MULTIPART_LIMIT)
+        with self.assertRaises(LimitExceededError) as raised:
+            encode_multipart(
+                {},
+                (
+                    UploadPart(
+                        "logs",
+                        "run.json",
+                        "application/json",
+                        exact_data + b"x",
+                    ),
+                ),
+            )
+        self.assertEqual(raised.exception.code, "evidence_upload_too_large")
+
+    def test_oversized_multipart_stops_before_transport(self) -> None:
+        calls: list[object] = []
+
+        def transport(*args: object) -> object:
+            """Record an unexpected transport attempt."""
+
+            calls.append(args)
+            return {"status": "unexpected"}
+
+        client = BackendClient(
+            api_key="dfx_" + "a" * 40,
+            transport=transport,  # type: ignore[arg-type]
+        )
+        with self.assertRaises(LimitExceededError):
+            client.multipart(
+                "/sdk/v2/judge/",
+                {"manifest": json.dumps({"schema_version": "1", "files": []})},
+                (
+                    UploadPart(
+                        "logs",
+                        "run.json",
+                        "application/json",
+                        b"x" * _MULTIPART_LIMIT,
+                    ),
+                ),
+                idempotency_key="idem-capacity",
+            )
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Raise bounded Evidence capacity so multi-step trace capture and larger Agent responses are not rejected by the previous small budgets.

- Default Trace budget: 8 MiB per Run; per-step span, attribute and event limits and visible loss accounting remain in place.
- Canonical Agent-output JSON: 4 MiB; Runtime Evidence: 5 MiB UTF-8; complete multipart body, including framing and metadata: 8 MiB. Lower advertised server limits still apply. Output is never truncated.
- Update bilingual documentation and run a synthetic capacity check in CI on Python 3.10–3.14, Windows and macOS.

Validation: six offline capacity checks pass, including ten trace-heavy steps, exact/+1 output and multipart limits, and a real 5 MiB typed-envelope UTF-8 boundary. Applicable canonical SDK suite: 511 tests, 9 skipped; seven applicable capacity/privacy regressions pass. Ruff, API documentation (9 APIs × 2 languages), Agent Profile migration/link checks, compileall, minimal local example, wheel/sdist build, Twine and clean-wheel imports pass.

This PR changes only capacity on the existing public protocols. It does not introduce the separate file-diff capability protocol or the upload-inspection feature. The file-diff-only regression and its three test modules are not applicable to this public baseline; they were not silently counted as passing. No private tests, acceptance files, internal assets or history are published. No production/model calls or package publication were performed.

Fixes #45
Fixes #46
