### PR TITLE
Bound strategy discovery caching and preserve safe error details

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -423,3 +423,26 @@ Catch `KumaError` for normal SDK failures. `str(exc)` is a safe user-facing
 message. Program logic should use `exc.code`, `exc.retryable`, and
 `exc.request_id`; `exc.details` is a bounded public mapping and should be logged
 only through an application-approved allowlist.
+
+Remote error details use exact per-code schemas (HTTP failures and async failed
+operations share validation):
+
+| `exc.code` | Allowed `exc.details` | Validation |
+| --- | --- | --- |
+| `case_step_limit_exceeded` | `{"max_allowed_steps": 10}` | Required non-boolean integer, 1–10. |
+| `unsupported_difficulty` | `{"supported_difficulties": ["D0", "D2"]}` | 1–5 unique values from D0–D4; server order is preserved, not required to be sorted. |
+| `strategy_capability_mismatch` | `{"missing_capabilities": ["file_change", "tool_call"]}` | 1–7 unique Evidence capabilities in canonical order: file_change, tool_call, command_result, test_result, state_transition, artifact_snapshot, agent_response_claim. |
+
+For example, on `unsupported_difficulty`, show the validated
+`exc.details.get("supported_difficulties", [])` so the caller can choose a
+supported value. Historical omission of difficulty/capability details yields
+`{}`. Present malformed, empty, unknown-key or out-of-range details for these
+codes raise `ProviderError(code="invalid_response")`; an invalid async response
+does not clear pending recovery state. The Case-limit contract is unchanged.
+
+Other HTTP details remain discarded; unknown async detail shapes remain rejected.
+The service has not defined safe `field`, `location`, `pattern_id`, log-name or
+hash-pair detail contracts for the other validation errors, so they are not
+forwarded. Remote free-form messages are not trusted or interpolated into SDK
+messages. These details are diagnostics, not instructions to automatically retry
+a failed or billable request.

--- a/docs/api-reference.zh-CN.md
+++ b/docs/api-reference.zh-CN.md
@@ -338,3 +338,22 @@ Rubric、Prompt 或 Provider 响应。已知 operation 只通过 GET 继续轮�
 ## 错误字段
 
 普通 SDK 失败统一捕获 `KumaError`。`str(exc)` 是安全的用户文案；程序判断使用 `exc.code`、`exc.retryable` 和 `exc.request_id`。`exc.details` 是有界公开 mapping，也只应通过应用自己的 allowlist 记录。
+
+远端错误详情按错误码使用精确 schema，HTTP 失败和异步 failed operation 共用校验：
+
+| `exc.code` | 允许的 `exc.details` | 校验规则 |
+| --- | --- | --- |
+| `case_step_limit_exceeded` | `{"max_allowed_steps": 10}` | 必填、非布尔整数，范围 1–10。 |
+| `unsupported_difficulty` | `{"supported_difficulties": ["D0", "D2"]}` | D0–D4 中 1–5 个不重复值；保留服务端顺序，不要求排序。 |
+| `strategy_capability_mismatch` | `{"missing_capabilities": ["file_change", "tool_call"]}` | 1–7 个不重复 Evidence 能力，按 file_change、tool_call、command_result、test_result、state_transition、artifact_snapshot、agent_response_claim 的规范顺序排列。 |
+
+例如遇到 `unsupported_difficulty`，可显示经过校验的
+`exc.details.get("supported_difficulties", [])`，让调用方选择支持的值。
+兼容旧服务省略难度/能力详情，此时返回 `{}`；若提供了畸形、空列表、未知键、
+越界或错误顺序的详情，则抛 `ProviderError(code="invalid_response")`。
+异步响应校验失败不会清除待恢复状态。Case 步数上限的既有合同不变。
+
+其它 HTTP 详情仍丢弃，未知异步详情结构仍拒绝。其它校验错误尚无安全的
+`field`、`location`、`pattern_id`、日志名或哈希对详情合同，因此不会透传。
+SDK 不信任任意远端 message，也不会将其插入异常文案。这些详情仅用于诊断，
+不意味着可以自动重试失败请求或再次发起计费操作。

--- a/docs/strategy-groups.md
+++ b/docs/strategy-groups.md
@@ -1,4 +1,25 @@
 # KUMA Strategy Groups
