### PR TITLE
feat(case): save and reuse complete official Cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Follow the [full-stack user-flow guide](examples/full_stack/README.md) to run KU
 
 ## Detailed documentation
 
+[Save and reuse a Case](docs/case-files.md)
+
 [English SDK guide](docs/sdk-guide.md) · [Strategy Groups](docs/strategy-groups.md) · [Agent tool capabilities](docs/agent-tool-capabilities.md) · [Python API reference](docs/api-reference.md) · [Agent Profile migration](docs/migration-agent-profile.md) · [简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [中文 API 参考](docs/api-reference.zh-CN.md) · [Runtime Evidence contract](docs/runtime-evidence.md)
 
 ## Project

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,6 +48,8 @@ kuma quickstart
 
 ## 详细文档
 
+[保存并复用 Case](docs/case-files.zh-CN.md)
+
 [简体中文 SDK 指南](docs/sdk-guide.zh-CN.md) · [策略组](docs/strategy-groups.zh-CN.md) · [Agent 工具能力](docs/agent-tool-capabilities.zh-CN.md) · [中文 API 参考](docs/api-reference.zh-CN.md) · [Agent Profile 迁移说明](docs/migration-agent-profile.md) · [English SDK guide](docs/sdk-guide.md) · [Python API reference](docs/api-reference.md) · [Runtime Evidence 合同](docs/runtime-evidence.md)
 
 ## 项目链接

--- a/docs/api-contract.md
+++ b/docs/api-contract.md
@@ -1,5 +1,20 @@
 # KUMA SDK API Contract
 
+## 保存的 Case 与官方 Judge 原件
+
+`Run.save_case(path)` / `create_run(case_path=...)` 使用本地 closed
+`kuma.case_artifact.v1`；完整字段、5 MiB/深度限制和来源规则见
+[Case 文件](case-files.zh-CN.md)。新官方 Judge 上传 raw schema `2` 的完整十字段
+公共 Case，part 为 `case_file`、filename `kuma-official-case.json`、MIME
+`application/json`；不上传本地 artifact 外壳，不同时传顶层 `case_id`。
+metadata 仍为既有 `repo_fingerprint/case_sha256/case_signature`，必须与 raw 一致。
+batch 使用既有 `case_file_part` 指向各条目的 Case part。Case 文件字节计入原有
+动态单文件和总预算；custom Case 仍用 `defuzex.custom_case.v1`。
+公开 checksum 不是认证：Backend 在新 reservation 前核验租户原件和原 CaseGen
+control 的唯一 Rubric 引用。SDK 不导入 Rubric，不把被编辑的官方 Case 降级为
+custom，也不在旧 Backend 拒绝时退回 case_id-only。历史客户端引用路径不作为
+新保存/加载流程的隐式兼容路径。
+
 Base URL：`https://defuzex.ai/api/agentdefuze`
 
 所有 URL 使用 trailing slash。SDK 请求使用：

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -56,6 +56,7 @@ run = create_run(
 | --- | --- | --- | --- |
 | `repo_path` | `str \| os.PathLike[str]` | `"."` | Chooses the repository being tested. KUMA reads bounded metadata and, when enabled, observes file changes below this directory. Use `"."` when your Python process already runs at the repository root. |
 | `agent_profile_path` | `str \| os.PathLike[str] \| None` | `None` | Points to the UTF-8 file that describes the Agent, its production scenario, expected behavior, and prohibited boundaries. Supply it for official Case generation. The selected Strategy Group still controls the testing capability/domain/method; profile prose cannot select or override that group. Front matter may contain a closed `strategy_group` coordinate and a relative `tool_capabilities` file; both are validated before Provider I/O. Omit the path only when your custom Case Provider does not need an Agent Profile. |
+| `case_path` | `str \| os.PathLike[str] \| None` | `None` | Loads a complete saved `kuma.case_artifact.v1` instead of generating a Case. Relative paths use `repo_path`, not cwd. Cannot combine with `case_provider`, `agent_profile_path`, or non-`auto` strategy. Loading validates at most 5 MiB before credentials/runtime setup and makes no CaseGen/catalog call; `max_steps=None` uses the saved count, a smaller explicit limit fails without truncation. Official Judge still needs credentials and validates the server original. |
 | `case_provider` | `CaseProvider \| callable \| None` | `None` | Chooses who creates the test Inputs. Leave `None` to request an official Case from KUMA; pass a callable when your application supplies its own local Case. |
 | `judge_provider` | `JudgeProvider \| callable \| None` | `None` | Chooses who evaluates all submitted results and builds the final report. Leave `None` for the official Judge, or pass a callable for your own local evaluation. Ignored when `judge=False`. |
 | `strategy` | `str` | `"auto"` | Preserves compatibility with services that use an unversioned strategy ID. For current Strategy Groups, put the exact `id` and `version` in Agent Profile front matter. Combining a structured declaration with a non-default legacy value fails instead of creating ambiguous intent. |
@@ -132,6 +133,32 @@ content uses `agent_profile_invalid`. The returned `strategy_group` is an exact
 coordinate declaration—not an inference from Profile prose.
 
 ## `Run`
+
+### `save_case`
+
+<!-- api-parameters:save_case:start -->
+
+| Argument | Type | Required/default | What it does and when to use it |
+| --- | --- | --- | --- |
+| `path` | `str \| os.PathLike[str]` | Required | Destination within this Run's repository; relative paths are repository-relative. Its parent must already exist. Choose a new filename: existing files, symlinks, mount escapes and concurrent overwrites are rejected. |
+
+<!-- api-parameters:save_case:end -->
+
+**Returns:** absolute `Path` to the complete UTF-8 Case artifact (maximum
+5,242,880 bytes). **Preconditions:** the Run has a validated complete Case;
+official Cases must retain their original public record. **Postconditions:**
+Run state, history and Input position do not change; no runtime ID, Evidence,
+Agent output, Rubric or credential is saved. **Raises:**
+`ValidationError(case_artifact_invalid)` for invalid/changed content,
+`ValidationError(case_origin_invalid)` for conflicting origin,
+`SensitiveDataError` for sensitive/private content, and `ConfigurationError`
+for unsafe/unwritable/existing paths. **Side effects:** bounded atomic file
+publication, no network. Privacy checks cannot be disabled. Public checksums
+detect corruption, not authenticity; official Judge validates the tenant-owned
+server original. [Save/load example and wire boundaries](case-files.md).
+
+`run.case_origin` is read-only `"official" | "custom"`; it describes the Case,
+not which Judge is configured. An official Judge does not make a custom Case official.
 
 ### `get_input`
 

--- a/docs/api-reference.zh-CN.md
+++ b/docs/api-reference.zh-CN.md
@@ -44,6 +44,7 @@ run = create_run(repo_path=".", agent_profile_path="agent-profile.md")
 | --- | --- | --- | --- |
 | `repo_path` | `str \| os.PathLike[str]` | `"."` | 指定“这次要测试哪个仓库”。KUMA 会读取该目录下的有界元数据，并在启用文件追踪时观察其中的文件变化。如果 Python 正在仓库根目录运行，保留 `"."` 即可。 |
 | `agent_profile_path` | `str \| os.PathLike[str] \| None` | `None` | 指向描述被测 Agent、生产场景、预期行为和禁止边界的 UTF-8 文件。官方 Case 必须提供。选定的策略组仍决定测试能力、领域和方法，Profile 自然语言不能选组或覆盖该选择。Front matter 可包含 closed `strategy_group` 坐标和相对路径 `tool_capabilities` 文件，两者都会在 Provider I/O 前校验。只有自定义 Case Provider 明确不需要 Agent Profile 时才可省略。 |
+| `case_path` | `str \| os.PathLike[str] \| None` | `None` | 加载完整 `kuma.case_artifact.v1` 文件，不重新生成 Case。相对路径基于 `repo_path` 而非 cwd；不能与 `case_provider`、`agent_profile_path` 或非 `auto` strategy 同用。最多读取 5 MiB，在凭据和 runtime 初始化前校验，不调用 CaseGen/目录；`max_steps=None` 使用保存的完整步数，显式值更小时报错、不截断。官方 Judge 仍需凭据并核验服务端原件。 |
 | `case_provider` | `CaseProvider \| callable \| None` | `None` | 决定由谁生成测试步骤。保留 `None` 会向 KUMA 官方服务申请 Case；传入 callable 表示由你的程序在本地提供 Case。 |
 | `judge_provider` | `JudgeProvider \| callable \| None` | `None` | 决定由谁评估全部步骤并生成最终报告。保留 `None` 使用官方 Judge；传入 callable 使用你自己的本地评估逻辑。`judge=False` 时不会使用它。 |
 | `strategy` | `str` | `"auto"` | 保留仅使用未版本化 strategy ID 的服务兼容性。当前策略组应在 Agent Profile front matter 中填写精确 `id` 与 `version`。结构化声明与非默认旧值同时出现时会直接失败，避免产生歧义。 |
@@ -106,6 +107,29 @@ BOM，校验 closed front matter 和三个必需行为章节，并返回不可�
 `strategy_group` 是精确坐标声明，不是从 Profile 正文推断的结果。
 
 ## `Run`
+
+### `save_case`
+
+<!-- api-parameters:save_case:start -->
+
+| 参数 | 类型 | 必填/默认值 | 用途与用法 |
+| --- | --- | --- | --- |
+| `path` | `str \| os.PathLike[str]` | 必填 | 保存到该 Run 仓库内部；相对路径从仓库根解析。父目录须已存在，请使用新文件名：已有文件、symlink、跨 mount 逃逸及并发覆盖都会拒绝。 |
+
+<!-- api-parameters:save_case:end -->
+
+**返回值：** 完整 UTF-8 Case 文件的绝对 `Path`，整文件最多 5,242,880 bytes。
+**前置条件：** Run 已持有完整有效 Case；官方 Case 必须保有原始公共记录。
+**后置条件：** 不改变 Run 状态、history 或 Input 位置，不保存运行 ID、Evidence、
+Agent 输出、Rubric 或凭据。**异常：** 内容无效/被改动时
+`ValidationError(case_artifact_invalid)`；来源冲突时
+`ValidationError(case_origin_invalid)`；敏感/私有内容为 `SensitiveDataError`；
+路径不安全、不可写或已存在为 `ConfigurationError`。**副作用：** 有界原子写文件，
+不联网，隐私检查不能关闭。公开 checksum 只能检测损坏，不能证明真实性；官方
+Judge 仍校验当前租户的服务端原件。参见[保存与加载示例及 wire 边界](case-files.zh-CN.md)。
+
+`run.case_origin` 是只读 `"official" | "custom"`，表示 Case 来源而不是 Judge
+类型；使用官方 Judge 不会把自定义 Case 变成官方 Case。
 
 ### `get_input`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,11 @@
 # SDK v4 架构
 
+Case 文件层 `repository/case_artifacts.py` 统一校验保存、加载与官方 Judge
+上传的同一公共原件。`case_artifact_io.py` 仅负责有界读取及固定父目录下的原子
+不覆盖发布；`create_run(case_path=...)` 在鉴权/运行材料初始化前加载，复用
+正常 Input 规范化并绑定新 Run ID。来源与 Rubric 不猜测：SDK checksum 不证明
+发行身份，Backend/Core 保留租户原件/原 Rubric 的权威核验职责。
+
 本文描述当前 `kuma` Python 包的模块边界、同步用户 API、内部 v2 operation 流程和关键不变量。公开 HTTP 字段与路径另见 [API Contract](api-contract.md)；使用方式见 [README](../README.md)。
 
 ## 系统边界与数据归属

--- a/docs/case-files.md
+++ b/docs/case-files.md
@@ -1,0 +1,84 @@
+# Save and reuse a complete Case
+
+[简体中文](case-files.zh-CN.md) | English
+
+Generate once, explicitly save the complete public Case, and execute it in a new
+Run or process without another CaseGen request:
+
+```python
+from kuma import create_run
+
+run = create_run(repo_path=".", agent_profile_path="agent-profile.md")
+saved = run.save_case("case.json")  # new file; parent must exist
+run.cancel()  # release this Run before starting another
+
+# This can be a separate process. No Profile or Case Provider is needed.
+reused = create_run(repo_path=".", case_path="case.json")
+print(reused.case_origin)  # "official"
+# Execute the Agent with reused.get_input(), then reused.submit(agent_output).
+reused.cancel()  # omit this when continuing execution
+```
+
+The usual Docker/API-key rules still apply. For a trusted local environment use
+`allow_local=True`; `judge=False` allows loading without official-service
+credentials. Loading performs no CaseGen or strategy-catalog request. Official
+Judge may negotiate Evidence and evaluate the saved Case; that is a separate
+Judge request, not free evaluation or a promise of zero billing.
+
+## File and identity
+
+The UTF-8 file is the closed object `schema_version`, `origin`, `case`, `integrity`.
+`schema_version` is `kuma.case_artifact.v1`; `origin` is `official` or `custom`.
+Maximum size is 5,242,880 bytes; JSON is finite and bounded to depth 32 (root 0).
+Duplicate keys and unknown fields fail. Files never contain Run IDs, execution
+history, Evidence, Agent outputs, credentials or private Rubrics. Privacy
+rejection applies even with `allow_sensitive=True`.
+
+An official file contains its original public schema-2 Case exactly once:
+`schema_version`, `batch_id`, `case_id`, `strategy_id`, `strategy_version`,
+`repo_fingerprint`, `title`, `description`, `steps`, `signature`. Each step has
+`step_id` and `prompt`. Integrity repeats the existing seven public references
+and may include the validated `executed_strategy_group`. There is no second
+normalized Inputs copy to edit independently.
+
+A custom file contains exactly `case_id`, `input_type`, `input_schema`, `inputs`,
+`extensions`, with `integrity: null`. Each input has `input_id`, `payload_type`,
+`payload`, `public_constraints`, `extensions`. A custom Case remains custom even
+when evaluated by official Judge. No Rubric is imported or created by the SDK.
+
+Loading preserves Case ID, Input IDs/order and content; only the new Run ID is
+rebound. `max_steps=None` uses the full saved count. An explicitly smaller value
+fails; a larger one never adds steps. Do not also pass a Profile, Case Provider,
+or non-default strategy. Automatic strategy scanning remains disabled.
+
+## Integrity and official Judge
+
+`signature` is `sha256:` plus canonical unsigned public-Case SHA-256;
+`case_sha256` hashes the complete public Case including signature. Canonical
+JSON uses sorted keys, compact separators, `ensure_ascii=False`, finite values
+and UTF-8. **These are public checksums, not signatures proving server issuance.**
+Changing a checksum cannot authorize a changed official Case.
+
+New official Judge requests send only the original schema-2 object as multipart
+`case_file`, filename `kuma-official-case.json`, MIME `application/json`; they do
+not also send a top-level `case_id`. Existing integrity metadata remains bound
+to the same object. Case bytes count toward negotiated file/total budgets.
+Backend verifies the tenant-owned original and original Rubric before new Judge
+reservation; accepted request recovery retains its original idempotency rules.
+
+Older SDK objects missing the original public record and inputs-only JSON files
+are not loadable official artifacts. Old Backend versions may reject the new
+official file; the SDK surfaces that error and never retries as custom or
+case-ID-only. To author a different Case, deliberately use a custom Provider and
+save its resulting custom Case. Never remove `origin` or fake official integrity.
+
+## Failure and file safety
+
+`case_artifact_invalid` means malformed, oversized or changed content;
+`case_origin_invalid` means absent/conflicting origin. Sensitive data is rejected
+without returning its value. Missing/unreadable/unsafe paths and existing save
+targets raise safe `ConfigurationError`. Relative paths use `repo_path`, not
+process cwd. Parents must exist; links, mount escapes and overwrite are rejected.
+Publication uses a temporary file, fsync and atomic no-replace hard link under a
+pinned parent. A filesystem lacking that operation fails rather than overwriting.
+Save/load never executes tools or uploads local configuration.

--- a/docs/case-files.zh-CN.md
+++ b/docs/case-files.zh-CN.md
@@ -1,0 +1,75 @@
+# 保存并复用完整 Case
+
+[English](case-files.md) | 简体中文
+
+生成一次后，显式保存完整公共 Case，随后可在新 Run 或新进程执行，不再次请求 CaseGen：
+
+```python
+from kuma import create_run
+
+run = create_run(repo_path=".", agent_profile_path="agent-profile.md")
+saved = run.save_case("case.json")  # 新文件；父目录须已存在
+run.cancel()  # 启动另一个 Run 前释放当前 Run
+
+# 可在另一个进程执行，不需要 Profile 或 Case Provider。
+reused = create_run(repo_path=".", case_path="case.json")
+print(reused.case_origin)  # "official"
+# 将 reused.get_input() 交给 Agent，再调用 reused.submit(agent_output)。
+reused.cancel()  # 如果继续执行，省略这行
+```
+
+原有 Docker/API Key 要求不变。可信本地开发可传 `allow_local=True`；
+`judge=False` 可不带官方服务凭据加载。加载不调用 CaseGen 或策略目录。
+官方 Judge 仍可能协商 Evidence 并评价保存的 Case，这是独立 Judge 请求，
+不表示评价免费，也不承诺零计费。
+
+## 文件与身份
+
+UTF-8 文件是 closed object，仅含 `schema_version`、`origin`、`case`、`integrity`。
+`schema_version` 固定 `kuma.case_artifact.v1`，`origin` 为 `official` 或 `custom`。
+整文件最多 5,242,880 bytes；JSON 必须有限，根深度 0、最大深度 32。
+拒绝重复 key 和未知字段。不包含运行 ID、执行 history、Evidence、Agent 输出、
+凭据或私有 Rubric；`allow_sensitive=True` 也不能绕过隐私拒绝。
+
+官方文件只保存一份原始公共 schema-2 Case：`schema_version`、`batch_id`、
+`case_id`、`strategy_id`、`strategy_version`、`repo_fingerprint`、`title`、
+`description`、`steps`、`signature`。每步仅含 `step_id`、`prompt`。
+integrity 保留既有七个公共引用字段，可额外包含已校验的
+`executed_strategy_group`；没有第二份可独立编辑的规范化 Inputs。
+
+自定义文件的 case 仅含 `case_id`、`input_type`、`input_schema`、`inputs`、
+`extensions`，`integrity: null`。每个 input 仅含 `input_id`、`payload_type`、
+`payload`、`public_constraints`、`extensions`。使用官方 Judge 也不会把自定义
+Case 变成官方 Case；SDK 不导入或生成 Rubric。
+
+加载保留 Case ID、Input ID/顺序和内容，只绑定新 Run ID。
+`max_steps=None` 使用完整保存步数；显式值较小则拒绝，较大也不补步骤。
+不得同时提供 Profile、Case Provider 或非默认 strategy。自动选组仍禁用。
+
+## 完整性与官方 Judge
+
+`signature` 是 `sha256:` 加未含 signature 的公共 Case canonical SHA-256；
+`case_sha256` 对包含 signature 的完整 Case 计算。Canonical JSON 使用 sorted
+keys、紧凑分隔符、`ensure_ascii=False`、有限值和 UTF-8。
+**这两个是公开 checksum，不是证明服务端发行身份的数字签名。** 重算 hash
+不会让被改动的官方 Case 获得授权。
+
+新官方 Judge 请求仅把原始 schema-2 object 放进 multipart `case_file`，
+文件名 `kuma-official-case.json`、MIME `application/json`，不再同时发送顶层
+`case_id`。既有 integrity metadata 绑定同一对象；Case 字节计入协商的单文件/
+总预算。Backend 在新 Judge reservation 前核对当前租户原件及原 Rubric；
+已接受请求的恢复继续遵守原幂等规则。
+
+缺少原始公共记录的旧 SDK 对象、只有 inputs 的 JSON 不能作为官方 artifact
+加载。旧 Backend 可能拒绝新官方文件；SDK 原样报告安全错误，不改为 custom
+或仅传 case ID 重试。想编写另一份 Case，请明确使用自定义 Provider，再保存其
+自定义 Case；不要删除 origin 或伪造官方 integrity。
+
+## 错误与文件安全
+
+`case_artifact_invalid` 表示格式、大小或内容无效/改变；`case_origin_invalid`
+表示来源缺失或冲突。敏感数据拒绝不回显命中值。文件缺失、不可读、路径不安全
+及保存目标已存在时抛安全 `ConfigurationError`。相对路径基于 `repo_path`，
+不基于 cwd。父目录须存在；拒绝链接、跨 mount 逃逸和覆盖。
+保存使用临时文件、fsync、固定父目录下的原子不覆盖 hard link；文件系统不支持
+时直接失败，不改用覆盖。保存/加载不执行工具，不上传本地配置。

--- a/docs/sdk-guide.md
+++ b/docs/sdk-guide.md
@@ -1,5 +1,9 @@
 # KUMA Python SDK guide
 
+To reuse the same complete Case in a new process, call `run.save_case("case.json")`
+then `create_run(repo_path=".", case_path="case.json")`. See [Case files](case-files.md)
+for origin, path/size limits, official verification and Judge billing boundaries.
+
 Evidence capacity: the default Trace budget is 8 MiB across one Run; span,
 attribute and event limits and visible loss counters remain active. Canonical
 Agent-output JSON allows 4 MiB, one Runtime Evidence envelope allows 5 MiB, and

--- a/docs/sdk-guide.zh-CN.md
+++ b/docs/sdk-guide.zh-CN.md
@@ -1,5 +1,9 @@
 # KUMA Python SDK 指南
 
+跨进程复用同一完整 Case：调用 `run.save_case("case.json")`，再使用
+`create_run(repo_path=".", case_path="case.json")`。来源、路径/大小限制、官方核验
+及 Judge 计费边界见 [Case 文件](case-files.zh-CN.md)。
+
 Evidence 容量：默认 Trace 总预算为每 Run 8 MiB；span、attribute、event 上限及
 透明丢弃计数继续生效。Agent 输出 canonical JSON 上限 4 MiB，单份 Runtime
 Evidence 上限 5 MiB，含元数据和分隔符的完整 multipart 上限 8 MiB。

--- a/src/kuma/api.py
+++ b/src/kuma/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import uuid
 from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -31,6 +32,8 @@ from .providers._official_wire import validate_official_case_provenance
 from .providers.base import CaseGenerationContext, CaseProvider, JudgeProvider
 from .providers.normalization import normalize_case
 from .repository.agent_profiles import AgentProfileSpec, parse_agent_profile
+from .repository.case_artifact_io import load_case_artifact
+from .repository.case_artifacts import LoadedCaseProvider, official_original
 from .repository.metadata import collect_repo_meta
 from .repository.privacy import enforce_sensitive_policy, scan_sensitive_text
 from .repository.strategy_groups import (
@@ -446,10 +449,71 @@ def _resolve_official_strategy_group(
     )
 
 
+def _prepare_case_source(
+    *,
+    repo_path: str | os.PathLike[str],
+    case_path: str | os.PathLike[str] | None,
+    case_provider: Any,
+    agent_profile_path: str | os.PathLike[str] | None,
+    config: CreateRunConfig,
+) -> tuple[
+    CaseProvider | None,
+    AgentProfileSpec | None,
+    CreateRunConfig,
+    LoadedCaseProvider | None,
+]:
+    """Select generated versus explicitly loaded Case before any external effects.
+
+    Args:
+        repo_path: Repository used to resolve a relative artifact file.
+        case_path: Optional saved artifact; None retains generation preflight.
+        case_provider: Caller provider, forbidden alongside a file.
+        agent_profile_path: Generation Profile, forbidden alongside a file.
+        config: Pure validated options; loading requires auto and never truncates.
+    Returns:
+        Provider, optional Profile, effective limits, and typed loaded-source marker.
+    Raises:
+        ConfigurationError: Conflicting input modes or unsafe/unreadable local path.
+        ValidationError: Invalid artifact or explicit step ceiling below its count.
+    Side Effects:
+        Only an explicitly selected bounded file may be read. No credentials,
+        catalog, CaseGen, runtime, or Evidence setup happens at this boundary.
+    """
+    if case_path is None:
+        provider, profile = _prepare_case_agent_profile(
+            case_provider, agent_profile_path
+        )
+        return provider, profile, config, None
+    if (
+        case_provider is not None
+        or agent_profile_path is not None
+        or config.strategy != "auto"
+    ):
+        raise ConfigurationError(
+            "case_path cannot be combined with a Provider, Profile, or strategy selection"
+        )
+    data = load_case_artifact(
+        _resolve_repo_path(repo_path), case_path, alias=_repo_root_alias(repo_path)
+    )
+    loaded = LoadedCaseProvider(data)
+    if config.max_steps is not None and config.max_steps < loaded.count:
+        raise ValidationError(
+            "Saved Case exceeds max_steps; it cannot be truncated",
+            code="case_artifact_invalid",
+        )
+    return (
+        loaded,
+        None,
+        replace(config, max_steps=config.max_steps or loaded.count),
+        loaded,
+    )
+
+
 def create_run(
     *,
     repo_path: str | os.PathLike[str] = ".",
     agent_profile_path: str | os.PathLike[str] | None = None,
+    case_path: str | os.PathLike[str] | None = None,
     case_provider: Any = None,
     judge_provider: Any = None,
     strategy: str = "auto",
@@ -486,6 +550,12 @@ def create_run(
             before Provider I/O and remains local on the current official wire.
         case_provider: :class:`CaseProvider` or compatible callable. ``None``
             selects the official authenticated provider.
+        case_path: Explicit saved Case artifact inside repo_path, or None to
+            generate normally. Relative paths use repo_path, not cwd. Cannot be
+            combined with case_provider, agent_profile_path, or non-auto strategy.
+            Loading performs no CaseGen/catalog request; preserves original IDs,
+            order and content while assigning a new Run ID. Official origin never
+            falls back to custom. max_steps=None accepts the full saved count.
         judge_provider: :class:`JudgeProvider` or compatible callable. ``None``
             selects the official provider when ``judge=True``.
         strategy: ``"auto"`` or an explicit public strategy ID. The SDK never
@@ -583,9 +653,12 @@ def create_run(
     )
     if config.upload_diff and not config.track_files:
         raise ConfigurationError("upload_diff requires track_files=True")
-    adapted_case_input, agent_profile = _prepare_case_agent_profile(
-        case_provider,
-        agent_profile_path,
+    adapted_case_input, agent_profile, config, loaded = _prepare_case_source(
+        repo_path=repo_path,
+        case_path=case_path,
+        case_provider=case_provider,
+        agent_profile_path=agent_profile_path,
+        config=config,
     )
     _preflight_official_agent_profile_privacy(
         agent_profile,
@@ -610,6 +683,8 @@ def create_run(
         trace_evidence=trace_evidence,
         agent_profile=agent_profile,
     )
+    if loaded is not None:
+        official_case = loaded.origin == "official"
 
     run_id = f"run_{uuid.uuid4().hex}"
     runtime = RuntimeSession.open(
@@ -622,10 +697,12 @@ def create_run(
         effective_max_steps = config.max_steps or (
             DEFAULT_CASE_MAX_STEPS if official_case else 50
         )
-        repo_meta = collect_repo_meta(resolved_repo)
+        repo_meta = (
+            {} if loaded is not None else collect_repo_meta(resolved_repo).to_dict()
+        )
         context = CaseGenerationContext(
             repo_path=resolved_repo,
-            repo_meta=repo_meta.to_dict(),
+            repo_meta=repo_meta,
             agent_profile=None if agent_profile is None else agent_profile.content,
             agent_description=(
                 None if agent_profile is None else agent_profile.agent_description
@@ -668,6 +745,8 @@ def create_run(
         official_provenance = case.extensions.get("official_case")
         if official_case:
             validate_official_case_provenance(official_provenance)
+            if loaded is not None:
+                official_original(case)
         elif "official_case" in case.extensions:
             raise ProviderError(
                 "Custom Case Provider returned reserved official_case metadata",

--- a/src/kuma/providers/official_case.py
+++ b/src/kuma/providers/official_case.py
@@ -15,6 +15,7 @@ from ..errors import (
     ValidationError,
 )
 from ..evidence.runtime_contract import CASEGEN_EVIDENCE_CAPABILITY_ORDER
+from ..repository.case_artifacts import validate_public_original
 from ..repository.metadata import prepare_repo_meta_upload
 from ..repository.privacy import enforce_sensitive_policy, scan_sensitive_json
 from ..repository.strategy_groups import validate_strategy_group_wire_selection
@@ -675,6 +676,15 @@ def _normalized_case(
     executed = _executed_strategy_group(response, requested_strategy_group)
     if executed is not None:
         provenance["executed_strategy_group"] = executed
+    invalid_original = False
+    try:
+        provenance["public_case"] = validate_public_original(raw_case)
+    except ValidationError:
+        invalid_original = True
+    if invalid_original:
+        raise ProviderError(
+            "The Backend returned an invalid public Case", code="invalid_response"
+        )
     return {
         "case_id": case_id,
         "inputs": inputs,

--- a/src/kuma/providers/official_judge.py
+++ b/src/kuma/providers/official_judge.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from ..contracts import JudgeBatchResult
 from ..errors import ConfigurationError, LimitExceededError, ProviderError
+from ..repository.case_artifacts import MAX_CASE_ARTIFACT_BYTES, official_original
 from ..repository.privacy import enforce_sensitive_policy, scan_sensitive_json
 from ..transport.backend import (
     BackendClient,
@@ -33,7 +34,6 @@ from ._official_judgment import normalize_official_judgment as _normalize_judgme
 from ._official_wire import (
     plain_json,
     required_text,
-    validate_official_case_provenance,
 )
 from .base import JudgeContext
 from .normalization import normalize_report, validate_custom_case_public_data
@@ -48,8 +48,10 @@ class _JudgeUpload:
     Attributes:
         run_id: Public Run identifier being judged.
         metadata: Safe manifest/history mapping sent as multipart metadata.
-        case_id: Official Case reference, or ``None`` for custom Case upload.
-        case_part: Serialized public custom Case part when required.
+        case_id: Legacy wire reference; new uploads use case_part instead.
+        local_case_id: Public Case locator retained in the local request ledger;
+            independent of the multipart case_id/case_file exclusive choice.
+        case_part: Serialized original official or public custom Case.
         log_parts: Bounded Evidence parts in deterministic order.
         idempotency_key: Stable key reused for retries of this exact Run history.
     """
@@ -60,6 +62,7 @@ class _JudgeUpload:
     case_part: UploadPart | None
     log_parts: tuple[UploadPart, ...]
     idempotency_key: str
+    local_case_id: str | None = None
 
 
 def _client_credential_identity(client: Any) -> str:
@@ -224,8 +227,9 @@ def _preflight_custom_case_privacy(
         allow_sensitive: Existing explicit ordinary-Evidence policy override.
 
     Raises:
-        SensitiveDataError: If the custom Case projection contains a recognized
-            sensitive shape and the existing policy disallows it.
+        SensitiveDataError: If the public Case projection contains a recognized
+            sensitive shape; official originals never permit policy overrides.
+        ValidationError: Official Inputs or provenance differ from their original.
         ProviderError: If the custom Case cannot be projected as public JSON.
 
     Preconditions:
@@ -257,8 +261,7 @@ def _official_case_reference(
     """Validate official provenance and return its opaque Backend reference metadata."""
     if "official_case" not in context.case.extensions:
         return None
-    official = context.case.extensions["official_case"]
-    provenance = validate_official_case_provenance(official)
+    _, provenance = official_original(context.case)
     metadata = {
         name: provenance[name]
         for name in ("repo_fingerprint", "case_sha256", "case_signature")
@@ -432,8 +435,31 @@ class OfficialJudgeProvider:
         case_id: str | None = None
         case_part: UploadPart | None = None
         if official is not None:
-            case_id, integrity = official
+            _, integrity = official
             metadata.update(integrity)
+            raw, _ = official_original(context.case)
+            encoded = json.dumps(
+                raw, ensure_ascii=False, separators=(",", ":"), allow_nan=False
+            ).encode("utf-8")
+            if len(encoded) > min(MAX_CASE_ARTIFACT_BYTES, config.max_file_bytes):
+                raise LimitExceededError(
+                    "Official Case exceeds the upload limit", code="invalid_case_file"
+                )
+            case_part = UploadPart(
+                name=f"{part_prefix}case" if part_prefix else "case_file",
+                filename="kuma-official-case.json",
+                content_type="application/json",
+                data=encoded,
+            )
+            if (
+                len(log_parts) + 1 > config.max_files
+                or len(encoded) + sum(len(part.data) for part in log_parts)
+                > config.max_total_bytes
+            ):
+                raise LimitExceededError(
+                    "Case and Evidence exceed the upload limit",
+                    code="log_size_exceeded",
+                )
         else:
             case_part, case_findings = _custom_case_part(context, config, part_prefix)
             findings.extend(case_findings)
@@ -445,6 +471,7 @@ class OfficialJudgeProvider:
             case_part=case_part,
             log_parts=log_parts,
             idempotency_key=idempotency_key or self._idempotency_key(run_id),
+            local_case_id=context.case.case_id,
         )
 
     def judge(self, context: JudgeContext) -> Mapping[str, Any]:
@@ -595,7 +622,7 @@ class OfficialJudgeProvider:
                     base_url=self.client.base_url,
                     api_key_sha256=_client_credential_identity(self.client),
                     run_id=upload.run_id,
-                    case_id=upload.case_id,
+                    case_id=upload.local_case_id,
                 )
 
         def start_operation(key: str, deadline: float) -> Mapping[str, Any]:
@@ -704,6 +731,14 @@ class OfficialJudgeProvider:
             item, item_parts = _batch_item(upload)
             items.append(item)
             parts.extend(item_parts)
+        if (
+            len(parts) > config.max_files
+            or sum(len(part.data) for part in parts) > config.max_total_bytes
+        ):
+            raise LimitExceededError(
+                "Case and Evidence exceed the batch upload limit",
+                code="log_size_exceeded",
+            )
         response = self.client.multipart(
             "/sdk/judge/batch/",
             {"batch": json.dumps({"items": items}, separators=(",", ":"))},

--- a/src/kuma/repository/_case_file_directory.py
+++ b/src/kuma/repository/_case_file_directory.py
@@ -1,0 +1,99 @@
+"""Pin artifact destination directories while publishing a new local Case."""
+
+from __future__ import annotations
+
+import os
+import stat
+from collections.abc import Callable, Iterator
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+
+
+def _windows_pin(path: Path) -> tuple[Callable[[int], int], int]:
+    """Open an existing Windows directory without permitting rename or deletion.
+
+    Artifact publication holds these handles for each path ancestor. Reparse
+    points are opened themselves, not followed; the caller rechecks canonical
+    identity before writing. Return the CloseHandle callable and owned handle.
+    Win32 errors are deliberately replaced by OSError without native text.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    kernel = ctypes.WinDLL("kernel32", use_last_error=True)
+    create = kernel.CreateFileW
+    create.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    ]
+    create.restype = wintypes.HANDLE
+    close = kernel.CloseHandle
+    close.argtypes = [wintypes.HANDLE]
+    close.restype = wintypes.BOOL
+    # READ_ATTRIBUTES; share read/write but not delete; OPEN_EXISTING;
+    # BACKUP_SEMANTICS permits directories, OPEN_REPARSE_POINT avoids following.
+    handle = create(str(path), 0x80, 3, None, 3, 0x02200000, None)
+    if handle == ctypes.c_void_p(-1).value:
+        raise OSError("Case directory could not be pinned")
+    return close, handle
+
+
+@contextmanager
+def pinned_case_directory(root: Path, parent: Path) -> Iterator[int | None]:
+    """Anchor a Case publication to an already validated repository directory.
+
+    Args:
+        root: Canonical authorized repository root.
+        parent: Existing canonical destination parent inside root.
+    Yields:
+        POSIX directory descriptor for all relative write/link/unlink operations;
+        None on Windows, where non-delete-sharing ancestor handles pin the path.
+    Raises:
+        OSError: Missing, moved, linked, reparse or cross-device directory.
+    Postconditions:
+        All directory handles close on success and every failure. POSIX uses
+        O_NOFOLLOW for every component; Windows never permits a pinned ancestor
+        to be renamed during publication. No directories are created.
+    """
+    relative = parent.relative_to(root)
+    with ExitStack() as stack:
+        if os.name == "nt":
+            for path in [*reversed(parent.parents), parent]:
+                close, handle = _windows_pin(path)
+                stack.callback(close, handle)
+            if parent.resolve(strict=True) != parent:
+                raise OSError("Case directory identity changed")
+            for path in [
+                root,
+                *(
+                    root.joinpath(*relative.parts[:i])
+                    for i in range(1, len(relative.parts) + 1)
+                ),
+            ]:
+                info = path.lstat()
+                if (
+                    not stat.S_ISDIR(info.st_mode)
+                    or getattr(info, "st_file_attributes", 0) & 0x400
+                    or info.st_dev != root.stat().st_dev
+                ):
+                    raise OSError("Case directory boundary changed")
+            yield None
+            return
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+        descriptor = os.open(root, flags)
+        stack.callback(os.close, descriptor)
+        device = os.fstat(descriptor).st_dev
+        for component in relative.parts:
+            descriptor = os.open(component, flags, dir_fd=descriptor)
+            stack.callback(os.close, descriptor)
+            if os.fstat(descriptor).st_dev != device:
+                raise OSError("Case directory crosses a mount")
+        frozen, named = os.fstat(descriptor), parent.stat()
+        if (frozen.st_dev, frozen.st_ino) != (named.st_dev, named.st_ino):
+            raise OSError("Case directory identity changed")
+        yield descriptor

--- a/src/kuma/repository/case_artifact_io.py
+++ b/src/kuma/repository/case_artifact_io.py
@@ -1,0 +1,200 @@
+"""Bounded local Case files; no-overwrite publication and verified read handles."""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from ..errors import ConfigurationError, ValidationError
+from ..evidence.tracking._log_paths import (
+    _verify_open_descriptor,
+    open_verified_log,
+    resolve_log_path,
+)
+from ._case_file_directory import pinned_case_directory
+from .case_artifacts import MAX_CASE_ARTIFACT_BYTES, validate_artifact
+from .privacy import enforce_sensitive_policy, scan_sensitive_path
+
+
+def _path(root: Path, supplied: str | os.PathLike[str], alias: Path) -> Path:
+    """Reuse repository containment/link/mount checks for one explicitly selected file."""
+    path, _, rejected = resolve_log_path(root, supplied, index=0, root_alias=alias)
+    if rejected is not None or path is None or path == root:
+        raise ConfigurationError(
+            "Case file path must stay inside the repository without links"
+        )
+    enforce_sensitive_policy(
+        scan_sensitive_path(path, location="case_artifact"), allow_sensitive=False
+    )
+    return path
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject ambiguous duplicate JSON keys before artifact schema validation."""
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError("duplicate key")
+        value[key] = item
+    return value
+
+
+def load_case_artifact(
+    root: Path, supplied: str | os.PathLike[str], *, alias: Path
+) -> dict[str, Any]:
+    """Read one explicit Case file before any Run or credential setup.
+
+    Args:
+        root: Validated canonical Run repository.
+        supplied: Explicit file; relative paths are rooted at root, never cwd.
+        alias: Original absolute root spelling, preserving macOS path aliases.
+    Returns:
+        Complete validated artifact; no source guessing or inputs-only fallback.
+    Raises:
+        ConfigurationError: Safe path/open errors without host error chains.
+        ValidationError: Invalid UTF-8/duplicate JSON/oversize/invalid artifact.
+    Side Effects:
+        Reads at most 5 MiB plus one sentinel byte from a verified regular handle.
+        No writes, schema fetch, credentials, or network operations.
+    """
+    path = _path(root, supplied, alias)
+    failed = False
+    try:
+        handle, _ = open_verified_log(root, path)
+        with handle:
+            raw = handle.read(MAX_CASE_ARTIFACT_BYTES + 1)
+    except OSError:
+        failed = True
+    if failed:
+        raise ConfigurationError("Case file is missing or unreadable")
+    invalid = len(raw) > MAX_CASE_ARTIFACT_BYTES
+    try:
+        data = json.loads(raw.decode("utf-8"), object_pairs_hook=_unique_object)
+    except (UnicodeError, ValueError, RecursionError):
+        invalid = True
+    if invalid:
+        raise ValidationError(
+            "Case file must contain bounded UTF-8 JSON", code="case_artifact_invalid"
+        )
+    return validate_artifact(data)
+
+
+def _publish(
+    root: Path, destination: Path, encoded: bytes, parent_fd: int | None
+) -> None:
+    """Write/fsync/link one temporary inode under a pinned destination parent.
+
+    The file descriptor stays open through publication. Relative POSIX operations
+    cannot be redirected by a later parent symlink; Windows pins its ancestors.
+    Check inode identity before linking and after publication, close ownership
+    on fdopen failure, and remove temporary/failed publication names on exit.
+    No existing destination is ever replaced. OSError is mapped by save's public
+    boundary after cleanup, so native exception chains never reach callers.
+    """
+    descriptor: int | None = None
+    temporary: Path | None = None
+    published = False
+    complete = False
+    created = False
+    options = {} if parent_fd is None else {"dir_fd": parent_fd}
+    target = destination if parent_fd is None else destination.name
+    try:
+        if parent_fd is None:
+            descriptor, name = tempfile.mkstemp(
+                prefix=".kuma-case-", suffix=".tmp", dir=destination.parent
+            )
+            temporary = Path(name)
+        else:
+            temporary = destination.parent / f".kuma-case-{secrets.token_hex(16)}.tmp"
+            descriptor = os.open(
+                temporary.name,
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=parent_fd,
+            )
+        created = True
+        frozen = os.fstat(descriptor)
+        _verify_open_descriptor(root, temporary, frozen)
+        source = temporary if parent_fd is None else temporary.name
+        with os.fdopen(descriptor, "wb") as handle:
+            descriptor = None
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+            _verify_open_descriptor(root, temporary, frozen)
+            link_options = (
+                {}
+                if parent_fd is None
+                else {"src_dir_fd": parent_fd, "dst_dir_fd": parent_fd}
+            )
+            os.link(source, target, follow_symlinks=False, **link_options)
+            published = True
+            named = os.stat(target, follow_symlinks=False, **options)
+            if (named.st_dev, named.st_ino) != (frozen.st_dev, frozen.st_ino):
+                raise OSError("Case publication identity changed")
+            _verify_open_descriptor(root, destination, frozen)
+            complete = True
+    finally:
+        try:
+            if descriptor is not None:
+                os.close(descriptor)
+        finally:
+            try:
+                if published and not complete:
+                    os.unlink(target, **options)
+            finally:
+                if created and temporary is not None:
+                    with suppress(FileNotFoundError):
+                        os.unlink(
+                            temporary if parent_fd is None else temporary.name,
+                            **options,
+                        )
+
+
+def save_case_artifact(
+    root: Path, supplied: str | os.PathLike[str], data: dict[str, Any]
+) -> Path:
+    """Atomically publish one reviewed public Case without overwriting any file.
+
+    Args:
+        root: Existing canonical repository, owned by the Run.
+        supplied: Explicit destination inside root; parent must already exist.
+        data: Validated reusable artifact, never History/Submission/Evidence.
+    Returns:
+        Absolute path to the newly published complete JSON file.
+    Raises:
+        ConfigurationError: Existing/unsafe target or local I/O failure.
+        ValidationError: Artifact size, content, or origin is invalid.
+    Postconditions:
+        Publication uses atomic hard-link creation (no replacement). Concurrent
+        writers cannot overwrite a winner. Temporary descriptors/files are closed
+        and cleaned on failure; unsupported filesystems fail without fallback.
+    Side Effects:
+        Writes/fsyncs one verified temporary sibling, links it to the destination,
+        and unlinks the temporary name. No directories or runtime state are created.
+    """
+    validated = validate_artifact(data)
+    encoded = json.dumps(
+        validated,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    destination = _path(root, supplied, root)
+    failed = False
+    try:
+        with pinned_case_directory(root, destination.parent) as parent_fd:
+            _publish(root, destination, encoded, parent_fd)
+    except (OSError, ValueError):
+        failed = True
+    if failed:
+        raise ConfigurationError(
+            "Case file could not be saved; choose a new accessible path"
+        )
+    return destination

--- a/src/kuma/repository/case_artifacts.py
+++ b/src/kuma/repository/case_artifacts.py
@@ -1,0 +1,398 @@
+"""Closed, rubric-free Case artifacts shared by Run storage and official Judge."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from typing import Any
+
+from .._json_values import detach_json
+from ..contracts import Case
+from ..errors import SensitiveDataError, ValidationError
+from ..providers._official_wire import (
+    canonical_sha256,
+    validate_executed_strategy_group,
+)
+from ..providers.normalization import normalize_case
+from .privacy import (
+    contains_private_data,
+    enforce_sensitive_policy,
+    scan_sensitive_json,
+)
+from .tool_capabilities import _plain_json
+
+CASE_ARTIFACT_VERSION = "kuma.case_artifact.v1"
+MAX_CASE_ARTIFACT_BYTES = 5_242_880
+_RAW_FIELDS = frozenset(
+    {
+        "schema_version",
+        "batch_id",
+        "case_id",
+        "strategy_id",
+        "strategy_version",
+        "repo_fingerprint",
+        "title",
+        "description",
+        "steps",
+        "signature",
+    }
+)
+_INTEGRITY_FIELDS = frozenset(
+    {
+        "batch_id",
+        "case_sha256",
+        "case_signature",
+        "repo_fingerprint",
+        "schema_version",
+        "strategy_id",
+        "strategy_version",
+    }
+)
+_CASE_FIELDS = frozenset(
+    {"case_id", "input_type", "input_schema", "inputs", "extensions"}
+)
+_INPUT_FIELDS = frozenset(
+    {"input_id", "payload_type", "payload", "public_constraints", "extensions"}
+)
+_HEX = re.compile(r"[0-9a-f]{64}\Z")
+
+
+def _invalid() -> ValidationError:
+    """Create the content-free artifact error reused across decoding boundaries."""
+    return ValidationError(
+        "Case artifact is invalid or does not match its original content",
+        code="case_artifact_invalid",
+    )
+
+
+def _object(value: Any, fields: frozenset[str]) -> dict[str, Any]:
+    """Require one already-detached object with exactly its frozen field set."""
+    if type(value) is not dict or set(value) != fields:
+        raise _invalid()
+    return value
+
+
+def _text(value: Any, maximum: int) -> bool:
+    """Check the existing wire string bound without stripping public content."""
+    return type(value) is str and 1 <= len(value) <= maximum
+
+
+def artifact_json(value: Any) -> Any:
+    """Detach finite JSON at root depth zero/max32 and map failures safely.
+
+    Artifact load/save and official upload invoke this existing bounded JSON
+    walker before schema/private checks. It neither truncates nor invokes tools;
+    rejected graphs become case_artifact_invalid without their exception chain.
+    """
+    failure = False
+    try:
+        plain = _plain_json(detach_json(value))
+        encoded = json.dumps(
+            plain, ensure_ascii=False, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+        failure = len(encoded) > MAX_CASE_ARTIFACT_BYTES
+    except Exception:
+        failure = True
+    if failure:
+        raise _invalid()
+    return plain
+
+
+def _privacy(value: Any) -> None:
+    """Reject private grading fields and credentials without policy overrides."""
+    if contains_private_data(
+        value,
+        extra_fields=(
+            "rubric",
+            "rubric_context",
+            "run_id",
+            "history",
+            "evidence",
+            "agent_output",
+            "submission",
+        ),
+    ):
+        raise SensitiveDataError(
+            "Private grading fields cannot be stored in a Case artifact"
+        )
+    enforce_sensitive_policy(
+        scan_sensitive_json(value, location="case_artifact"), allow_sensitive=False
+    )
+
+
+def validate_public_original(value: Any) -> dict[str, Any]:
+    """Validate the exact original public Case and its non-secret checksum.
+
+    Args:
+        value: Ten-field server public Case, including its original signature.
+    Returns:
+        Detached unchanged content after length/step/checksum validation.
+    Raises:
+        ValidationError: case_artifact_invalid for malformed or changed content.
+        SensitiveDataError: Private or sensitive content, regardless of overrides.
+    Postconditions:
+        SHA validation detects corruption only; it is not authenticity proof.
+        Backend must read the tenant-owned original and bind its original Rubric.
+    Side Effects:
+        None; no server read, signature key, or filesystem access.
+    """
+    raw = _object(artifact_json(value), _RAW_FIELDS)
+    _privacy(raw)
+    limits = {
+        "batch_id": 36,
+        "case_id": 64,
+        "strategy_id": 40,
+        "strategy_version": 40,
+        "title": 200,
+        "description": 2000,
+    }
+    if raw["schema_version"] != "2" or any(
+        not _text(raw[key], limit) for key, limit in limits.items()
+    ):
+        raise _invalid()
+    valid_uuid = False
+    try:
+        valid_uuid = str(uuid.UUID(raw["batch_id"])) == raw["batch_id"]
+    except ValueError:
+        valid_uuid = False
+    if (
+        not valid_uuid
+        or type(raw["repo_fingerprint"]) is not str
+        or not _HEX.fullmatch(raw["repo_fingerprint"])
+    ):
+        raise _invalid()
+    steps = raw["steps"]
+    if type(steps) is not list or not 1 <= len(steps) <= 10:
+        raise _invalid()
+    ids: set[str] = set()
+    for step in steps:
+        _object(step, frozenset({"step_id", "prompt"}))
+        if (
+            not _text(step["step_id"], 80)
+            or not _text(step["prompt"], 12000)
+            or step["step_id"] in ids
+        ):
+            raise _invalid()
+        ids.add(step["step_id"])
+    unsigned = {key: value for key, value in raw.items() if key != "signature"}
+    if raw["signature"] != "sha256:" + canonical_sha256(unsigned):
+        raise _invalid()
+    return raw
+
+
+def _integrity(raw: dict[str, Any], value: Any) -> dict[str, Any]:
+    """Bind closed artifact references to the single public original content."""
+    if type(value) is not dict:
+        raise _invalid()
+    allowed = _INTEGRITY_FIELDS | (
+        {"executed_strategy_group"} if "executed_strategy_group" in value else set()
+    )
+    refs = _object(value, frozenset(allowed))
+    if any(
+        refs[key] != raw[key]
+        for key in (
+            "batch_id",
+            "repo_fingerprint",
+            "schema_version",
+            "strategy_id",
+            "strategy_version",
+        )
+    ):
+        raise _invalid()
+    if refs["case_signature"] != raw["signature"] or refs[
+        "case_sha256"
+    ] != canonical_sha256(raw):
+        raise _invalid()
+    if "executed_strategy_group" in refs:
+        invalid = False
+        try:
+            validate_executed_strategy_group(refs["executed_strategy_group"])
+        except Exception:
+            invalid = True
+        if invalid:
+            raise _invalid()
+    return refs
+
+
+def original_case_mapping(raw: dict[str, Any], refs: dict[str, Any]) -> dict[str, Any]:
+    """Derive executable Inputs from the only saved original, retaining identity."""
+    return {
+        "case_id": raw["case_id"],
+        "input_type": "text",
+        "input_schema": None,
+        "inputs": [
+            {
+                "input_id": step["step_id"],
+                "payload_type": "text",
+                "payload": step["prompt"],
+                "public_constraints": {},
+                "extensions": {},
+            }
+            for step in raw["steps"]
+        ],
+        "extensions": {"official_case": {**refs, "public_case": raw}},
+    }
+
+
+def case_content(case: Case) -> dict[str, Any]:
+    """Project only reusable public Case fields, excluding Run and rubric slots."""
+    return artifact_json(
+        {
+            "case_id": case.case_id,
+            "input_type": case.input_type,
+            "input_schema": case.input_schema,
+            "extensions": case.extensions,
+            "inputs": [
+                {
+                    "input_id": item.input_id,
+                    "payload_type": item.payload_type,
+                    "payload": item.payload,
+                    "public_constraints": item.public_constraints,
+                    "extensions": item.extensions,
+                }
+                for item in case.inputs
+            ],
+        }
+    )
+
+
+def official_original(case: Case) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Bind every current executable Input to the saved official public original.
+
+    Run.save_case and OfficialJudge share this check before file/network effects.
+    Missing historical originals, changed IDs/payload/type/constraints/extensions
+    raise case_artifact_invalid, never a custom fallback. Checksums do not verify
+    issuance or tenant ownership; the Backend still performs that authoritative read.
+    """
+    extension = artifact_json(case.extensions.get("official_case"))
+    if type(extension) is not dict or "public_case" not in extension:
+        raise _invalid()
+    raw = validate_public_original(extension["public_case"])
+    refs = _integrity(
+        raw, {key: value for key, value in extension.items() if key != "public_case"}
+    )
+    expected = original_case_mapping(raw, refs)
+    actual = case_content(case)
+    if actual != expected:
+        raise _invalid()
+    return raw, refs
+
+
+def _validate_custom(value: Any) -> dict[str, Any]:
+    """Validate exact custom fields with the existing public Case normalizer."""
+    content = _object(value, _CASE_FIELDS)
+    if (
+        type(content["extensions"]) is not dict
+        or "official_case" in content["extensions"]
+    ):
+        raise ValidationError(
+            "Custom Case cannot contain official origin", code="case_origin_invalid"
+        )
+    if (
+        not _text(content["case_id"], 64)
+        or type(content["inputs"]) is not list
+        or not content["inputs"]
+    ):
+        raise _invalid()
+    for item in content["inputs"]:
+        _object(item, _INPUT_FIELDS)
+        if not _text(item["input_id"], 80):
+            raise _invalid()
+    invalid = False
+    try:
+        normalized = normalize_case(
+            content,
+            run_id="artifact-validation",
+            max_steps=len(content["inputs"]),
+            required_input_type=None,
+            required_input_schema=None,
+        )
+        invalid = case_content(normalized) != content
+    except Exception:
+        invalid = True
+    if invalid:
+        raise _invalid()
+    return content
+
+
+def validate_artifact(value: Any) -> dict[str, Any]:
+    """Validate the frozen disk union before credentials, runtime, or transport.
+
+    Args:
+        value: Parsed UTF-8 artifact with exactly version, origin, case, integrity.
+    Returns:
+        Detached validated artifact; there is only one public content source.
+    Raises:
+        ValidationError: case_origin_invalid for absent/conflicting origin;
+            case_artifact_invalid for shape/content/graph/size errors.
+        SensitiveDataError: Credentials/private grading content; no override.
+    Side Effects:
+        None. Normalization validates custom inputs without invoking providers.
+    """
+    data = artifact_json(value)
+    if type(data) is not dict or data.get("origin") not in ("official", "custom"):
+        raise ValidationError(
+            "Case artifact must declare its origin", code="case_origin_invalid"
+        )
+    _object(data, frozenset({"schema_version", "origin", "case", "integrity"}))
+    if data["schema_version"] != CASE_ARTIFACT_VERSION:
+        raise _invalid()
+    _privacy(data)
+    if data["origin"] == "official":
+        raw = validate_public_original(data["case"])
+        _integrity(raw, data["integrity"])
+    else:
+        if data["integrity"] is not None:
+            raise ValidationError(
+                "Custom Case cannot contain official integrity",
+                code="case_origin_invalid",
+            )
+        _validate_custom(data["case"])
+    return data
+
+
+def artifact_from_case(case: Case) -> dict[str, Any]:
+    """Serialize a Run-owned Case without exporting runtime or private state."""
+    if "official_case" in case.extensions:
+        content, integrity = official_original(case)
+        origin = "official"
+    else:
+        content, integrity, origin = case_content(case), None, "custom"
+    return validate_artifact(
+        {
+            "schema_version": CASE_ARTIFACT_VERSION,
+            "origin": origin,
+            "case": content,
+            "integrity": integrity,
+        }
+    )
+
+
+def artifact_case_mapping(data: dict[str, Any]) -> dict[str, Any]:
+    """Return the validated artifact's sole content in the existing normalizer shape."""
+    if data["origin"] == "official":
+        return original_case_mapping(data["case"], data["integrity"])
+    return data["case"]
+
+
+class LoadedCaseProvider:
+    """Internal prevalidated file source, distinct from a user custom Provider.
+
+    Attributes:
+        artifact: Closed local document validated before credential discovery.
+        origin: Explicit official/custom discriminator, never inferred from IDs.
+        count: Complete number of saved steps; used only as a nontruncating limit.
+    """
+
+    def __init__(self, artifact: dict[str, Any]) -> None:
+        """Bind validated artifact content without reading or generating a Case."""
+        self.artifact = artifact
+        self.origin = artifact["origin"]
+        self.count = len(
+            artifact["case"]["steps" if self.origin == "official" else "inputs"]
+        )
+
+    def generate_case(self, context: Any) -> dict[str, Any]:
+        """Supply the saved complete content to normal Run ID rebinding, with no I/O."""
+        return artifact_case_mapping(self.artifact)

--- a/src/kuma/run.py
+++ b/src/kuma/run.py
@@ -30,6 +30,8 @@ from .evidence.tracking.evidence import EvidenceCollector, PreparedEvidence
 from .providers.base import JudgeContext, JudgeProvider
 from .providers.normalization import normalize_report
 from .providers.official_judge import OfficialJudgeProvider
+from .repository.case_artifact_io import save_case_artifact
+from .repository.case_artifacts import artifact_from_case
 from .runtime import RuntimeSession
 
 RunState = Literal[
@@ -283,6 +285,41 @@ class Run:
         self._stopped_early = False
         self._evidence = evidence
         self._mutex = threading.RLock()
+
+    @property
+    def case_origin(self) -> Literal["official", "custom"]:
+        """Return the explicit Case origin, not a guess based on its identifier."""
+        return "official" if "official_case" in self._case.extensions else "custom"
+
+    def save_case(self, path: str | os.PathLike[str]) -> Path:
+        """Save the complete reusable public Case without execution data.
+
+        Args:
+            path: Explicit destination within this Run's repo_path. Relative
+                paths resolve from that repository. Parent must exist; an
+                existing file is never overwritten, including concurrent saves.
+        Returns:
+            Absolute Path to the new UTF-8 kuma.case_artifact.v1 document.
+        Raises:
+            ValidationError: Malformed/changed official content or artifact limits.
+            SensitiveDataError: Private or sensitive content, without overrides.
+            ConfigurationError: Unsafe path, existing target, or file I/O failure.
+        Preconditions:
+            This Run owns a complete Case; official Cases retain the raw original.
+        Postconditions:
+            State/history/input position are unchanged. No Run ID, Evidence,
+            Agent output, rubric or credentials are exported. Checksums are not
+            authenticity proofs; official Judge still checks the server original.
+        Side Effects:
+            Atomically writes one bounded file, without network or tool execution.
+        Security/Privacy:
+            The complete file is limited to 5 MiB; links and mount escapes are
+            rejected. allow_sensitive never bypasses artifact privacy checks.
+        """
+        with self._mutex:
+            artifact = artifact_from_case(self._case)
+            root = self._runtime.workspace.repo_path
+            return save_case_artifact(root, path, artifact)
 
     @property
     def state(self) -> RunState:

--- a/tools/verify_public_api_docs.py
+++ b/tools/verify_public_api_docs.py
@@ -45,6 +45,7 @@ PUBLIC_APIS = (
         "parse_agent_profile",
     ),
     PublicApi("get_input", "src/kuma/run.py", "Run.get_input"),
+    PublicApi("save_case", "src/kuma/run.py", "Run.save_case"),
     PublicApi("submit", "src/kuma/run.py", "Run.submit"),
     PublicApi("judge", "src/kuma/run.py", "Run.judge"),
     PublicApi(


### PR DESCRIPTION
## Summary
- Add `Run.save_case(path)`, `create_run(case_path=...)`, and read-only `case_origin`.
- Keep one bounded, closed public Case artifact with explicit official/custom origin; atomic no-overwrite saves and repository-bound paths.
- Official Judge uploads the complete original Case, preserves original integrity references, and never silently falls back to custom or case-ID-only.
- Explain save/load, origin, checksum-versus-authentication, server verification and billing boundaries in both languages.

## Validation
- 26 focused canonical tests against this public source: OK, 1 platform skip.
- Public API docs: 10 APIs × 2 languages; 18 Python fences and 82 local links checked.
- Ruff check/format, compileall, minimal_local, diff and sanitized-scope checks pass.
- No tests, private history, acceptance assets, credentials or runtime artifacts are included.

## Compatibility / merge gate
The production Backend must support official schema-2 `case_file` and authoritative tenant/original-Rubric validation before merge. Public checksums alone are not authentication. Older Backend errors are surfaced without fallback. Custom wire is unchanged. No package version bump, PyPI publication, tag or Release is part of this PR.