### PR TITLE
docs(readme): focus core capabilities on user workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ KUMA is the public Python SDK for testing Agent behavior through a strict `Run` 
 
 ## Core capabilities
 
-- Synchronous, framework-neutral Case and Judge workflow.
-- Official or custom Providers, including fully local runs.
-- Bounded file, log, and optional trace Evidence.
-- Default Trace budget: 8 MiB per Run. Agent output: 4 MiB canonical JSON;
-  Runtime Evidence: 5 MiB; complete multipart upload: 8 MiB. Stricter server
-  limits still apply; output is rejected rather than truncated.
-- Strategy Groups choose the testing method; an Agent Profile supplies only the
-  Agent, scenario, expected-behavior, and prohibited-boundary context.
+- Run repeatable Case-to-Judgment evaluations through one framework-neutral
+  Python workflow.
+- Use KUMA's official services, plug in custom Case and Judge Providers, or keep
+  the workflow fully local.
+- Capture bounded, structured Evidence from step results, file changes, explicit
+  logs, and optional OpenTelemetry traces.
+- Select the testing method with a versioned Strategy Group, and describe the
+  Agent and its operating context with an Agent Profile.
 
 ## Install
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,14 +17,12 @@ KUMA 是公开 Python SDK，通过严格的 `Run` 协议和有界 Evidence 采�
 
 ## 核心能力
 
-- 同步且不绑定框架的 Case 与 Judge 流程。
-- 支持官方或自定义 Provider，也可完全本地运行。
-- 有界采集文件、日志和可选 Trace Evidence。
-- 默认 Trace 预算为每 Run 8 MiB；Agent 输出 canonical JSON 上限 4 MiB，
-  Runtime Evidence 上限 5 MiB，完整 multipart 上传上限 8 MiB。
-  服务端更小的限制仍有效；输出超限会拒绝，不会截断。
-- Strategy Group 决定测试方法；Agent Profile 只提供被测 Agent、运行场景、
-  预期行为和禁止边界的上下文。
+- 通过统一、框架无关的 Python 工作流，完成从 Case 到 Judgment 的可重复评测。
+- 可使用 KUMA 官方服务，也可接入自定义 Case 和 Judge Provider，或保持全本地运行。
+- 有界采集步骤结果、文件变更、显式日志与可选 OpenTelemetry Trace，
+  形成结构化 Evidence。
+- 通过带版本的 Strategy Group 选择测试方法，并用 Agent Profile 描述被测
+  Agent 及其运行上下文。
 
 ## 安装
 


### PR DESCRIPTION
## Summary

- Rewrite the English and Simplified Chinese Core capabilities sections around user-visible workflows.
- Remove Trace and multipart size limits from the project homepages.
- Keep those limits in the canonical SDK, API, and Runtime Evidence documentation.

## Validation

- python tools/verify_agent_profile_migration.py
- python tools/verify_public_api_docs.py
- python -m ruff check --exclude *.ipynb .
- python -m ruff format --check --exclude *.ipynb .
- python -m compileall -q src examples tools
- PYTHONPATH=src python -m kuma quickstart
- PYTHONPATH=src python examples/minimal_local.py
- uvx detect-secrets scan README.md README.zh-CN.md (0 findings)
- python -m build and python -m twine check