+## Discovery cache and refresh
+
+Official `create_run` calls share validated catalogs within one process for at
+most **60 seconds after successful validation**, with a **32-entry LRU** keyed
+by canonical Backend URL and the exact credential fingerprint. Different keys,
+URLs and processes do not share entries; custom transports bypass this cache.
+The cache contains discovery metadata, not Agent content, request bodies or keys.
+
+`kuma strategies list`, `KumaClient.strategies()` and
+`KumaClient.strategy_group_catalog()` always fetch a fresh catalog. A failed
+refresh invalidates the previous value; there is no stale-on-error fallback.
+Concurrent Run lookups share one GET. Waiters stop after the smaller of their
+HTTP timeout and 30 seconds, without starting replacement GETs automatically.
+Each Run still checks its selection and required capabilities, even on a hit.
+
+Availability can be up to 60 seconds old; the server remains authoritative.
+Refreshing metadata does not change a pending request's catalog release or
+idempotency identity, and never automatically retries a paid Case/Judge request.
+This optimization removes redundant discovery GETs, not Case/Judge execution:
+with the default Judge enabled, the final `run.submit(...)` also waits for Judge.
+
 
 [English](strategy-groups.md) | [简体中文](strategy-groups.zh-CN.md)
 

--- a/docs/strategy-groups.zh-CN.md
+++ b/docs/strategy-groups.zh-CN.md
@@ -1,4 +1,22 @@
 # KUMA 策略组
+## 目录缓存与刷新
+
+官方 `create_run` 在同一进程内共享校验成功的目录，有效期为**成功校验后
+60 秒**，采用最多 **32 项的 LRU**，按规范化 Backend URL 与当前密钥的精确
+指纹隔离。不同密钥、URL、进程不共享；自定义 transport 不使用此缓存。
+缓存只保存目录元数据，不保存 Agent 正文、请求正文或密钥。
+
+`kuma strategies list`、`KumaClient.strategies()` 和
+`KumaClient.strategy_group_catalog()` 每次都会请求最新目录；刷新失败立即
+使旧值失效，不会用旧目录兜底。并发 Run 查询共享一次 GET，等待者最多等待
+其 HTTP timeout 与 30 秒中的较小值，失败后不会自行发起替代 GET。
+即使命中缓存，每个 Run 仍重新检查选择和所需能力。
+
+目录可用性最多滞后 60 秒，服务端仍做最终裁决。刷新不会改变已有请求的
+目录 release 或幂等身份，也不会自动重试付费 Case/Judge 请求。
+这只减少重复目录 GET，不消除 Case/Judge 执行时间：默认启用 Judge 时，
+最后一次 `run.submit(...)` 还会等待 Judge 完成。
+
 
 [English](strategy-groups.md) | [简体中文](strategy-groups.zh-CN.md)
 

