### PR TITLE
docs(readme): install the latest SDK from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,16 @@ KUMA is the public Python SDK for testing Agent behavior through a strict `Run` 
 
 ## Install
 
-Python 3.10 or newer is required:
+Install the latest GitHub `main` source. Requires Python 3.10 or newer and Git:
 
 ```bash
-python -m pip install "kuma-defuzex==0.1.0"
+python -m pip install --upgrade "git+https://github.com/DefuzeX-AI/KUMA-DefuzeX.git"
 ```
+
+Run this in the Python environment used by your Agent, then restart the Agent.
+The package is not currently available on PyPI; install from GitHub as above.
+For optional OTel dependencies and Trace setup, see the
+[Runtime Trace guide](docs/runtime-trace.md).
 
 ## Quick start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,11 +31,15 @@ KUMA 是公开 Python SDK，通过严格的 `Run` 协议和有界 Evidence 采�
 
 ## 安装
 
-需要 Python 3.10 或更高版本：
+安装 GitHub `main` 最新源码，需要 Python 3.10 或更高版本以及 Git：
 
 ```bash
-python -m pip install "kuma-defuzex==0.1.0"
+python -m pip install --upgrade "git+https://github.com/DefuzeX-AI/KUMA-DefuzeX.git"
 ```
+
+请在 Agent 实际使用的 Python 环境中运行，安装后重启 Agent。
+当前 PyPI 尚无可用公开包，请按上面的命令从 GitHub 安装。
+可选 OTel 依赖与 Trace 配置见 [Runtime Trace 指南](docs/runtime-trace.zh-CN.md)。
 
 ## 快速开始
 


### PR DESCRIPTION
Replace the unavailable PyPI installation command in both README languages with the GitHub main source installation command. State Python 3.10+, Git, the Agent Python environment and restart requirements, with a link to optional OTel setup. The package is currently unavailable on PyPI. Documentation-only: install command parsing, local links and diff checks passed. No source, version, tag or package publication changes.