### PR TITLE
Use consistent service-busy wording in 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For optional OTel dependencies and Trace setup, see the
 
 ## Versions and update reminders
 
-SDK version: **0.2.1**. Publication status is shown in the
+SDK version: **0.2.2**. Publication status is shown in the
 [official Releases](https://github.com/DefuzeX-AI/KUMA-DefuzeX/releases).
 Run `kuma updates check` (or Python `kuma.check_for_updates()`) to check stable
 Release tags: patch-only updates are **optional**, higher major/minor versions

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -43,7 +43,7 @@ python -m pip install --upgrade "git+https://github.com/DefuzeX-AI/KUMA-DefuzeX.
 
 ## 版本与更新提醒
 
-SDK 版本：**0.2.1**；是否已正式发布以
+SDK 版本：**0.2.2**；是否已正式发布以
 [官方 Releases](https://github.com/DefuzeX-AI/KUMA-DefuzeX/releases) 为准。
 运行 `kuma updates check`（或 Python `kuma.check_for_updates()`）检查正式版：
 只升补丁号为**可选更新**，主/次版本提高为**必须升级提醒**，但不阻断任务、不自动安装。

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,5 +1,16 @@
 # Versions and releases / 版本与发布
 
+## 0.2.2
+
+- `service_busy` now consistently displays “服务繁忙，请稍后重试。” for
+  synchronous and asynchronous failures. The exception remains `ServiceBusyError`;
+  its stable code and server-provided retryable flag, including false, are unchanged.
+- 同步和异步服务繁忙错误统一中文提示；仅接受固定文案，任意服务端内部文字仍被
+  安全回退。提示不改变重试资格、不触发自动重试；`retryable=false` 时不要自动重试。
+- Optional patch update from 0.2.1, with no automatic installation or PyPI
+  publication implied. Availability follows the official GitHub Release.
+  这是可选补丁，是否发行以正式 Release 为准，不自动安装。
+
 ## 0.2.1
 
 Availability is determined by the corresponding official GitHub Release, not

--- a/src/kuma/_version.py
+++ b/src/kuma/_version.py
@@ -1,5 +1,5 @@
 """Single source of truth for the package version."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = ["__version__"]

--- a/src/kuma/transport/backend.py
+++ b/src/kuma/transport/backend.py
@@ -617,6 +617,7 @@ _ERROR_MESSAGES = {
     ServiceError: "The KUMA service request failed.",
 }
 _CODE_ERROR_MESSAGES = {
+    "service_busy": "服务繁忙，请稍后重试。",  # noqa: RUF001
     "forbidden": "此密钥没有权限使用该功能。",
     "idempotency_conflict": "这个请求已经提交过了，请不要重复提交。",  # noqa: RUF001
     "invalid_api_key": "密钥无效。",


### PR DESCRIPTION
Maps service_busy to a fixed safe Chinese message for synchronous and asynchronous errors. ServiceBusyError, stable code and retryable=false remain unchanged; arbitrary remote messages are not exposed. Includes consistent 0.2.2 version/README/release notes. Scoped source-bound tests: 61 passed; Ruff and wheel/sdist build/Twine passed. No private tests or other features included. GitHub-only patch release, no PyPI. Awaiting final export review and matching Backend readiness before merge.