--- a/src/kuma/api.py
+++ b/src/kuma/api.py
@@ -43,6 +43,7 @@ from .repository.strategy_groups import (
 from .run import Run
 from .runtime import RuntimeSession
 from .transport.backend import DEFAULT_BASE_URL, BackendClient
+from .transport.catalog_cache import read_strategy_catalog
 
 
 def configure(*, api_key: str) -> Path:
@@ -409,15 +410,21 @@ def _resolve_official_strategy_group(
     agent_profile: AgentProfileSpec | None,
     available_capabilities: tuple[str, ...],
 ) -> ResolvedStrategyGroup | None:
-    """Fetch and resolve the Strategy Group contract for an official Case.
+    """Read cached discovery and resolve the group anew for each official Case.
 
     New catalogs always produce one exact selection. A bounded legacy catalog
     keeps the old Case wire only when the user did not explicitly declare a
-    Strategy Group; explicit intent cannot be silently downgraded.
+    Strategy Group; explicit intent cannot be silently downgraded. Selection and
+    required-capability validation execute on every call, including cache hits.
+    Default transports share credential-isolated catalogs for at most 60 seconds
+    after validation; custom transports bypass caching. Failed refreshes never
+    use stale entries. No paid request identity or Run lifecycle is changed.
     """
     if backend is None:
         return None
-    catalog_value = backend.json("GET", "/sdk/strategies/")
+    catalog_value = read_strategy_catalog(
+        backend, fetch=lambda: backend.json("GET", "/sdk/strategies/")
+    )
     explicit = None if agent_profile is None else agent_profile.strategy_group
     if is_legacy_strategy_catalog(catalog_value):
         if explicit is not None:

--- a/src/kuma/client.py
+++ b/src/kuma/client.py
@@ -27,6 +27,7 @@ from .transport.backend import (
     _validate_base_url,
     _validate_timeout,
 )
+from .transport.catalog_cache import read_strategy_catalog
 
 Transport = WireTransport
 
@@ -140,6 +141,9 @@ class KumaClient:
 
         Side Effects:
             Performs one authenticated HTTPS/allowed-loopback GET request.
+            Strategy discovery refreshes the shared catalog cache before this
+            entry point maps transport errors; Run waiters retain their own
+            original SDK error classes rather than this client's legacy mapping.
 
         Security/Privacy:
             Stable public errors are exposed without returning raw remote bodies.
@@ -149,6 +153,12 @@ class KumaClient:
                 401, "Set KUMA_API_KEY or pass api_key to KumaClient."
             )
         try:
+            if path == "/sdk/strategies/":
+                return read_strategy_catalog(
+                    self._backend,
+                    fetch=lambda: self._backend.json("GET", path),
+                    refresh=True,
+                )
             return self._backend.json("GET", path)
         except AuthenticationError as exc:
             raise KumaAuthenticationError(401, str(exc)) from None
@@ -189,8 +199,9 @@ class KumaClient:
             KumaRateLimitError: Account quota prevents the read.
 
         Side Effects:
-            Performs one public Backend GET. Case generation does not use this
-            method as a client-side availability precheck.
+            Always refreshes through a public Backend GET, replacing the shared
+            process-local discovery cache; failure invalidates the old entry.
+            Run selection uses the cache but repeats selection/capability checks.
         """
 
         return self._read("/sdk/strategies/")
@@ -212,7 +223,7 @@ class KumaClient:
             Performs one public Backend GET. It does not generate a Case or run
             local scanner selection.
         """
-        return validate_strategy_group_catalog(self._read("/sdk/strategies/"))
+        return validate_strategy_group_catalog(self.strategies())
 
     def judge_config(self) -> Mapping[str, Any]:
         """Fetch current public Judge upload limits and Evidence types.

--- a/src/kuma/transport/backend.py
+++ b/src/kuma/transport/backend.py
@@ -33,6 +33,7 @@ from ..errors import (
     ServiceError,
     ValidationError,
 )
+from ..evidence.runtime_contract import CASEGEN_EVIDENCE_CAPABILITY_ORDER
 from ..runtime import is_running_in_docker
 from .http import (
     WireResponse,
@@ -46,6 +47,13 @@ DEFAULT_BASE_URL = "https://defuzex.ai/api/agentdefuze"
 _MAX_RESPONSE_BYTES = 8 * 1024 * 1024
 _MAX_MULTIPART_BYTES = 8 * 1024 * 1024
 _CLIENT_REQUEST_ID_PATTERN = re.compile(r"kreq_[0-9a-f]{32}\Z")
+_PUBLIC_ERROR_DETAIL_CODES = frozenset(
+    {
+        "case_step_limit_exceeded",
+        "unsupported_difficulty",
+        "strategy_capability_mismatch",
+    }
+)
 WireTransport = Callable[
     [str, str, Mapping[str, str], bytes | None, float],
     Mapping[str, Any],
@@ -430,14 +438,14 @@ def _error_envelope(
 
     Returns:
         ``(code, retryable, message, details)`` where arbitrary details are
-        discarded and only the closed Case step-limit field may survive.
+        discarded except for the per-code closed public detail schemas.
 
     Preconditions:
         ``error`` has not yet crossed the public SDK exception boundary.
 
     Postconditions:
         Only typed ``code``, ``retryable``, optional text ``message``, and the
-        integer ``max_allowed_steps`` for ``case_step_limit_exceeded`` remain.
+        explicitly validated Case-limit/difficulty/capability details remain.
 
     Security/Privacy:
         Backend/Core/provider diagnostics cannot flow through ``details``.
@@ -450,13 +458,62 @@ def _error_envelope(
     retryable = raw_retryable if isinstance(raw_retryable, bool) else False
     raw_message = envelope.get("message")
     message = raw_message if isinstance(raw_message, str) else None
-    return code, retryable, message, _case_step_limit_details(code, envelope)
+    return code, retryable, message, _public_error_details(code, envelope)
+
+
+def _public_error_details(code: str, envelope: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Detach only deployed per-code public details for HTTP and async failures.
+
+    Args:
+        code: Validated public error code; unrelated HTTP details are discarded.
+        envelope: Error fields from a bounded response. Historical omission is
+            accepted for difficulty/capability errors, not the required Case limit.
+
+    Returns:
+        A fresh mapping: Case integer limit, unique D0-D4 difficulty list in
+        server order, or canonical ordered missing Evidence capabilities.
+
+    Raises:
+        ProviderError: Present supported-code details have extra keys, invalid
+            types, duplicates, unknown values, or invalid bounds/order.
+
+    Security/Privacy:
+        No I/O or arbitrary strings survive. Async parsing restricts allowed
+        codes before calling this shared validator; pending state is not modified.
+    """
+    if code == "case_step_limit_exceeded":
+        return _case_step_limit_details(code, envelope)
+    if code not in _PUBLIC_ERROR_DETAIL_CODES or "details" not in envelope:
+        return {}
+    field, allowed = (
+        ("supported_difficulties", ("D0", "D1", "D2", "D3", "D4"))
+        if code == "unsupported_difficulty"
+        else ("missing_capabilities", CASEGEN_EVIDENCE_CAPABILITY_ORDER)
+    )
+    details = envelope["details"]
+    values = details.get(field) if isinstance(details, Mapping) else None
+    if (
+        not isinstance(details, Mapping)
+        or set(details) != {field}
+        or type(values) is not list
+        or not 1 <= len(values) <= len(allowed)
+        or any(type(value) is not str or value not in allowed for value in values)
+        or len(set(values)) != len(values)
+        or (
+            code == "strategy_capability_mismatch"
+            and values != [value for value in allowed if value in values]
+        )
+    ):
+        raise ProviderError(
+            "The Backend returned invalid public error details", code="invalid_response"
+        )
+    return {field: list(values)}
 
 
 def _case_step_limit_details(
     code: str, envelope: Mapping[str, Any]
 ) -> Mapping[str, int]:
-    """Validate the sole public error-detail shape allowed through the SDK.
+    """Validate the required closed Case service ceiling for the shared mapper.
 
     Arbitrary Backend details remain discarded for every other error code. The
     Case limit code fails closed when its required details object is absent,
@@ -622,7 +679,7 @@ def _mapped_remote_error(error: _RemoteError) -> KumaError:
 
     Returns:
         Unraised ``KumaError`` subclass carrying safe message, stable code,
-        retryability, and an empty detached details mapping.
+        retryability, and a detached per-code safe details mapping.
 
     Preconditions:
         The response has already passed size and top-level JSON validation.
@@ -666,8 +723,8 @@ def mapped_error(
         status: HTTP-equivalent status used for class fallback; defaults to 400.
         message: Optional frozen public wording. Arbitrary text is ignored by
             :func:`_public_error_message`.
-        details: Optional closed public error details. Only the Case step-limit
-            code may carry ``max_allowed_steps``.
+        details: Optional closed Case-limit, supported-difficulty or missing-
+            capability details; no other remote diagnostic fields are retained.
 
     Returns:
         Unraised public ``KumaError`` suitable for a batch item or asynchronous
@@ -680,7 +737,7 @@ def mapped_error(
         Produces the same class/message policy as a synchronous HTTP failure.
 
     Security/Privacy:
-        Discards all details except the validated integer Case service ceiling.
+        Discards details outside the validated per-code public whitelist.
     """
 
     envelope: dict[str, Any] = {

--- a/src/kuma/transport/catalog_cache.py
+++ b/src/kuma/transport/catalog_cache.py
@@ -1,0 +1,179 @@
+"""Bounded, credential-isolated caching of validated discovery metadata only."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable, Mapping
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..errors import KumaTimeoutError
+from ..repository.strategy_groups import (
+    StrategyGroupCatalog,
+    is_legacy_strategy_catalog,
+    validate_strategy_group_catalog,
+)
+from .backend import BackendClient, _wire_transport
+
+_TTL = 60.0
+_CAPACITY = 32
+_LOCK = threading.Lock()
+_ENTRIES: OrderedDict[tuple[str, str], tuple[float, StrategyGroupCatalog]] = (
+    OrderedDict()
+)
+
+
+@dataclass
+class _Flight:
+    """Share one completed discovery attempt with its existing waiters only.
+
+    Attributes:
+        done: Signals publication of either value or error, including cancellation.
+        value: Detached completed response, copied again for each waiting caller.
+        error: Attempt failure propagated to current waiters, never cached by key.
+    """
+
+    done: threading.Event = field(default_factory=threading.Event)
+    value: Mapping[str, Any] | None = None
+    error: BaseException | None = None
+
+
+_FLIGHTS: dict[tuple[str, str], _Flight] = {}
+
+
+def _await_flight(flight: _Flight, timeout: float) -> Mapping[str, Any]:
+    """Wait for one owned GET without starting a replacement after failure.
+
+    Args:
+        flight: Exact generation joined while holding the cache lock.
+        timeout: Caller HTTP timeout; local wait is capped at 30 seconds.
+
+    Returns:
+        Detached response after the owner publishes success.
+
+    Raises:
+        KumaTimeoutError: The bounded wait elapsed; owner continues independently.
+        BaseException: The original owner failure, including cancellation.
+
+    Side Effects:
+        Blocks this caller only; neither holds the cache lock nor performs I/O.
+    """
+    if not flight.done.wait(min(30.0, timeout)):
+        raise KumaTimeoutError(
+            "The KUMA metadata request timed out.",
+            code="network_timeout",
+            retryable=True,
+        )
+    if flight.error is not None:
+        raise flight.error
+    assert flight.value is not None
+    return deepcopy(flight.value)
+
+
+def _read_validated(
+    fetch: Callable[[], Mapping[str, Any]],
+) -> tuple[Mapping[str, Any], StrategyGroupCatalog | None]:
+    """Read through the caller's existing transport and validate discovery shape.
+
+    Args:
+        fetch: Existing authenticated metadata GET boundary. It must preserve
+            transport exceptions; each public caller applies its own error map
+            after cache coordination, not inside the shared attempt.
+
+    Returns:
+        Detached legacy mapping with no cacheable catalog, or a closed validated
+        immutable catalog and its detached wire mapping. Legacy compatibility is
+        preserved but never cached.
+
+    Raises:
+        KumaError: Existing transport or canonical schema error, unchanged.
+
+    Side Effects:
+        Calls fetch once; HTTP retry ownership stays with the existing client.
+    """
+    raw = fetch()
+    if is_legacy_strategy_catalog(raw):
+        return deepcopy(raw), None
+    catalog = validate_strategy_group_catalog(raw)
+    return catalog.to_dict(), catalog
+
+
+def read_strategy_catalog(
+    backend: BackendClient | None,
+    *,
+    fetch: Callable[[], Mapping[str, Any]],
+    refresh: bool = False,
+) -> Mapping[str, Any]:
+    """Read bounded discovery metadata for Run selection or explicit discovery.
+
+    Args:
+        backend: Authenticated transport owning canonical URL, credential digest
+            and per-attempt timeout. Custom transports bypass caching entirely.
+        fetch: Existing authenticated GET callable; preserves caller error mapping.
+        refresh: Explicit discovery always starts a new network generation, even
+            with an unexpired entry or another in-flight fetch.
+
+    Returns:
+        Detached catalog mapping. Only canonical immutable catalogs are cached,
+        for 60 monotonic seconds from validation, across at most 32 namespaces.
+
+    Raises:
+        KumaTimeoutError: A follower waited min(30 seconds, caller timeout).
+        KumaError: Fetch/validation failed; no stale entry is returned.
+
+    Postconditions:
+        New refresh generations fence older completions. Existing waiters share
+        their attempt's failure without automatically starting replacement GETs.
+        Run selection and capability validation still execute for each caller.
+
+    Side Effects:
+        Mutates process-local LRU and per-key flight state. No network occurs
+        under the lock; no disk, paid POST, retry policy or ledger is modified.
+
+    Security/Privacy:
+        Namespace uses canonical base and exact credential digest, not raw keys.
+        Custom transports never share cached values. Cached availability is not
+        authorization; the service remains authoritative for every paid request.
+    """
+    if type(backend) is not BackendClient or backend._transport is not _wire_transport:
+        return fetch()
+    key = (backend.base_url, backend.credential_identity)
+    with _LOCK:
+        entry = _ENTRIES.get(key)
+        if not refresh and entry is not None and time.monotonic() < entry[0]:
+            _ENTRIES.move_to_end(key)
+            return entry[1].to_dict()
+        _ENTRIES.pop(key, None)
+        flight = _FLIGHTS.get(key)
+        owner = refresh or flight is None
+        if owner:
+            flight = _Flight()
+            _FLIGHTS[key] = flight
+    assert flight is not None
+    if not owner:
+        return _await_flight(flight, backend.timeout)
+    try:
+        value, catalog = _read_validated(fetch)
+        validated_at = time.monotonic()
+        with _LOCK:
+            if _FLIGHTS.get(key) is flight:
+                if catalog is not None:
+                    _ENTRIES[key] = (validated_at + _TTL, catalog)
+                    _ENTRIES.move_to_end(key)
+                    while len(_ENTRIES) > _CAPACITY:
+                        _ENTRIES.popitem(last=False)
+                del _FLIGHTS[key]
+            flight.value = value
+            flight.done.set()
+        return deepcopy(value)
+    except BaseException as exc:
+        with _LOCK:
+            if _FLIGHTS.get(key) is flight:
+                _ENTRIES.pop(key, None)
+                del _FLIGHTS[key]
+            flight.error = exc
+            flight.done.set()
+        raise

--- a/src/kuma/transport/operations.py
+++ b/src/kuma/transport/operations.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import Any
 
 from ..config import (
-    DEFAULT_CASE_MAX_STEPS,
     DEFAULT_OPERATION_WAIT_TIMEOUT,
     validate_operation_wait_timeout,
 )
@@ -26,7 +25,12 @@ from ..errors import (
     ProviderError,
     ServiceBusyError,
 )
-from .backend import BackendClient, mapped_error
+from .backend import (
+    _PUBLIC_ERROR_DETAIL_CODES,
+    BackendClient,
+    _public_error_details,
+    mapped_error,
+)
 
 _DEFAULT_RESUME_POLL_MS = 1_000
 _MIN_POLL_MS = 100
@@ -399,8 +403,8 @@ def _poll_response(
 
     Returns:
         Status plus either a succeeded result mapping or a closed failed-error
-        tuple. Case step-limit errors may additionally carry the sole safe detail
-        ``max_allowed_steps``.
+        tuple. Known codes may carry closed Case-limit, difficulty or missing-
+        capability details validated by the same policy as HTTP errors.
 
     Raises:
         ProviderError: If IDs differ, status/fields violate the closed union, or
@@ -450,21 +454,15 @@ def _poll_response(
             retryable = error["retryable"]
             message = error.get("message")
             details = error.get("details")
-            details_valid = "details" not in error or (
-                code == "case_step_limit_exceeded"
-                and isinstance(details, Mapping)
-                and set(details) == {"max_allowed_steps"}
-                and not isinstance(details.get("max_allowed_steps"), bool)
-                and isinstance(details.get("max_allowed_steps"), int)
-                and 1 <= details["max_allowed_steps"] <= DEFAULT_CASE_MAX_STEPS
-            )
             if (
                 isinstance(code, str)
                 and 1 <= len(code) <= 64
                 and isinstance(retryable, bool)
                 and ("message" not in error or isinstance(message, str))
-                and details_valid
+                and ("details" not in error or code in _PUBLIC_ERROR_DETAIL_CODES)
             ):
+                if "details" in error:
+                    details = _public_error_details(code, error)
                 return status, None, (code, retryable, message, details)
     raise ProviderError(
         "The Backend returned an invalid operation status response",


### PR DESCRIPTION
## Changes
- Cache validated catalogs for 60 seconds in a credential-isolated, 32-entry process-local LRU. Explicit discovery refreshes; concurrent waiters share one attempt without stale fallback or replacement retries.
- Revalidate each Run selection/capability; preserve pending identities and per-entry-point error types.
- Preserve only closed details for case_step_limit_exceeded, unsupported_difficulty and strategy_capability_mismatch. Unknown/free-form details are not exposed; historical omission remains supported.
- Update English and Chinese guides.

## Verification
66 focused canonical tests bound to this public source PASS; scoped Ruff/format PASS; public docs 9 APIs x 2 languages PASS; diff-check PASS. Required CI will validate packaging/platforms. No production, model or paid calls.

Fixes #52
Fixes #57

This does not validate the performance estimate in #52 or implement arbitrary details suggested in #57. No private tests/assets/history or unrelated strategy features are included.