### PR TITLE
Fix Judge upload counts and release 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For optional OTel dependencies and Trace setup, see the
 
 ## Versions and update reminders
 
-SDK version: **0.2.0**. Publication status is shown in the
+SDK version: **0.2.1**. Publication status is shown in the
 [official Releases](https://github.com/DefuzeX-AI/KUMA-DefuzeX/releases).
 Run `kuma updates check` (or Python `kuma.check_for_updates()`) to check stable
 Release tags: patch-only updates are **optional**, higher major/minor versions

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,7 +43,7 @@ python -m pip install --upgrade "git+https://github.com/DefuzeX-AI/KUMA-DefuzeX.
 
 ## 版本与更新提醒
 
-SDK 版本：**0.2.0**；是否已正式发布以
+SDK 版本：**0.2.1**；是否已正式发布以
 [官方 Releases](https://github.com/DefuzeX-AI/KUMA-DefuzeX/releases) 为准。
 运行 `kuma updates check`（或 Python `kuma.check_for_updates()`）检查正式版：
 只升补丁号为**可选更新**，主/次版本提高为**必须升级提醒**，但不阻断任务、不自动安装。

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -245,6 +245,17 @@ credentials, raw tracebacks, prompts, or unapproved file contents.
 
 ### `judge`
 
+The Backend advertises `max_files` as twice the supported maximum Case step
+count (currently 10 × 2 = 20), not twice this Run's actual steps. The Case file
+and every Evidence file each consume a slot. Batch Judge applies that count
+independently to each item, not the batch sum; the SDK never hardcodes 20.
+File-count rejection happens before Judge POST. Existing byte and privacy
+checks remain: the Backend enforces combined Case+Evidence bytes for every
+item, including custom Cases; the SDK preserves its existing per-path byte
+checks and conservative aggregate batch cap. This update does not add a new
+combined-byte preflight for custom single Judge uploads. Deploy the matching
+Backend first; clients continue to respect an older Backend's smaller limit.
+
 <!-- api-parameters:judge:start -->
 
 | Argument | Type | Required/default | What it does and when to use it |

--- a/docs/api-reference.zh-CN.md
+++ b/docs/api-reference.zh-CN.md
@@ -198,6 +198,14 @@ Judge 仍校验当前租户的服务端原件。参见[保存与加载示例及 
 
 ### `judge`
 
+Backend 广告的 `max_files` 为支持的最大 Case 步数 × 2（当前 10 × 2 = 20），
+不是本次 Run 的实际步数 × 2。Case 文件和每份 Evidence 各占一个名额。
+Batch Judge 按每个 item 分别计算，不将整批相加；SDK 不硬编码 20。
+文件数超限在 Judge POST 前拒绝。字节和隐私检查保持：Backend 对每项强制
+检查 Case+Evidence 合计字节，包括自定义 Case；SDK 保留各路径原有字节检查
+和保守的整批字节上限。本次不新增自定义 Case 单次 Judge 的合计字节预检。
+应先部署配套 Backend；客户端仍遵守旧 Backend 返回的较小上限。
+
 <!-- api-parameters:judge:start -->
 
 | 参数 | 类型 | 必填/默认值 | 它控制什么、什么时候填写 |

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,26 @@
 # Versions and releases / 版本与发布
 
+## 0.2.1
+
+Availability is determined by the corresponding official GitHub Release, not
+this document or a development branch. 是否可用以对应正式 Release 为准。
+
+- Corrects Judge file-count preflight: Case plus Evidence count toward the
+  advertised per-item limit for both official and custom Cases. Batch counts
+  each item independently rather than rejecting their combined file count.
+- The matching Backend derives the file count as twice its supported maximum
+  step count (currently 20 files); clients consume that value, not a hardcoded
+  20 or a limit based on this Run's actual steps. Deploy the Backend first.
+- 修复官方/自定义 Judge 文件计数；Case 与 Evidence 都占名额，batch 按每项
+  分别计算。服务端按支持的最大步数 × 2 返回上限，客户端直接遵守配置。
+- Existing byte budgets, privacy checks and request identities are unchanged.
+  Combined bytes for custom single Judge remain enforced by the Backend; this
+  patch does not add a new local combined-byte preflight for that path.
+- 字节预算、敏感检查与请求身份不变；自定义 Case 单次 Judge 的合计字节仍由
+  Backend 强制检查，本补丁不新增该路径的本地合计预检。
+- This is an optional patch update from 0.2.0. It does not publish to PyPI or
+  automatically install itself. 0.2.0 → 0.2.1 是可选补丁，不自动安装。
+
 ## 0.2.0
 
 Release availability is determined by the corresponding official

--- a/src/kuma/_version.py
+++ b/src/kuma/_version.py
@@ -1,5 +1,5 @@
 """Single source of truth for the package version."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 __all__ = ["__version__"]

--- a/src/kuma/providers/_official_evidence_upload.py
+++ b/src/kuma/providers/_official_evidence_upload.py
@@ -34,9 +34,14 @@ class JudgeUploadConfig:
     """Hold the validated dynamic public Judge upload limits.
 
     Attributes:
-        max_files: Maximum multipart Evidence files accepted per request.
+        max_files: Maximum Case plus Evidence files per Judge item, including
+            each batch item independently. Consumed from Backend configuration;
+            the SDK does not derive it from the current Case's step count.
         max_file_bytes: Maximum bytes accepted for one Evidence part.
-        max_total_bytes: Maximum combined multipart Evidence bytes.
+        max_total_bytes: Backend limit for combined Case and Evidence bytes.
+            The SDK preserves its existing per-path checks and conservative
+            aggregate batch preflight; the Backend enforces the combined limit
+            for every item, including custom single Judge uploads.
         manifest_schema_version: Exact public manifest version to serialize.
         max_batch_items: Maximum Runs accepted by synchronous batch Judge.
         evidence_types: Closed public Evidence media/type identifiers advertised

--- a/src/kuma/providers/official_judge.py
+++ b/src/kuma/providers/official_judge.py
@@ -422,7 +422,14 @@ class OfficialJudgeProvider:
         part_prefix: str = "",
         idempotency_key: str | None = None,
     ) -> _JudgeUpload:
-        """Build and privacy-check an official or custom Case Judge upload."""
+        """Stage one Case and its Evidence under the advertised per-item limits.
+
+        Called by single and batch Judge preparation before POST. ``max_files``
+        counts the Case artifact plus all Evidence parts for this item.
+        Existing Evidence, Case and aggregate byte/privacy checks remain in
+        their respective paths. Returns staged parts without I/O;
+        raises stable size or privacy errors before request persistence/upload.
+        """
         run_id = self._run_id(context)
         log_parts, manifest, findings = _evidence_upload(context, config, part_prefix)
         metadata: dict[str, Any] = {
@@ -452,8 +459,7 @@ class OfficialJudgeProvider:
                 data=encoded,
             )
             if (
-                len(log_parts) + 1 > config.max_files
-                or len(encoded) + sum(len(part.data) for part in log_parts)
+                len(encoded) + sum(len(part.data) for part in log_parts)
                 > config.max_total_bytes
             ):
                 raise LimitExceededError(
@@ -463,6 +469,11 @@ class OfficialJudgeProvider:
         else:
             case_part, case_findings = _custom_case_part(context, config, part_prefix)
             findings.extend(case_findings)
+        if len(log_parts) + 1 > config.max_files:
+            raise LimitExceededError(
+                "Case and Evidence exceed the upload limit",
+                code="log_size_exceeded",
+            )
         enforce_sensitive_policy(findings, allow_sensitive=self.allow_sensitive)
         return _JudgeUpload(
             run_id=run_id,
@@ -689,7 +700,9 @@ class OfficialJudgeProvider:
 
         Args:
             contexts: Non-empty unique-Run completed contexts, no larger than the
-                Backend-advertised ``max_batch_items``.
+                Backend-advertised ``max_batch_items``. Each item's Case and
+                Evidence share ``max_files``; it is not a batch-wide count.
+                The existing aggregate multipart byte budget also applies.
 
         Returns:
             Tuple in request order. Each :class:`JudgeBatchResult` contains
@@ -731,10 +744,7 @@ class OfficialJudgeProvider:
             item, item_parts = _batch_item(upload)
             items.append(item)
             parts.extend(item_parts)
-        if (
-            len(parts) > config.max_files
-            or sum(len(part.data) for part in parts) > config.max_total_bytes
-        ):
+        if sum(len(part.data) for part in parts) > config.max_total_bytes:
             raise LimitExceededError(
                 "Case and Evidence exceed the batch upload limit",
                 code="log_size_exceeded",


### PR DESCRIPTION
Counts Case and Evidence files together per Judge item, including custom Cases. Batch limits apply independently per item rather than across the batch. Uses the Backend-advertised limit (supported maximum steps times two); byte budgets, privacy checks and request identities remain unchanged. Includes bilingual API documentation, consistent 0.2.1 package/README versions and independent release notes. Related scoped tests: 16 passed against public source; Ruff, documentation checks, wheel/sdist build and Twine passed. No private tests or internal assets included. GitHub-only release; no PyPI publication.