### PR TITLE
feat(updates): prepare 0.2.0 with nonblocking release reminders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Ordinary CI commands must not contact the release API.
+  KUMA_DISABLE_UPDATE_CHECK: "1"
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ The package is not currently available on PyPI; install from GitHub as above.
 For optional OTel dependencies and Trace setup, see the
 [Runtime Trace guide](docs/runtime-trace.md).
 
+## Versions and update reminders
+
+SDK version: **0.2.0**. Publication status is shown in the
+[official Releases](https://github.com/DefuzeX-AI/KUMA-DefuzeX/releases).
+Run `kuma updates check` (or Python `kuma.check_for_updates()`) to check stable
+Release tags: patch-only updates are **optional**, higher major/minor versions
+**require an upgrade reminder**, but never block work or install automatically.
+Official requests check in the background; import/help/local/custom do not.
+Set `KUMA_DISABLE_UPDATE_CHECK=1` to disable all checks. Offline failures are safe;
+results are cached for 24 hours per process. Old 0.1.0 users must upgrade manually
+once to gain reminders. [Full policy and limits](docs/releases.md).
+
 ## Quick start
 
 Run the deterministic local check without an account, API key, Docker, or network:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,6 +41,16 @@ python -m pip install --upgrade "git+https://github.com/DefuzeX-AI/KUMA-DefuzeX.
 当前 PyPI 尚无可用公开包，请按上面的命令从 GitHub 安装。
 可选 OTel 依赖与 Trace 配置见 [Runtime Trace 指南](docs/runtime-trace.zh-CN.md)。
 
+## 版本与更新提醒
+
+SDK 版本：**0.2.0**；是否已正式发布以
+[官方 Releases](https://github.com/DefuzeX-AI/KUMA-DefuzeX/releases) 为准。
+运行 `kuma updates check`（或 Python `kuma.check_for_updates()`）检查正式版：
+只升补丁号为**可选更新**，主/次版本提高为**必须升级提醒**，但不阻断任务、不自动安装。
+官方请求后台检查，import/help/local/custom 不联网检查；设置
+`KUMA_DISABLE_UPDATE_CHECK=1` 可全部禁用。离线失败不影响业务，结果按进程缓存
+24 小时。0.1.0 用户需先手动升级一次才能获得提醒。[完整规范与限制](docs/releases.md)。
+
 ## 快速开始
 
 无需账号、API Key、Docker 或网络即可运行确定性的本地检查：

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,6 +6,30 @@ This page documents the stable user-facing Python entry points. Types, defaults,
 ranges, side effects, and failure behavior match the current implementation.
 KUMA uses keyword-only arguments for its main APIs so call sites remain readable.
 
+## `check_for_updates`
+
+```python
+from kuma import check_for_updates
+
+update = check_for_updates()
+print(update["status"], update["latest_version"], update["release_url"])
+```
+
+No parameters. Returns a detached dict: `status` is `disabled`, `checking`,
+`unavailable`, `up_to_date`, `optional` (new patch) or `required` (new major/minor);
+`current_version` is the local string, `latest_version` and `release_url` are
+validated official-release values or `None`, and `cached` is boolean. Required
+is a strong reminder, never a blocked request or automatic installation.
+
+Explicit calls can perform one anonymous GitHub HTTPS request (one-second socket
+timeout, 64 KiB cap, no retry); ordinary failure returns unavailable. Concurrent
+checks return checking without waiting. Success/failure is cached in memory for
+24 hours per process. Set `KUMA_DISABLE_UPDATE_CHECK=1` to disable even explicit
+calls. No credentials, Agent data, disk writes, proxies or redirects. Official
+transport schedules the same checker on a daemon thread; import/help/local/custom
+paths do not check. CLI equivalent: `kuma updates check`, JSON stdout, exit zero.
+See [release policy](releases.md) for all status fields and lifecycle limits.
+
 ## `configure`
 
 ```python

--- a/docs/api-reference.zh-CN.md
+++ b/docs/api-reference.zh-CN.md
@@ -4,6 +4,29 @@
 
 本文记录稳定的用户侧 Python API。参数类型、默认值、范围、副作用和失败语义均以当前实现为准。KUMA 的主要 API 使用仅关键字参数，调用时应保留参数名。
 
+## `check_for_updates`
+
+```python
+from kuma import check_for_updates
+
+update = check_for_updates()
+print(update["status"], update["latest_version"], update["release_url"])
+```
+
+无参数。返回独立字典：`status` 为 `disabled`、`checking`、`unavailable`、
+`up_to_date`、`optional`（新补丁）或 `required`（新主/次版本）；
+`current_version` 是本地版本字符串，`latest_version`/`release_url` 是已校验的
+官方发行版信息或 `None`，`cached` 是布尔值。required 是必须升级的强提醒，
+不拒绝请求、不自动安装。
+
+显式调用最多执行一次匿名 GitHub HTTPS 请求（socket 超时 1 秒、64 KiB 上限、
+不重试）；普通失败返回 unavailable，并发检查直接返回 checking，不等待。
+成功/失败在当前进程缓存 24 小时。`KUMA_DISABLE_UPDATE_CHECK=1` 连显式调用
+也禁用。不读取凭据、不发送 Agent 数据、不写磁盘、不走代理/重定向。官方传输
+复用同一检查器的 daemon 后台线程；import/help/local/custom 不检查。
+等价 CLI：`kuma updates check`，JSON 写 stdout、退出码为 0。
+全部字段及生命周期限制见[版本发布规范](releases.md)。
+
 ## `configure`
 
 ```python

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,102 @@
+# Versions and releases / 版本与发布
+
+## 0.2.0
+
+Release availability is determined by the corresponding official
+[GitHub Release](https://github.com/DefuzeX-AI/KUMA-DefuzeX/releases), not by a
+development branch or each new main commit. 发行状态以对应正式 Release 为准。
+
+- Consolidates public source improvements since 0.1.0: Agent Profile naming,
+  reusable complete Case files, bounded Agent output and Trace Evidence, optional
+  unified file diffs and captured tool arguments/results. See the existing
+  [Trace and file-diff guide](runtime-trace.md) for opt-in and privacy limits.
+- Adds anonymous, nonblocking update reminders plus explicit Python/CLI checks.
+- 独立版本汇总上述已有公开能力，并新增更新提醒。0.1.0 用户需手动升级一次并重启
+  Agent，旧安装无法自行获得提醒；更新器不执行 pip、不自动安装。
+- A GitHub Release does not imply PyPI publication or a service deployment.
+  GitHub 发行版不代表已经发布 PyPI 包或变更服务部署。
+
+## Version rules / 版本规则
+
+| Installed → latest stable | Status | Meaning / 含义 |
+| --- | --- | --- |
+| 0.2.0 → 0.2.1 | optional | Patch-only: optional / 补丁升级，可选 |
+| 0.1.9 → 0.2.0 | required | Higher minor: upgrade required reminder / 次版本，必须升级提醒 |
+| 0.2.9 → 1.0.0 | required | Higher major: upgrade required reminder / 主版本，必须升级提醒 |
+| 0.2.0 → 0.2.0 or 0.1.9 | up_to_date | Equal or ahead: silent / 相等或领先，不提醒 |
+
+These are KUMA's rules, including pre-1.0. Required is a strong reminder, not a
+denied API request, interrupted task, changed billing or automatic install.
+主/次版本提示必须升级，但不阻断已有业务、不收费重试、不自动安装。
+Only strict stable `vX.Y.Z` GitHub Release tags are compared; drafts/prereleases,
+main commits and PyPI are not update sources. 不将草稿或每次提交当作新正式版。
+
+## Check explicitly / 手动检查
+
+```bash
+kuma updates check
+```
+
+```python
+from kuma import check_for_updates
+
+result = check_for_updates()
+print(result["status"], result["latest_version"], result["release_url"])
+```
+
+No options/arguments. Both interfaces provide the same detached JSON-compatible
+object; the CLI prints JSON to stdout and returns zero for all these statuses:
+
+| Field | Type / Meaning |
+| --- | --- |
+| status | disabled / checking / unavailable / up_to_date / optional / required |
+| current_version | Installed package version / 本地包版本字符串 |
+| latest_version | Validated stable version, or null / 已校验正式版本或 null |
+| release_url | Official tag URL derived from that version, or null |
+| cached | Boolean; true for a cached success/failure / 是否命中进程缓存 |
+
+无需参数；离线/限流/畸形响应返回 unavailable，不输出原始错误或响应正文。
+已有并发检查时立即返回 checking，不等待或重复联网。Required 也不会使 CLI 失败。
+
+## Background checks and privacy / 后台检查与隐私
+
+Successful real official Python/CLI transport schedules a daemon check centrally.
+It never waits for GitHub; import/help/local/custom workflows do not check.
+The cache contains one result for 24 hours per process, including failures, with
+one request in flight and a nonblocking reservation lock. There is no disk cache.
+Short-lived commands may exit before a reminder appears; use the explicit check
+when you need its result. Reminders go to stderr, leaving business JSON intact.
+
+官方实际请求成功后后台检查，不等待 GitHub；import/help/local/custom 不检查。
+成功/失败均在当前进程缓存 24 小时、并发去重、不写磁盘；新进程重新开始。
+短命进程可能先退出而没有提醒，可用显式命令；提醒仅写 stderr。
+
+Set `KUMA_DISABLE_UPDATE_CHECK=1` to disable both explicit and automatic checks,
+including cached reminders. Other values leave checks enabled. Set it before a
+workflow; a request already sent cannot be unsent. 设置此开关可全部禁用，但已发出的
+请求无法撤回。检测到禁用后不会再打印提醒。
+
+The fixed official GitHub releases/latest HTTPS endpoint receives no credentials,
+Backend headers, Agent/Evidence/repository content or local paths. No proxies or
+redirects are followed; TLS uses Python's default verification. GitHub receives
+ordinary connection metadata such as the source IP. Only validated version fields
+are retained; arbitrary release text, URLs or commands are never executed.
+
+固定官方 GitHub HTTPS 源；不发送 API Key/用户业务数据，不跟随代理或重定向。
+只保留已校验版本，不执行远端返回的 URL/命令。每次响应最多 64 KiB、socket 超时
+1 秒、不重试；socket 超时不是 DNS/操作系统调度的硬总时限，但业务不等待检查。
+Each explicit fetch has a one-second socket timeout, 64 KiB limit and no retry;
+socket timeout is not a hard DNS/OS wall-clock deadline. Ordinary failures are
+safe unavailable results and never change the original business result.
+
+## Publication / 发布约定
+
+Every formal release has its own version, immutable tag and independent Release
+notes, created after its accepted source is merged to public main. Existing tags
+are never moved; new functionality must not be presented as a new release by
+merely appending to old notes. 每次正式发布独立版本/tag/Release，不改旧 tag 指向。
+
+Package metadata reads the single source `kuma._version.__version__`. Version,
+docs and the tagged source must agree. Install a pinned release using its tag
+only once it exists; installing main gets the latest source, not a promise of a
+new formal release. 元数据、源码、文档版本必须一致；main 最新源码不等于新正式版。

--- a/src/kuma/__init__.py
+++ b/src/kuma/__init__.py
@@ -70,6 +70,7 @@ from .repository.tool_capability_io import (
 )
 from .requests import RequestRecord, list_requests, resume_request, show_request
 from .serialization import to_json
+from .updates import check_for_updates
 
 __all__ = [
     "AGENT_CAPABILITIES_SCHEMA_VERSION",
@@ -117,6 +118,7 @@ __all__ = [
     "ToolCapability",
     "ValidationError",
     "__version__",
+    "check_for_updates",
     "configure",
     "create_run",
     "list_requests",

--- a/src/kuma/_version.py
+++ b/src/kuma/_version.py
@@ -1,5 +1,5 @@
 """Single source of truth for the package version."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 __all__ = ["__version__"]

--- a/src/kuma/cli.py
+++ b/src/kuma/cli.py
@@ -18,6 +18,7 @@ from .repository.tool_capability_io import (
     scan_agent_tool_manifest,
 )
 from .requests import list_requests, resume_request, show_request
+from .updates import check_for_updates
 
 
 def _emit(data: Any) -> None:
@@ -162,10 +163,38 @@ def cmd_requests_resume(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_updates_check(args: argparse.Namespace) -> int:
+    """Print a safe update-status JSON object; offline/disabled checks exit zero.
+
+    Args:
+        args: Parsed no-option updates check command; no credentials are read.
+
+    Returns:
+        Zero, including required reminders, unavailable or disabled results.
+
+    Side Effects:
+        Calls the bounded explicit GitHub check and emits its detached result to
+        stdout. Never installs software or calls Backend/Agent/model services.
+    """
+    _emit(check_for_updates())
+    return 0
+
+
+def _add_update_parser(subparsers: Any) -> None:
+    """Register the explicit update command without scheduling checks or I/O."""
+    updates = subparsers.add_parser("updates", help="check official GitHub releases")
+    update_commands = updates.add_subparsers(dest="updates_command", required=True)
+    update_check = update_commands.add_parser(
+        "check", help="report update status; never install"
+    )
+    update_check.set_defaults(func=cmd_updates_check)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the public CLI parser without performing I/O."""
     parser = argparse.ArgumentParser(prog="kuma")
     subparsers = parser.add_subparsers(dest="command", required=True)
+    _add_update_parser(subparsers)
     whoami = subparsers.add_parser(
         "whoami", help="validate KUMA_API_KEY and show entitlements"
     )

--- a/src/kuma/transport/backend.py
+++ b/src/kuma/transport/backend.py
@@ -35,6 +35,7 @@ from ..errors import (
 )
 from ..evidence.runtime_contract import CASEGEN_EVIDENCE_CAPABILITY_ORDER
 from ..runtime import is_running_in_docker
+from ..updates import schedule_update_check
 from .http import (
     WireResponse,
     request_timeout,
@@ -209,6 +210,8 @@ def _wire_transport(
 
     Side Effects:
         Sends one HTTPS request, or approved loopback/Docker-gateway HTTP request.
+        A successful response schedules one cached, nonblocking anonymous GitHub
+        Release check; KUMA_DISABLE_UPDATE_CHECK=1 disables that separate check.
 
     Security/Privacy:
         Response text, provider details, and tracebacks are never interpolated
@@ -217,10 +220,12 @@ def _wire_transport(
     request = Request(url, data=body, headers=dict(headers), method=method)
     try:
         with urlopen(request, timeout=timeout) as response:
-            return WireResponse(
+            result = WireResponse(
                 status=response.status,
                 payload=_read_response(response, response.status),
             )
+        schedule_update_check()
+        return result
     except HTTPError as exc:
         try:
             try:

--- a/src/kuma/updates.py
+++ b/src/kuma/updates.py
@@ -1,0 +1,227 @@
+"""Credential-isolated GitHub Release checks, independent of paid SDK transport."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import threading
+import time
+from urllib.error import HTTPError
+from urllib.request import HTTPRedirectHandler, ProxyHandler, Request, build_opener
+
+from ._version import __version__
+
+_RELEASE_API = "https://api.github.com/repos/DefuzeX-AI/KUMA-DefuzeX/releases/latest"
+_RELEASE_PAGE = "https://github.com/DefuzeX-AI/KUMA-DefuzeX/releases/tag/v"
+_VERSION = re.compile(
+    r"(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})\.(0|[1-9][0-9]{0,8})\Z"
+)
+_CACHE_SECONDS = 24 * 60 * 60
+_MAX_BYTES = 65536
+_LOCK = threading.Lock()
+_cached: dict[str, str | bool | None] | None = None
+_expires = 0.0
+_inflight = False
+
+
+class _NoRedirect(HTTPRedirectHandler):
+    """Keep the anonymous updater on its fixed official HTTPS endpoint."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        """Decline every redirect; urllib closes the response and raises HTTPError."""
+        return None
+
+
+def _disabled() -> bool:
+    """Read the opt-out at call time, including before cached results or I/O."""
+    return os.environ.get("KUMA_DISABLE_UPDATE_CHECK") == "1"
+
+
+def _result(status: str, latest: str | None = None) -> dict[str, str | bool | None]:
+    """Build a detached, body-free result from a local status and validated version."""
+    return {
+        "status": status,
+        "current_version": __version__,
+        "latest_version": latest,
+        "release_url": None if latest is None else _RELEASE_PAGE + latest,
+        "cached": False,
+    }
+
+
+def _release_result(raw: bytes) -> dict[str, str | bool | None]:
+    """Project bounded GitHub metadata into a safe semantic-version comparison.
+
+    Only stable ``vX.Y.Z`` releases with exact false draft/prerelease flags are
+    eligible. Arbitrary release text/URLs never enter results or terminal output.
+    Malformed metadata raises ValueError/UnicodeError for the caller to suppress.
+    A higher major/minor is required; patch-only is optional, never a hard block.
+    """
+    if len(raw) > _MAX_BYTES:
+        raise ValueError("release response exceeds limit")
+    payload = json.loads(raw.decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("invalid release")
+    tag = payload.get("tag_name")
+    current_match = _VERSION.fullmatch(__version__)
+    if (
+        payload.get("draft") is not False
+        or payload.get("prerelease") is not False
+        or not isinstance(tag, str)
+        or not tag.startswith("v")
+        or not _VERSION.fullmatch(tag[1:])
+        or current_match is None
+    ):
+        raise ValueError("invalid release version")
+    latest = tuple(map(int, tag[1:].split(".")))
+    current = tuple(map(int, current_match.groups()))
+    status = "up_to_date"
+    if latest > current:
+        status = "required" if latest[:2] > current[:2] else "optional"
+    return _result(status, tag[1:])
+
+
+def _fetch_release() -> dict[str, str | bool | None]:
+    """Fetch at most 64 KiB from GitHub without user credentials or redirects.
+
+    Uses a private opener, no proxy/environment authentication, a one-second
+    socket timeout and no retries. All response resources close before return.
+    HTTP/DNS/TLS/JSON failures propagate only to the best-effort wrapper.
+    """
+    request = Request(
+        _RELEASE_API,
+        headers={"Accept": "application/vnd.github+json", "User-Agent": "kuma-updates"},
+    )
+    opener = build_opener(ProxyHandler({}), _NoRedirect())
+    try:
+        with opener.open(request, timeout=1.0) as response:
+            if response.status != 200:
+                raise ValueError("release unavailable")
+            raw = response.read(_MAX_BYTES + 1)
+    except HTTPError as error:
+        error.close()
+        raise ValueError("release unavailable") from None
+    return _release_result(raw)
+
+
+def _reserve() -> dict[str, str | bool | None] | None:
+    """Return cached/checking status or reserve the sole process-local fetch.
+
+    The lock protects only metadata, never network I/O. None grants ownership;
+    the caller must finish via _complete even if fetching or starting a thread
+    fails. Successes and failures share the same 24-hour monotonic expiry.
+    """
+    global _inflight
+    if not _LOCK.acquire(blocking=False):
+        return _result("checking")
+    try:
+        if _cached is not None and time.monotonic() < _expires:
+            return {**_cached, "cached": True}
+        if _inflight:
+            return _result("checking")
+        _inflight = True
+    finally:
+        _LOCK.release()
+    return None
+
+
+def _complete(result: dict[str, str | bool | None]) -> None:
+    """Publish one detached result and release fetch ownership without disk writes."""
+    global _cached, _expires, _inflight
+    with _LOCK:
+        _cached = dict(result)
+        _expires = time.monotonic() + _CACHE_SECONDS
+        _inflight = False
+
+
+def _perform() -> dict[str, str | bool | None]:
+    """Complete a reserved attempt; suppress all ordinary update failures.
+
+    Recheck opt-out immediately before I/O. No raw exception, remote body or
+    host data is exposed. This independent read cannot retry or mutate a paid
+    operation; the cache always releases its reservation after normal failure.
+    """
+    try:
+        result = _result("disabled") if _disabled() else _fetch_release()
+    except Exception:
+        result = _result("unavailable")
+    _complete(result)
+    return result
+
+
+def check_for_updates() -> dict[str, str | bool | None]:
+    """Check the latest official GitHub Release without changing the installation.
+
+    Args:
+        None. Set KUMA_DISABLE_UPDATE_CHECK=1 to prevent even an explicit check.
+
+    Returns:
+        Detached dict with status (disabled, checking, unavailable, up_to_date,
+        optional, required), current_version, latest_version (str or None),
+        release_url (official URL or None) and cached (bool). A concurrent fetch
+        returns checking immediately. Patch-only updates are optional; higher
+        major/minor versions are required reminders, not business restrictions.
+
+    Raises:
+        No ordinary network/parse failure; unavailable is returned instead.
+
+    Side Effects:
+        At most one anonymous HTTPS request per process per 24 hours, including
+        failures, with one-second socket timeout, 64 KiB limit and no retries.
+        This explicit API may wait for I/O; automatic checks use a daemon thread.
+        No files, credentials, subprocesses, pip or Backend calls are involved.
+
+    Security/Privacy:
+        No Agent/request/key data is sent. Redirects and proxies are disabled;
+        only validated version numbers enter the result. Import performs no I/O.
+    """
+    if _disabled():
+        return _result("disabled")
+    existing = _reserve()
+    return _perform() if existing is None else existing
+
+
+def _background_check() -> None:
+    """Emit at most one advisory after a reserved background fetch completes.
+
+    Writes safe required/optional text to stderr only. Disabled/unavailable or
+    current releases stay silent; terminal failures never affect SDK work. A
+    short-lived process may exit before its daemon produces any reminder.
+    """
+    result = _perform()
+    if _disabled() or result["status"] not in {"optional", "required"}:
+        return
+    try:
+        label = (
+            "需要更新 / Update required"
+            if result["status"] == "required"
+            else "可选更新 / Update optional"
+        )
+        print(
+            f"KUMA: {label}: {result['current_version']} -> "
+            f"{result['latest_version']}. {result['release_url']} "
+            "(Reminder only; current work continues. 不会自动安装或中断任务。)",
+            file=sys.stderr,
+        )
+    except Exception:
+        pass
+
+
+def schedule_update_check() -> None:
+    """Schedule a best-effort check after real official transport succeeds.
+
+    Called centrally by Backend transport for Python and CLI official workflows,
+    never by imports, local/custom providers or parser/help. Returns without
+    waiting for network I/O. One process-local cache/reservation deduplicates
+    simultaneous requests and suppresses retries for 24 hours, including failure.
+    Thread startup/terminal/network failures cannot change the original result.
+    """
+    if _disabled() or _reserve() is not None:
+        return
+    try:
+        threading.Thread(
+            target=_background_check, name="kuma-updates", daemon=True
+        ).start()
+    except Exception:
+        _complete(_result("unavailable"))


### PR DESCRIPTION
## Changes
- Prepare SDK version 0.2.0 using the existing single-source package version.
- Add kuma updates check and kuma.check_for_updates() against official stable GitHub Release tags.
- Patch-only newer versions are optional; higher major/minor versions produce an update-required reminder. Neither blocks work nor installs anything.
- Successful official transport schedules a daemon check with process-local 24-hour success/failure caching and concurrent deduplication. Import/help/local/custom workflows do not check.
- KUMA_DISABLE_UPDATE_CHECK=1 disables automatic and explicit checks. No credentials, Agent data, proxies, redirects or automatic pip operations; failures remain safe and nonblocking.
- Synchronize bilingual documentation and explain independent immutable version tags and Release notes. Existing 0.1.0 users must upgrade manually once to gain reminders.

## Verification
- Source-bound update and CLI tests: 23 passed.
- Updater line and branch coverage: 100%, measured on the identical implementation.
- Ruff, bilingual API documentation, Markdown links and Python examples passed.
- Wheel/sdist build, Twine, version/import and public package-content checks passed.

This PR does not publish a Release, tag or PyPI package, and does not deploy services. Release availability remains determined by an explicitly published official Release.